### PR TITLE
Feature/Release ARM Image

### DIFF
--- a/.github/scripts/Dockerfile.aarch64-unknown-linux-gnu
+++ b/.github/scripts/Dockerfile.aarch64-unknown-linux-gnu
@@ -1,0 +1,9 @@
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main@sha256:b4f5bf74812f9bb6516140d4b83d1f173c2d5ce0523f3e1c2253d99d851c734f
+
+ENV PKG_CONFIG_ALLOW_CROSS="true"
+
+RUN set-eux; dpkg --add-architecture arm64 && \
+    apt-get update && \
+    apt-get install --assume-yes clang-8 libclang-8-dev binutils-aarch64-linux-gnu zlib1g-dev:arm64 unzip wget && \
+    wget https://github.com/protocolbuffers/protobuf/releases/download/v21.10/protoc-21.10-linux-x86_64.zip && \
+    unzip protoc-21.10-linux-x86_64.zip -d /usr/local

--- a/.github/scripts/Dockerfile.x86_64-unknown-linux-gnu
+++ b/.github/scripts/Dockerfile.x86_64-unknown-linux-gnu
@@ -1,0 +1,6 @@
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main@sha256:bf0cd3027befe882feb5a2b4040dc6dbdcb799b25c5338342a03163cea43da1b
+
+RUN set-eux; apt-get update && \
+    apt-get install --assume-yes clang libclang-dev unzip wget && \
+    wget https://github.com/protocolbuffers/protobuf/releases/download/v21.10/protoc-21.10-linux-x86_64.zip && \
+    unzip protoc-21.10-linux-x86_64.zip -d /usr/local

--- a/.github/scripts/install_macos_deps.sh
+++ b/.github/scripts/install_macos_deps.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+brew install llvm
+brew install protobuf

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,49 +1,112 @@
 name: Docker
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch: { }
 
 env:
   CI_RUST_TOOLCHAIN: 1.70.0
+  REGISTRY_IMAGE: datenlord/xline
 
 jobs:
-  docker:
-    name: Docker
-    runs-on: ubuntu-latest
+  push_image:
+    name: Push Docker Image
+    runs-on: ${{ matrix.job.os }}
+    outputs:
+      app_version: ${{ steps.generate_app_version.outputs.app_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - os: ubuntu-latest
+            platform: linux/amd64
+            target: x86_64-unknown-linux-gnu
+            cross_image: x86_64-linux-gnu
+          - os: ubuntu-latest
+            platform: linux/arm64
+            target: aarch64-unknown-linux-gnu
+            cross_image: aarch64-linux-gnu
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - run: sudo bash ./.github/scripts/install_deps.sh
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: default
-          toolchain: ${{ env.CI_RUST_TOOLCHAIN }}
-          override: true
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
-      - run: |
-          mv ./target/release/xline ./scripts
-          mv ./target/release/benchmark ./scripts
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: actions/checkout@v3
+
+      - name: Generate App Version
+        id: generate_app_version
+        run: echo app_version=`git describe --tags --always` >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+
+      - name: Setup Custom Image for ${{ matrix.job.cross_image }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .github/scripts
+          file: .github/scripts/Dockerfile.${{ matrix.job.target }}
+          tags: ${{ matrix.job.cross_image }}:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install Toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ env.CI_RUST_TOOLCHAIN }}
+          target: ${{ matrix.job.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          key: '${{ matrix.job.target }}'
+
+      - name: Install cross
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cross
+          cache-key: '${{ matrix.job.target }}'
+
+      - name: Build Xline Binary
+        run: |
+          cross build --target ${{ matrix.job.target }} --release
+
+      # Build docker image across multiple runners
+      - name: Move Cross-compiled Binary
+        run: |
+          mv ./target/${{ matrix.job.target }}/release/xline ./scripts
+          mv ./target/${{ matrix.job.target }}/release/benchmark ./scripts
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Generate App Version
-        run: echo APP_VERSION=`git describe --tags --always` >> $GITHUB_ENV
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
+
+      - name: Build Docker Image
+        id: build_image
+        uses: docker/build-push-action@v4
         with:
-          push: true
           context: ./scripts
-          tags: |
-            datenlord/xline:latest
-            datenlord/xline:${{ env.APP_VERSION }}
+          platforms: ${{ matrix.job.platform }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export Digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build_image.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload Digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge_image:
+    needs: push_image
+    uses: ./.github/workflows/merge_image.yml
+    secrets: inherit
+    with:
+      app_version: ${{ needs.push_image.outputs.app_version }}

--- a/.github/workflows/merge_image.yml
+++ b/.github/workflows/merge_image.yml
@@ -1,0 +1,46 @@
+on:
+  workflow_call:
+    inputs:
+      app_version:
+        required: true
+        type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+
+env:
+  REGISTRY_IMAGE: datenlord/xline
+
+jobs:
+  merge_image:
+    runs-on: ubuntu-latest
+    name: Merge Docker Image
+    steps:
+      - name: Download Digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push Manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+                      -t ${{ env.REGISTRY_IMAGE }}:latest \
+                      -t ${{ env.REGISTRY_IMAGE }}:${{ inputs.app_version }} \
+                      $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect Manifest
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ inputs.app_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,27 +7,15 @@ on:
 
 env:
   CI_RUST_TOOLCHAIN: 1.70.0
+  REGISTRY_IMAGE: datenlord/xline
 
 jobs:
-  build:
-    name: Upload Release Asset
+  create_release:
+    name: Create Release
     runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Install Dependencies
-        run: sudo bash ./.github/scripts/install_deps.sh
-      - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: default
-          toolchain: ${{ env.CI_RUST_TOOLCHAIN }}
-          override: true
-      - uses: Swatinem/rust-cache@v2
-      - name: Build Xline
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1.0.0
@@ -38,36 +26,137 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-      - name: Upload Release Asset
+
+  publish_release:
+    name: Publish Release
+    needs: create_release
+    runs-on: ${{ matrix.job.os }}
+    outputs:
+      app_version: ${{ steps.generate_app_version.outputs.app_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - os: ubuntu-latest
+            platform: linux/amd64
+            target: x86_64-unknown-linux-gnu
+            cross_image: x86_64-linux-gnu
+          - os: ubuntu-latest
+            platform: linux/arm64
+            target: aarch64-unknown-linux-gnu
+            cross_image: aarch64-linux-gnu
+          - os: macos-latest
+            platform: darwin/amd64
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            platform: darwin/arm64
+            target: aarch64-apple-darwin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Generate App Version
+        id: generate_app_version
+        run: echo app_version=`git describe --tags --always` >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        if: matrix.job.cross_image
+        uses: docker/setup-buildx-action@v1
+
+      - name: Setup Custom Image for ${{ matrix.job.cross_image }}
+        if: matrix.job.cross_image
+        uses: docker/build-push-action@v2
+        with:
+          context: .github/scripts
+          file: .github/scripts/Dockerfile.${{ matrix.job.target }}
+          tags: ${{ matrix.job.cross_image }}:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install Packages (macOS)
+        if: matrix.job.os == 'macos-latest'
+        run: |
+          .github/scripts/install_macos_deps.sh
+
+      - name: Install Toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ env.CI_RUST_TOOLCHAIN }}
+          target: ${{ matrix.job.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          key: '${{ matrix.job.target }}'
+
+      - name: Install cross
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cross
+          cache-key: '${{ matrix.job.target }}'
+
+      - name: Build Xline Binary
+        run: |
+          cross build --target ${{ matrix.job.target }} --release
+
+      - name: Upload Asset
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.1
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./target/release/xline
-          asset_name: xline-linux-amd64
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: ./target/${{ matrix.job.target }}/release/xline
+          asset_name: xline-${{ matrix.job.target }}
           asset_content_type: application/octet-stream
-      - run: |
-          mv ./target/release/xline ./scripts
-          mv ./target/release/benchmark ./scripts
+
+      # Build docker image across multiple runners
+      - name: Move Cross-compiled Binary
+        if: startsWith(matrix.job.platform, 'linux/')
+        run: |
+          mv ./target/${{ matrix.job.target }}/release/xline ./scripts
+          mv ./target/${{ matrix.job.target }}/release/benchmark ./scripts
+
       - name: Set up QEMU
+        if: startsWith(matrix.job.platform, 'linux/')
         uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        if: startsWith(matrix.job.platform, 'linux/')
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Generate App Version
-        run: echo APP_VERSION=`git describe --tags --always` >> $GITHUB_ENV
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
+
+      - name: Build Docker Image
+        if: startsWith(matrix.job.platform, 'linux/')
+        id: build_image
+        uses: docker/build-push-action@v4
         with:
-          push: true
           context: ./scripts
-          tags: |
-            datenlord/xline:latest
-            datenlord/xline:${{ env.APP_VERSION }}
+          platforms: ${{ matrix.job.platform }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export Digest
+        if: startsWith(matrix.job.platform, 'linux/')
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build_image.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload Digest
+        uses: actions/upload-artifact@v3
+        if: startsWith(matrix.job.platform, 'linux/')
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge_image:
+    needs: publish_release
+    uses: ./.github/workflows/merge_image.yml
+    secrets: inherit
+    with:
+      app_version: ${{ needs.publish_release.outputs.app_version }}

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[target.aarch64-unknown-linux-gnu]
+image = "aarch64-linux-gnu"
+
+[target.x86_64-unknown-linux-gnu]
+image = "x86_64-linux-gnu"

--- a/doc/quick-start/README.md
+++ b/doc/quick-start/README.md
@@ -1,52 +1,19 @@
 # Quick Start
 
-## Build an Xline docker image
+## Run Xline from a pre-built image
 
 ```bash
 # Assume that docker engine environment is installed.
 
-# clone source code
-git clone https://github.com/datenlord/Xline
-cd Xline
-
-# build docker image
-# you may need to add sudo before the command to make it work
-docker build . -t datenlord/xline:latest -f doc/quick-start/Dockerfile
+docker run -it --name=xline datenlord/xline \
+  xline \
+  --name xline \
+  --storage-engine rocksdb \
+  --members xline=127.0.0.1:2379 \
+  --data-dir /usr/local/xline/data-dir
 ```
 
-## Start Xline servers
-
-``` bash
-cp ./xline-test-utils/{private,public}.pem ./scripts
-
-./scripts/quick_start.sh
-```
-
-## Send Etcd requests
-
-``` bash
-# Set Key A's value to 1
-docker exec node4 /bin/sh -c "/usr/local/bin/etcdctl --endpoints=\"http://172.20.0.3:2379\" put A 1"
-
-# Get Key A's value
-docker exec node4 /bin/sh -c "/usr/local/bin/etcdctl --endpoints=\"http://172.20.0.3:2379\" get A"
-```
-
-## Validation Test
-
-```bash
-docker cp node1:/usr/local/bin/lock_client ./scripts
-
-./scripts/validation_test.sh
-```
-
-## Benchmark
-
-```bash
-./scripts/benchmark.sh
-```
-
-## Build from scratch
+## Run Xline from source code
 
 ### Install dependencies
 
@@ -56,7 +23,7 @@ docker cp node1:/usr/local/bin/lock_client ./scripts
 sudo apt-get install -y autoconf autogen libtool
 
 # requires protobuf-compiler >= 3.15
-git clone --branch v3.21.12  --recurse-submodules https://github.com/protocolbuffers/protobuf
+git clone --branch v3.21.12 --recurse-submodules https://github.com/protocolbuffers/protobuf
 cd protobuf
 ./autogen.sh
 ./configure
@@ -86,13 +53,70 @@ cd Xline
 cargo build --release
 ```
 
+### Run Xline
+
+```bash
+./target/release/xline --name xline \
+  --storage-engine rocksdb \
+  --members xline=127.0.0.1:2379 \
+  --data-dir <path-to-data-dir>
+```
+
+## Test Xline cluster
+
+### Build image for validation
+
+```bash
+# Assume that docker engine environment is installed.
+
+# clone source code
+git clone https://github.com/datenlord/Xline
+cd Xline
+
+# build docker image
+# you may need to add sudo before the command to make it work
+docker build . -t datenlord/xline:latest -f doc/quick-start/Dockerfile
+```
+
+### Start Xline servers
+
+```bash
+cp ./xline-test-utils/{private,public}.pem ./scripts
+
+./scripts/quick_start.sh
+```
+
+### Test basic etcd requests
+
+```bash
+# Set Key A's value to 1
+docker exec node4 /bin/sh -c "/usr/local/bin/etcdctl --endpoints=\"http://172.20.0.3:2379\" put A 1"
+
+# Get Key A's value
+docker exec node4 /bin/sh -c "/usr/local/bin/etcdctl --endpoints=\"http://172.20.0.3:2379\" get A"
+```
+
+### Validation test
+
+```bash
+docker cp node1:/usr/local/bin/lock_client ./scripts
+
+./scripts/validation_test.sh
+```
+
+### Benchmark
+
+```bash
+./scripts/benchmark.sh
+```
+
 # Directory Structure
 
-| directory name | description |
-|----------------|-------------|
+| directory name | description                                             |
+|----------------|---------------------------------------------------------|
 | benchmark      | a customized benchmark using CURP protocol based client |
-| curp           | the CURP protocol |
-| xline          | xline services |
-| engine         | persistent storage |
-| utils          | some utilities, like lock, config, etc. |
-| scripts        | the shell scripts for env deployment or benchmarking |
+| curp           | the CURP protocol                                       |
+| xline          | xline services                                          |
+| engine         | persistent storage                                      |
+| utils          | some utilities, like lock, config, etc.                 |
+| scripts        | the shell scripts for env deployment or benchmarking    |


### PR DESCRIPTION
Please briefly answer these questions:

The test workflow: https://github.com/iGxnon/rust-ci-test/actions/runs/5362996116

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

  Etcd images are compatible with computers that have ARM architecture. Additionally, xline can also support ARM thanks to Rust's cross-compilation.

* what changes does this pull request make?

  This pull request updated the release's CI to allow for automatic building of ARM images.
  
  - Added ARM image building process in Github Action CI
  - Added release artifacts for macOS and ARM Linux
  - Reorganize quick-start readme

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

  No