### PR TITLE
Feature/Abort on panic macro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,8 @@ jobs:
     strategy:
       matrix:
         config:
-          - { name: "Normal", args: "", rustflags: "" }
-          - { name: "Madsim", args: "--package=simulation", rustflags: "--cfg madsim" }
+          - { name: "Normal", args: "-- --nocapture", rustflags: "" }
+          - { name: "Madsim", args: "--package=simulation -- --nocapture", rustflags: "--cfg madsim" }
     name: Test ${{ matrix.config.name }}
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,10 +32,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d6b683edf8d1119fe420a94f8a7e389239666aa72e65495d91c00462510151"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "predicates 3.0.3",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
 
 [[package]]
 name = "async-channel"
@@ -226,6 +247,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
+dependencies = [
+ "memchr",
+ "once_cell",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -456,6 +489,7 @@ dependencies = [
  "prost-build",
  "serde",
  "tempfile",
+ "test-macros",
  "thiserror",
  "tokio-stream 0.1.12 (git+https://github.com/madsim-rs/tokio.git?rev=ab251ad)",
  "tower",
@@ -630,6 +664,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +705,7 @@ dependencies = [
  "parking_lot",
  "rocksdb",
  "serde",
+ "test-macros",
  "thiserror",
  "tokio-util",
 ]
@@ -1385,7 +1426,7 @@ dependencies = [
  "fragile",
  "lazy_static",
  "mockall_derive",
- "predicates",
+ "predicates 2.1.5",
  "predicates-tree",
 ]
 
@@ -1759,6 +1800,18 @@ dependencies = [
  "normalize-line-endings",
  "predicates-core",
  "regex",
+]
+
+[[package]]
+name = "predicates"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "itertools",
+ "predicates-core",
 ]
 
 [[package]]
@@ -2287,6 +2340,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
+name = "test-macros"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2731,6 +2795,7 @@ dependencies = [
  "opentelemetry-jaeger",
  "parking_lot",
  "serde",
+ "test-macros",
  "thiserror",
  "toml 0.5.10",
  "tracing",
@@ -2765,6 +2830,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"
@@ -3079,6 +3153,7 @@ dependencies = [
  "rand",
  "serde",
  "sha2",
+ "test-macros",
  "thiserror",
  "tokio-stream 0.1.12 (git+https://github.com/madsim-rs/tokio.git?rev=ab251ad)",
  "tokio-util",
@@ -3107,6 +3182,7 @@ dependencies = [
  "madsim-tonic",
  "pbkdf2",
  "rand",
+ "test-macros",
  "thiserror",
  "tower",
  "utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "xline-client",
   "simulation",
   "xline-test-utils",
+  "test-macros"
 ]
 
 # TODO: We should remove it when the madsim updates its release (v0.2.23) in the crate.io

--- a/curp/Cargo.toml
+++ b/curp/Cargo.toml
@@ -57,6 +57,7 @@ anyhow = "1.0.66"
 mockall = "0.11.3"
 once_cell = "1.17.0"
 tempfile = "3"
+test-macros = { path = "../test-macros" }
 
 [build-dependencies]
 tonic-build = { version = "0.2", package = "madsim-tonic-build" }

--- a/curp/src/rpc/connect.rs
+++ b/curp/src/rpc/connect.rs
@@ -294,6 +294,7 @@ mod tests {
     use bytes::Bytes;
     use engine::{EngineType, Snapshot as EngineSnapshot};
     use futures::{pin_mut, StreamExt};
+    use test_macros::abort_on_panic;
     use tracing_test::traced_test;
 
     use super::*;
@@ -301,6 +302,7 @@ mod tests {
 
     #[traced_test]
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_install_snapshot_stream() {
         const SNAPSHOT_SIZE: u64 = 200 * 1024;
         let mut snapshot = EngineSnapshot::new_for_receiving(EngineType::Memory).unwrap();

--- a/curp/src/server/cmd_worker/mod.rs
+++ b/curp/src/server/cmd_worker/mod.rs
@@ -279,10 +279,12 @@ mod tests {
         mock_role_change, sleep_millis, sleep_secs,
         test_cmd::{TestCE, TestCommand},
     };
+    use test_macros::abort_on_panic;
 
     // This should happen in fast path in most cases
     #[traced_test]
     #[tokio::test]
+    #[abort_on_panic]
     async fn fast_path_normal() {
         let (er_tx, mut er_rx) = mpsc::unbounded_channel();
         let (as_tx, mut as_rx) = mpsc::unbounded_channel();
@@ -312,6 +314,7 @@ mod tests {
     // When the execution takes more time than sync, `as` should be called after exe has finished
     #[traced_test]
     #[tokio::test]
+    #[abort_on_panic]
     async fn fast_path_cond1() {
         let (er_tx, _er_rx) = mpsc::unbounded_channel();
         let (as_tx, mut as_rx) = mpsc::unbounded_channel();
@@ -346,6 +349,7 @@ mod tests {
     // When the execution takes more time than sync and fails, after sync should not be called
     #[traced_test]
     #[tokio::test]
+    #[abort_on_panic]
     async fn fast_path_cond2() {
         let (er_tx, mut er_rx) = mpsc::unbounded_channel();
         let (as_tx, mut as_rx) = mpsc::unbounded_channel();
@@ -384,6 +388,7 @@ mod tests {
     // This should happen in slow path in most cases
     #[traced_test]
     #[tokio::test]
+    #[abort_on_panic]
     async fn slow_path_normal() {
         let (er_tx, mut er_rx) = mpsc::unbounded_channel();
         let (as_tx, mut as_rx) = mpsc::unbounded_channel();
@@ -412,6 +417,7 @@ mod tests {
     // When exe fails
     #[traced_test]
     #[tokio::test]
+    #[abort_on_panic]
     async fn slow_path_exe_fails() {
         let (er_tx, mut er_rx) = mpsc::unbounded_channel();
         let (as_tx, mut as_rx) = mpsc::unbounded_channel();
@@ -443,6 +449,7 @@ mod tests {
     // If cmd1 and cmd2 conflict, order will be (cmd1 exe) -> (cmd1 as) -> (cmd2 exe) -> (cmd2 as)
     #[traced_test]
     #[tokio::test]
+    #[abort_on_panic]
     async fn conflict_cmd_order() {
         let (er_tx, mut er_rx) = mpsc::unbounded_channel();
         let (as_tx, mut as_rx) = mpsc::unbounded_channel();
@@ -485,6 +492,7 @@ mod tests {
 
     #[traced_test]
     #[tokio::test]
+    #[abort_on_panic]
     async fn reset_will_wipe_all_states_and_outdated_cmds() {
         let (er_tx, mut er_rx) = mpsc::unbounded_channel();
         let (as_tx, mut as_rx) = mpsc::unbounded_channel();
@@ -524,6 +532,7 @@ mod tests {
 
     #[traced_test]
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_snapshot() {
         // ce1
         let (er_tx, mut _er_rx) = mpsc::unbounded_channel();

--- a/curp/src/server/gc.rs
+++ b/curp/src/server/gc.rs
@@ -73,6 +73,7 @@ mod tests {
     use std::{sync::Arc, time::Duration};
 
     use parking_lot::{Mutex, RwLock};
+    use test_macros::abort_on_panic;
 
     use super::*;
     use crate::{
@@ -86,6 +87,7 @@ mod tests {
     use curp_test_utils::{sleep_secs, test_cmd::TestCommand};
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn cmd_board_gc_test() {
         let board: CmdBoardRef<TestCommand> = Arc::new(RwLock::new(CommandBoard::new()));
         tokio::spawn(gc_cmd_board(Arc::clone(&board), Duration::from_millis(500)));
@@ -137,6 +139,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn spec_gc_test() {
         let spec: SpecPoolRef<TestCommand> = Arc::new(Mutex::new(SpeculativePool::new()));
         tokio::spawn(gc_spec_pool(Arc::clone(&spec), Duration::from_millis(500)));
@@ -169,6 +172,7 @@ mod tests {
 
     // To verify #206 is fixed
     #[tokio::test]
+    #[abort_on_panic]
     async fn spec_gc_will_not_panic() {
         let spec: SpecPoolRef<TestCommand> = Arc::new(Mutex::new(SpeculativePool::new()));
 

--- a/curp/src/server/raw_curp/tests.rs
+++ b/curp/src/server/raw_curp/tests.rs
@@ -1,5 +1,6 @@
 use std::time::Instant;
 
+use test_macros::abort_on_panic;
 use tokio::{sync::oneshot, time::sleep};
 use tracing_test::traced_test;
 use utils::config::{
@@ -296,6 +297,7 @@ fn handle_ae_will_reject_wrong_log() {
 
 #[traced_test]
 #[tokio::test]
+#[abort_on_panic]
 async fn follower_will_not_start_election_when_heartbeats_are_received() {
     let curp = {
         let mut exe_tx = MockCEEventTxApi::<TestCommand>::default();
@@ -326,6 +328,7 @@ async fn follower_will_not_start_election_when_heartbeats_are_received() {
 
 #[traced_test]
 #[tokio::test]
+#[abort_on_panic]
 async fn follower_or_candidate_will_start_election_if_timeout() {
     let curp = {
         let mut exe_tx = MockCEEventTxApi::<TestCommand>::default();

--- a/curp/src/server/storage/rocksdb.rs
+++ b/curp/src/server/storage/rocksdb.rs
@@ -90,8 +90,10 @@ mod tests {
 
     use super::*;
     use curp_test_utils::{sleep_secs, test_cmd::TestCommand};
+    use test_macros::abort_on_panic;
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn create_and_recover() -> Result<(), Box<dyn Error>> {
         let db_dir = tempfile::tempdir().unwrap().into_path();
 

--- a/curp/tests/read_state.rs
+++ b/curp/tests/read_state.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use curp::{client::ReadState, cmd::Command};
 use curp_test_utils::{init_logger, sleep_millis, test_cmd::TestCommand};
+use test_macros::abort_on_panic;
 use utils::config::ClientTimeout;
 
 use crate::common::curp_group::CurpGroup;
@@ -9,6 +10,7 @@ use crate::common::curp_group::CurpGroup;
 mod common;
 
 #[tokio::test]
+#[abort_on_panic]
 async fn read_state() {
     init_logger();
     let group = CurpGroup::new(3).await;

--- a/curp/tests/server.rs
+++ b/curp/tests/server.rs
@@ -5,6 +5,7 @@ use std::{sync::Arc, time::Duration};
 use clippy_utilities::NumericCast;
 use curp_test_utils::{init_logger, sleep_millis, sleep_secs, test_cmd::TestCommand};
 use madsim::rand::{thread_rng, Rng};
+use test_macros::abort_on_panic;
 use utils::config::ClientTimeout;
 
 use crate::common::curp_group::{
@@ -13,6 +14,7 @@ use crate::common::curp_group::{
 mod common;
 
 #[tokio::test]
+#[abort_on_panic]
 async fn basic_propose() {
     init_logger();
 
@@ -35,6 +37,7 @@ async fn basic_propose() {
 }
 
 #[tokio::test]
+#[abort_on_panic]
 async fn synced_propose() {
     init_logger();
 
@@ -63,6 +66,7 @@ async fn synced_propose() {
 
 // Each command should be executed once and only once on each node
 #[tokio::test]
+#[abort_on_panic]
 async fn exe_exact_n_times() {
     init_logger();
 
@@ -100,6 +104,7 @@ async fn exe_exact_n_times() {
 
 // To verify PR #86 is fixed
 #[tokio::test]
+#[abort_on_panic]
 async fn fast_round_is_slower_than_slow_round() {
     init_logger();
 
@@ -139,6 +144,7 @@ async fn fast_round_is_slower_than_slow_round() {
 }
 
 #[tokio::test]
+#[abort_on_panic]
 async fn concurrent_cmd_order() {
     init_logger();
 
@@ -195,6 +201,7 @@ async fn concurrent_cmd_order() {
 
 /// This test case ensures that the issue 228 is fixed.
 #[tokio::test]
+#[abort_on_panic]
 async fn concurrent_cmd_order_should_have_correct_revision() {
     init_logger();
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -28,3 +28,6 @@ tokio = { version = "0.2", package = "madsim-tokio", features = [
 ] }
 bytes = "1.4.0"
 tokio-util = { version = "0.7.8", features = ["io"] }
+
+[dev-dependencies]
+test-macros = { path = "../test-macros" }

--- a/engine/src/proxy.rs
+++ b/engine/src/proxy.rs
@@ -197,6 +197,7 @@ mod test {
     use std::iter::{repeat, zip};
 
     use clippy_utilities::NumericCast;
+    use test_macros::abort_on_panic;
 
     use super::*;
     use crate::api::snapshot_api::SnapshotApi;
@@ -314,6 +315,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn snapshot_should_work() {
         let dir = PathBuf::from("/tmp/snapshot_should_work");
         let origin_data_dir = dir.join("origin");

--- a/engine/src/rocksdb_engine.rs
+++ b/engine/src/rocksdb_engine.rs
@@ -551,10 +551,13 @@ impl SnapshotApi for RocksSnapshot {
 
 #[cfg(test)]
 mod test {
+    use test_macros::abort_on_panic;
+
     use super::*;
 
     static TEST_TABLES: [&str; 3] = ["t1", "t2", "t3"];
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_rocks_errors() {
         let dir = PathBuf::from("/tmp/test_rocks_errors");
         let engine_path = dir.join("engine");

--- a/simulation/tests/it/curp/server_recovery.rs
+++ b/simulation/tests/it/curp/server_recovery.rs
@@ -185,7 +185,6 @@ async fn leader_and_follower_both_crash_and_recovery() {
     group.stop().await;
 }
 
-// Leader should recover speculatively executed commands
 #[madsim::test]
 async fn new_leader_will_recover_spec_cmds_cond1() {
     init_logger();

--- a/test-macros/Cargo.toml
+++ b/test-macros/Cargo.toml
@@ -6,7 +6,7 @@ description = "Macros for test configurations"
 keywords = ["Test", "Macros"]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/datenlord/Xline/tree/master/test-macros"
+repository = "https://github.com/xline-kv/Xline/tree/master/test-macros"
 version = "0.1.0"
 edition = "2021"
 

--- a/test-macros/Cargo.toml
+++ b/test-macros/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "test-macros"
+authors = ["DatenLord <dev@datenlord.io>"]
+categories = ["Macros"]
+description = "Macros for test configurations"
+keywords = ["Test", "Macros"]
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/datenlord/Xline/tree/master/test-macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full"] }
+
+[dev-dependencies]
+assert_cmd = "2.0.11"

--- a/test-macros/README.md
+++ b/test-macros/README.md
@@ -1,0 +1,3 @@
+# Test Macros
+
+This crate provide macros for test configurations.

--- a/test-macros/src/bin/no_abort.rs
+++ b/test-macros/src/bin/no_abort.rs
@@ -1,0 +1,8 @@
+//! This binary is only used for this crate's tests
+#[tokio::main]
+async fn main() {
+    _ = tokio::spawn(async {
+        panic!("here is a panic");
+    })
+    .await;
+}

--- a/test-macros/src/bin/with_abort.rs
+++ b/test-macros/src/bin/with_abort.rs
@@ -1,0 +1,9 @@
+//! This binary is only used for this crate's tests
+#[tokio::main]
+#[test_macros::abort_on_panic]
+async fn main() {
+    _ = tokio::spawn(async {
+        panic!("here is a panic");
+    })
+    .await;
+}

--- a/test-macros/src/lib.rs
+++ b/test-macros/src/lib.rs
@@ -1,0 +1,22 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ItemFn, Stmt};
+
+#[proc_macro_attribute]
+pub fn abort_on_panic(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut input: syn::ItemFn = parse_macro_input!(item as ItemFn);
+
+    let panic_hook: Stmt = syn::parse_quote! {
+        std::panic::set_hook(Box::new(|info| {
+            let stacktrace = std::backtrace::Backtrace::force_capture();
+            println!("Got panic. @info:{}\n@stackTrace:{}", info, stacktrace);
+            std::process::abort();
+        }));
+    };
+
+    input.block.stmts.insert(0, panic_hook);
+
+    TokenStream::from(quote! {
+        #input
+    })
+}

--- a/test-macros/src/lib.rs
+++ b/test-macros/src/lib.rs
@@ -9,7 +9,7 @@ pub fn abort_on_panic(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let panic_hook: Stmt = syn::parse_quote! {
         std::panic::set_hook(Box::new(|info| {
             let stacktrace = std::backtrace::Backtrace::force_capture();
-            println!("Got panic. @info:{}\n@stackTrace:{}", info, stacktrace);
+            println!("Got panic.\n@info:\n{}\n@stackTrace:\n{}", info, stacktrace);
             std::process::abort();
         }));
     };

--- a/test-macros/tests/test_abort.rs
+++ b/test-macros/tests/test_abort.rs
@@ -1,0 +1,13 @@
+use assert_cmd::Command;
+
+#[test]
+fn should_fail() {
+    let mut cmd = Command::cargo_bin("with_abort").unwrap();
+    cmd.assert().failure();
+}
+
+#[test]
+fn should_success() {
+    let mut cmd = Command::cargo_bin("no_abort").unwrap();
+    cmd.assert().success();
+}

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -40,3 +40,4 @@ derive_builder = "0.12.0"
 [dev-dependencies]
 opentelemetry-jaeger = "0.17.0"
 tracing-subscriber = "0.3.16"
+test-macros = { path = "../test-macros" }

--- a/utils/src/tokio_lock.rs
+++ b/utils/src/tokio_lock.rs
@@ -65,9 +65,12 @@ where
 
 #[cfg(test)]
 mod test {
+    use test_macros::abort_on_panic;
+
     use super::*;
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn mutex_map_works() {
         let mu = Mutex::new(1);
         mu.map_lock(|mut g| {
@@ -79,6 +82,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn rwlock_map_works() {
         let mu = RwLock::new(1);
         mu.map_write(|mut g| {

--- a/xline-client/Cargo.toml
+++ b/xline-client/Cargo.toml
@@ -30,3 +30,4 @@ http = "0.2.9"
 [dev-dependencies]
 xline-test-utils = { path = "../xline-test-utils" }
 rand = "0.8.5"
+test-macros = { path = "../test-macros" }

--- a/xline-client/tests/kv.rs
+++ b/xline-client/tests/kv.rs
@@ -1,5 +1,6 @@
 //! The following tests are originally from `etcd-client`
 use common::get_cluster_client;
+use test_macros::abort_on_panic;
 use xline_client::{
     clients::kv::{Compare, DeleteRangeRequest, PutRequest, RangeRequest, Txn, TxnOp},
     error::Result,
@@ -9,6 +10,7 @@ use xlineapi::CompareResult;
 mod common;
 
 #[tokio::test]
+#[abort_on_panic]
 async fn test_put() -> Result<()> {
     let (_cluster, client) = get_cluster_client().await?;
     let mut client = client.kv_client();
@@ -42,6 +44,7 @@ async fn test_put() -> Result<()> {
 }
 
 #[tokio::test]
+#[abort_on_panic]
 async fn test_get() -> Result<()> {
     let (_cluster, client) = get_cluster_client().await?;
     let mut client = client.kv_client();
@@ -92,6 +95,7 @@ async fn test_get() -> Result<()> {
 }
 
 #[tokio::test]
+#[abort_on_panic]
 async fn test_delete() -> Result<()> {
     let (_cluster, client) = get_cluster_client().await?;
     let mut client = client.kv_client();
@@ -165,6 +169,7 @@ async fn test_delete() -> Result<()> {
 }
 
 #[tokio::test]
+#[abort_on_panic]
 async fn test_txn() -> Result<()> {
     let (_cluster, client) = get_cluster_client().await?;
     let mut client = client.kv_client();

--- a/xline/Cargo.toml
+++ b/xline/Cargo.toml
@@ -69,3 +69,4 @@ tonic-build = { version = "0.2", package = "madsim-tonic-build" }
 mockall = "0.11.3"
 rand = "0.8.5"
 xline-test-utils = { path = "../xline-test-utils" }
+test-macros = { path = "../test-macros" }

--- a/xline/src/server/barriers.rs
+++ b/xline/src/server/barriers.rs
@@ -101,11 +101,13 @@ mod test {
     use std::{sync::Arc, time::Duration};
 
     use futures::future::join_all;
+    use test_macros::abort_on_panic;
     use tokio::time::{sleep, timeout};
 
     use super::*;
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_id_barrier() {
         let id_barrier = Arc::new(IdBarrier::new());
         let barriers = (0..5)
@@ -126,6 +128,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_index_barrier() {
         let index_barrier = Arc::new(IndexBarrier::new());
         let barriers = (0..5).map(|i| {

--- a/xline/src/server/kv_server.rs
+++ b/xline/src/server/kv_server.rs
@@ -505,6 +505,7 @@ where
 
 #[cfg(test)]
 mod test {
+    use test_macros::abort_on_panic;
 
     use super::*;
     use crate::storage::db::DB;
@@ -554,6 +555,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_future_revision() {
         let current_revision = 10;
         let range_request = RangeRequest {

--- a/xline/src/server/maintenance.rs
+++ b/xline/src/server/maintenance.rs
@@ -178,6 +178,7 @@ where
 mod test {
     use std::{error::Error, path::PathBuf};
 
+    use test_macros::abort_on_panic;
     use tokio_stream::StreamExt;
     use utils::config::StorageConfig;
 
@@ -185,6 +186,7 @@ mod test {
     use crate::storage::db::DB;
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_snapshot_rpc() -> Result<(), Box<dyn Error>> {
         let dir = PathBuf::from("/tmp/test_snapshot_rpc");
         let db_path = dir.join("db");

--- a/xline/src/server/watch_server.rs
+++ b/xline/src/server/watch_server.rs
@@ -413,6 +413,7 @@ mod test {
     };
 
     use parking_lot::Mutex;
+    use test_macros::abort_on_panic;
     use tokio::time::{sleep, timeout};
     use utils::config::{default_watch_progress_notify_interval, StorageConfig};
 
@@ -454,6 +455,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_watch_client_closes_connection() -> Result<(), Box<dyn std::error::Error>> {
         let (req_tx, req_rx) = mpsc::channel(CHANNEL_SIZE);
         let (res_tx, mut res_rx) = mpsc::channel(CHANNEL_SIZE);
@@ -491,6 +493,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     #[allow(clippy::similar_names)] // use num as suffix
     async fn test_multi_watch_handle() -> Result<(), Box<dyn std::error::Error>> {
         let mut mock_watcher = MockKvWatcherOps::new();
@@ -553,6 +556,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_watch_prev_kv() {
         let index = Arc::new(Index::new());
         let db = DB::open(&StorageConfig::Memory).unwrap();
@@ -617,6 +621,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_watch_progress() -> Result<(), Box<dyn std::error::Error>> {
         let (req_tx, req_rx) = mpsc::channel(CHANNEL_SIZE);
         let (res_tx, mut res_rx) = mpsc::channel(CHANNEL_SIZE);
@@ -672,6 +677,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn watch_task_should_be_terminated_when_response_tx_is_closed(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (req_tx, req_rx) = mpsc::channel(CHANNEL_SIZE);

--- a/xline/src/storage/db.rs
+++ b/xline/src/storage/db.rs
@@ -215,9 +215,11 @@ mod test {
     use std::path::PathBuf;
 
     use engine::SnapshotApi;
+    use test_macros::abort_on_panic;
 
     use super::*;
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_reset() -> Result<(), ExecuteError> {
         let data_dir = PathBuf::from("/tmp/test_reset");
         let db = DB::open(&StorageConfig::RocksDB(data_dir.clone()))?;
@@ -241,6 +243,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_db_snapshot() -> Result<(), ExecuteError> {
         let dir = PathBuf::from("/tmp/test_db_snapshot");
         let origin_db_path = dir.join("origin_db");
@@ -266,6 +269,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_db_snapshot_wrong_type() -> Result<(), ExecuteError> {
         let dir = PathBuf::from("/tmp/test_db_snapshot_wrong_type");
         let db_path = dir.join("db");
@@ -282,6 +286,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_get_snapshot() -> Result<(), ExecuteError> {
         let dir = PathBuf::from("/tmp/test_get_snapshot");
         let data_path = dir.join("data");
@@ -296,6 +301,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_db_write_ops() {
         let db = DB::open(&StorageConfig::Memory).unwrap();
         let lease = PbLease {

--- a/xline/src/storage/kv_store.rs
+++ b/xline/src/storage/kv_store.rs
@@ -746,6 +746,7 @@ where
 mod test {
     use std::time::Duration;
 
+    use test_macros::abort_on_panic;
     use utils::config::StorageConfig;
 
     use super::*;
@@ -822,6 +823,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_keys_only() -> Result<(), ExecuteError> {
         let db = DB::open(&StorageConfig::Memory)?;
         let (store, _rev) = init_store(db).await?;
@@ -842,6 +844,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_range_empty() -> Result<(), ExecuteError> {
         let db = DB::open(&StorageConfig::Memory)?;
         let (store, _rev) = init_store(db).await?;
@@ -860,6 +863,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_range_filter() -> Result<(), ExecuteError> {
         let db = DB::open(&StorageConfig::Memory)?;
         let (store, _rev) = init_store(db).await?;
@@ -883,6 +887,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_range_sort() -> Result<(), ExecuteError> {
         let db = DB::open(&StorageConfig::Memory)?;
         let (store, _rev) = init_store(db).await?;
@@ -926,6 +931,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_recover() -> Result<(), ExecuteError> {
         let db = DB::open(&StorageConfig::Memory)?;
         let _store = init_store(Arc::clone(&db)).await?;
@@ -950,6 +956,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_txn() -> Result<(), ExecuteError> {
         let txn_req = RequestWithToken::new(
             TxnRequest {
@@ -1006,6 +1013,7 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+    #[abort_on_panic]
     async fn test_kv_store_index_available() {
         let db = DB::open(&StorageConfig::Memory).unwrap();
         let (store, revision) = init_store(Arc::clone(&db)).await.unwrap();

--- a/xline/src/storage/kvwatcher.rs
+++ b/xline/src/storage/kvwatcher.rs
@@ -538,6 +538,7 @@ mod test {
     use std::{collections::BTreeMap, time::Duration};
 
     use clippy_utilities::Cast;
+    use test_macros::abort_on_panic;
     use tokio::time::{sleep, timeout};
     use utils::config::StorageConfig;
 
@@ -573,6 +574,7 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+    #[abort_on_panic]
     async fn watch_should_not_lost_events() {
         let (store, db, kv_watcher) = init_empty_store();
         let mut map = BTreeMap::new();
@@ -626,6 +628,7 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+    #[abort_on_panic]
     async fn test_victim() {
         let (store, db, kv_watcher) = init_empty_store();
         // response channel with capacity 1, so it will be full easily, then we can trigger victim
@@ -662,6 +665,7 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+    #[abort_on_panic]
     async fn test_cancel_watcher() {
         let (_store, _db, kv_watcher) = init_empty_store();
         let (event_tx, _event_rx) = mpsc::channel(1);

--- a/xline/src/storage/lease_store/mod.rs
+++ b/xline/src/storage/lease_store/mod.rs
@@ -370,12 +370,14 @@ where
 mod test {
     use std::{error::Error, time::Duration};
 
+    use test_macros::abort_on_panic;
     use utils::config::StorageConfig;
 
     use super::*;
     use crate::storage::db::DB;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+    #[abort_on_panic]
     async fn test_lease_storage() -> Result<(), Box<dyn Error>> {
         let db = DB::open(&StorageConfig::Memory)?;
         let lease_store = init_store(db);
@@ -472,6 +474,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[abort_on_panic]
     async fn test_recover() -> Result<(), ExecuteError> {
         let db = DB::open(&StorageConfig::Memory)?;
         let store = init_store(Arc::clone(&db));

--- a/xline/tests/auth_test.rs
+++ b/xline/tests/auth_test.rs
@@ -1,11 +1,13 @@
 use std::error::Error;
 
 use etcd_client::{AuthClient, ConnectOptions, GetOptions, Permission, PermissionType};
+use test_macros::abort_on_panic;
 use xline::client::kv_types::{PutRequest, RangeRequest};
 
 use xline_test_utils::Cluster;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_auth_empty_user_get() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;
@@ -20,6 +22,7 @@ async fn test_auth_empty_user_get() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_auth_empty_user_put() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;
@@ -34,6 +37,7 @@ async fn test_auth_empty_user_put() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_auth_token_with_disable() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;
@@ -54,6 +58,7 @@ async fn test_auth_token_with_disable() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_auth_revision() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;
@@ -69,6 +74,7 @@ async fn test_auth_revision() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_auth_non_authorized_rpcs() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;
@@ -85,6 +91,7 @@ async fn test_auth_non_authorized_rpcs() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_kv_authorization() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;
@@ -124,6 +131,7 @@ async fn test_kv_authorization() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_role_delete() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;
@@ -141,6 +149,7 @@ async fn test_role_delete() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_no_root_user_do_admin_ops() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;
@@ -172,6 +181,7 @@ async fn test_no_root_user_do_admin_ops() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_auth_wrong_password() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;

--- a/xline/tests/kv_test.rs
+++ b/xline/tests/kv_test.rs
@@ -1,6 +1,7 @@
 use std::{error::Error, time::Duration};
 
 use etcd_client::Client;
+use test_macros::abort_on_panic;
 use xline::client::kv_types::{
     DeleteRangeRequest, PutRequest, RangeRequest, SortOrder, SortTarget,
 };
@@ -8,6 +9,7 @@ use xline::client::kv_types::{
 use xline_test_utils::Cluster;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_kv_put() -> Result<(), Box<dyn Error>> {
     struct TestCase {
         req: PutRequest,
@@ -42,6 +44,7 @@ async fn test_kv_put() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_kv_get() -> Result<(), Box<dyn Error>> {
     struct TestCase<'a> {
         req: RangeRequest,
@@ -158,6 +161,7 @@ async fn test_kv_get() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_range_redirect() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;
@@ -174,6 +178,7 @@ async fn test_range_redirect() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_kv_delete() -> Result<(), Box<dyn Error>> {
     struct TestCase<'a> {
         req: DeleteRangeRequest,

--- a/xline/tests/lease_test.rs
+++ b/xline/tests/lease_test.rs
@@ -1,11 +1,13 @@
 use std::{error::Error, time::Duration};
 
+use test_macros::abort_on_panic;
 use tracing::info;
 use xline::client::kv_types::{LeaseGrantRequest, PutRequest, RangeRequest};
 
 use xline_test_utils::Cluster;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_lease_expired() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;
@@ -31,6 +33,7 @@ async fn test_lease_expired() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_lease_keep_alive() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;

--- a/xline/tests/lock_test.rs
+++ b/xline/tests/lock_test.rs
@@ -1,10 +1,12 @@
 use std::{error::Error, time::Duration};
 
 use etcd_client::LockOptions;
+use test_macros::abort_on_panic;
 use tokio::time::{self, timeout};
 use xline_test_utils::Cluster;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_lock() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;
@@ -32,6 +34,7 @@ async fn test_lock() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_lock_timeout() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;

--- a/xline/tests/maintenance.rs
+++ b/xline/tests/maintenance.rs
@@ -1,5 +1,6 @@
 use std::{path::PathBuf, time::Duration};
 
+use test_macros::abort_on_panic;
 use tokio::io::AsyncWriteExt;
 use xline::client::{
     kv_types::{PutRequest, RangeRequest},
@@ -8,6 +9,7 @@ use xline::client::{
 use xline_test_utils::Cluster;
 
 #[tokio::test]
+#[abort_on_panic]
 async fn test_snapshot_and_restore() -> Result<(), Box<dyn std::error::Error>> {
     let dir = PathBuf::from("/tmp/test_snapshot_and_restore");
     tokio::fs::create_dir_all(&dir).await?;

--- a/xline/tests/watch_test.rs
+++ b/xline/tests/watch_test.rs
@@ -1,11 +1,13 @@
 use std::error::Error;
 
 use etcd_client::EventType;
+use test_macros::abort_on_panic;
 use xline::client::kv_types::{DeleteRangeRequest, PutRequest};
 
 use xline_test_utils::Cluster;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[abort_on_panic]
 async fn test_watch() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;


### PR DESCRIPTION
Closes: #267

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?
    
   This PR add a new `abort_on_panic` macro. It adds a panic hook at the beginning of a funciton, which can be used in tokio tests to force test to fail when a tokio task panic. 

    This is more of a temporary solution as there is no way tokio could handle a panic in tasks properly unless the task is joined.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)