### PR TITLE
test: add test case information in abort_on_panic macros

### DIFF
--- a/test-macros/src/lib.rs
+++ b/test-macros/src/lib.rs
@@ -5,11 +5,12 @@ use syn::{parse_macro_input, ItemFn, Stmt};
 #[proc_macro_attribute]
 pub fn abort_on_panic(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut input: syn::ItemFn = parse_macro_input!(item as ItemFn);
+    let test_case = &input.sig.ident.to_string();
 
     let panic_hook: Stmt = syn::parse_quote! {
         std::panic::set_hook(Box::new(|info| {
             let stacktrace = std::backtrace::Backtrace::force_capture();
-            println!("Got panic.\n@info:\n{}\n@stackTrace:\n{}", info, stacktrace);
+            println!("`{}` panic! \n@info:\n{}\n@stackTrace:\n{}", #test_case, info, stacktrace);
             std::process::abort();
         }));
     };


### PR DESCRIPTION
Closes: #360

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)