### PR TITLE
fix: resolve failing madsim tests

### DIFF
--- a/simulation/src/curp_group.rs
+++ b/simulation/src/curp_group.rs
@@ -257,13 +257,13 @@ impl CurpGroup {
     }
 
     pub async fn get_leader(&self) -> (ServerId, u64) {
-        for _ in 0..5 {
+        loop {
             if let Some(leader) = self.try_get_leader().await {
                 return leader;
             }
             debug!("failed to get leader");
+            madsim::time::sleep(Duration::from_millis(100)).await;
         }
-        panic!("can't get leader");
     }
 
     // get latest term and ensure every working node has the same term

--- a/simulation/tests/it/curp/server_election.rs
+++ b/simulation/tests/it/curp/server_election.rs
@@ -1,13 +1,10 @@
-use std::time::Duration;
-
-use curp_test_utils::{init_logger, test_cmd::TestCommand};
-use madsim::time::sleep;
+use curp_test_utils::{init_logger, sleep_secs, test_cmd::TestCommand};
 use utils::config::ClientTimeout;
 
 use simulation::curp_group::CurpGroup;
 
 async fn wait_for_election() {
-    sleep(Duration::from_secs(3)).await;
+    sleep_secs(3).await;
 }
 
 fn check_leader_state(group: &CurpGroup, leader: &String) {
@@ -50,7 +47,7 @@ async fn election() {
     check_role_state(&group, 5, &leader0);
 
     // check after some time, the term and the leader is still not changed
-    madsim::time::sleep(Duration::from_secs(1)).await;
+    sleep_secs(1).await;
     let leader2 = group
         .try_get_leader()
         .await
@@ -139,14 +136,12 @@ async fn propose_after_reelect() {
             .0,
         vec![]
     );
-    // wait for the cmd to be synced
-    madsim::time::sleep(Duration::from_secs(1)).await;
 
     let leader1 = group.get_leader().await.0;
     check_role_state(&group, 5, &leader1);
     group.disable_node(&leader1);
 
-    madsim::time::sleep(Duration::from_secs(2)).await;
+    wait_for_election().await;
     assert_eq!(
         client
             .propose(TestCommand::new_get(vec![0]))

--- a/simulation/tests/it/curp/server_recovery.rs
+++ b/simulation/tests/it/curp/server_recovery.rs
@@ -353,10 +353,14 @@ async fn old_leader_will_discard_spec_exe_cmds() {
 }
 
 #[madsim::test]
-async fn all_crash_and_recovery() {
+async fn minority_crash_and_recovery() {
     init_logger();
 
-    let mut group = CurpGroup::new(3).await;
+    const NODES: usize = 9;
+    const MINORITY: usize = (NODES - 1) / 2;
+
+    let mut group = CurpGroup::new(NODES).await;
+
     let client = group.new_client(ClientTimeout::default()).await;
 
     assert_eq!(
@@ -376,12 +380,11 @@ async fn all_crash_and_recovery() {
         vec![0]
     );
 
-    let all = group.all.keys().cloned().collect_vec();
-    for node in &all {
+    let minority = group.all.keys().take(MINORITY).cloned().collect_vec();
+    for node in &minority {
         group.crash(node).await;
     }
-    sleep_secs(2).await;
-    for node in &all {
+    for node in &minority {
         group.restart(node, node.as_str() == "S0").await;
     }
 

--- a/simulation/tests/it/curp/server_recovery.rs
+++ b/simulation/tests/it/curp/server_recovery.rs
@@ -312,14 +312,14 @@ async fn old_leader_will_discard_spec_exe_cmds() {
         group.enable_node(&node.id);
     }
     // wait for election
-    sleep_secs(3).await;
+    sleep_secs(15).await;
     let leader2 = group.get_leader().await.0;
     assert_ne!(leader2, leader1);
 
     // 4: recover the old leader, its state should be reverted to the original state
     group.enable_node(&leader1);
     // wait for reversion
-    sleep_secs(1).await;
+    sleep_secs(15).await;
     let res = leader1_store
         .lock()
         .as_ref()
@@ -432,7 +432,7 @@ async fn recovery_after_compaction() {
     }
 
     // wait for log compactions
-    sleep_secs(1).await;
+    sleep_secs(15).await;
 
     debug!("start recovery");
 
@@ -440,7 +440,7 @@ async fn recovery_after_compaction() {
     group.restart(&node_id, false).await;
 
     // wait for node to restart
-    sleep_secs(3).await;
+    sleep_secs(15).await;
 
     {
         let node = group.nodes.get_mut(&node_id).unwrap();


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    Described in : #361

* what changes does this pull request make?

    1. change `all_crash_and_recovery` to `minority_crash_and_recovery`. This test does not match the assumption of current implementation(that the majority of nodes should not crash), therefore lead to a test failure.
    2. refactor some assumptions based on time synchronization, makes these test runs more stable under madsim simulated time.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)