### PR TITLE
doc: add examples to xline client

### DIFF
--- a/xline-client/README.md
+++ b/xline-client/README.md
@@ -112,6 +112,10 @@ To create a xline client:
  }
  ```
 
+## Examples
+
+You can find them in [examples](https://github.com/xline-kv/Xline/tree/master/xline-client/examples)
+
 ## Xline Compatibility
 
 We aim to maintain compatibility with each corresponding Xline version, and update this library with each new Xline release.

--- a/xline-client/README.md
+++ b/xline-client/README.md
@@ -13,13 +13,13 @@ Official Xline API client for Rust that supports the [CURP](https://github.com/x
   - [x] Range
   - [x] Delete
   - [x] Transaction
-  - [ ] Compact
+  - [x] Compact
 - Lease
-  - [ ] Grant
-  - [ ] Revoke
-  - [ ] KeepAlive
-  - [ ] TimeToLive
-  - [ ] Leases
+  - [x] Grant
+  - [x] Revoke
+  - [x] KeepAlive
+  - [x] TimeToLive
+  - [x] Leases
 - Watch
   - [x] WatchCreate
   - [x] WatchCancel
@@ -54,8 +54,8 @@ Official Xline API client for Rust that supports the [CURP](https://github.com/x
   - [ ] Leader
   - [ ] Observe
 - Lock
-  - [ ] Lock
-  - [ ] Unlock
+  - [x] Lock
+  - [x] Unlock
 - Maintenance
   - [ ] Alarm
   - [ ] Status

--- a/xline-client/examples/auth.rs
+++ b/xline-client/examples/auth.rs
@@ -1,0 +1,35 @@
+use xline_client::{error::Result, Client, ClientOptions};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // the name and address of all curp members
+    let curp_members = [
+        ("server0", "10.0.0.1:2379"),
+        ("server1", "10.0.0.2:2379"),
+        ("server2", "10.0.0.3:2379"),
+    ];
+
+    let client = Client::connect(curp_members, ClientOptions::default())
+        .await?
+        .auth_client();
+
+    // enable auth
+    let _resp = client.auth_enable().await?;
+
+    // connect using the root user
+    let options = ClientOptions::default().with_user("root", "rootpwd");
+    let client = Client::connect(curp_members, options).await?.auth_client();
+
+    // disable auth
+    let _resp = client.auth_disable();
+
+    // get auth status
+    let resp = client.auth_status().await?;
+    println!("auth status:");
+    println!(
+        "enabled: {}, revision: {}",
+        resp.enabled, resp.auth_revision
+    );
+
+    Ok(())
+}

--- a/xline-client/examples/auth_role.rs
+++ b/xline-client/examples/auth_role.rs
@@ -1,0 +1,71 @@
+use xline_client::{
+    error::Result,
+    types::auth::{
+        AuthRoleAddRequest, AuthRoleDeleteRequest, AuthRoleGetRequest,
+        AuthRoleGrantPermissionRequest, AuthRoleRevokePermissionRequest, Permission,
+        PermissionType,
+    },
+    Client, ClientOptions,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // the name and address of all curp members
+    let curp_members = [
+        ("server0", "10.0.0.1:2379"),
+        ("server1", "10.0.0.2:2379"),
+        ("server2", "10.0.0.3:2379"),
+    ];
+
+    let client = Client::connect(curp_members, ClientOptions::default())
+        .await?
+        .auth_client();
+
+    // add roles
+    client.role_add(AuthRoleAddRequest::new("role1")).await?;
+    client.role_add(AuthRoleAddRequest::new("role2")).await?;
+
+    // grant permissions to roles
+    client
+        .role_grant_permission(AuthRoleGrantPermissionRequest::new(
+            "role1",
+            Permission::new(PermissionType::Read, "key1"),
+        ))
+        .await?;
+    client
+        .role_grant_permission(AuthRoleGrantPermissionRequest::new(
+            "role2",
+            Permission::new(PermissionType::Readwrite, "key2"),
+        ))
+        .await?;
+
+    // list all roles and their permissions
+    let resp = client.role_list().await?;
+    println!("roles:");
+    for role in resp.roles {
+        println!("{}", role);
+        let get_resp = client.role_get(AuthRoleGetRequest::new(role)).await?;
+        println!("permmisions:");
+        for perm in get_resp.perm {
+            println!("{} {}", perm.perm_type, String::from_utf8_lossy(&perm.key));
+        }
+    }
+
+    // revoke permissions from roles
+    client
+        .role_revoke_permission(AuthRoleRevokePermissionRequest::new("role1", "key1"))
+        .await?;
+    client
+        .role_revoke_permission(AuthRoleRevokePermissionRequest::new("role2", "key2"))
+        .await?;
+
+    // delete roles
+    client
+        .role_delete(AuthRoleDeleteRequest::new("role1"))
+        .await?;
+    client
+        .role_delete(AuthRoleDeleteRequest::new("role2"))
+        .await?;
+
+    Ok(())
+}

--- a/xline-client/examples/auth_user.rs
+++ b/xline-client/examples/auth_user.rs
@@ -1,0 +1,69 @@
+use xline_client::{
+    error::Result,
+    types::auth::{
+        AuthUserAddRequest, AuthUserChangePasswordRequest, AuthUserDeleteRequest,
+        AuthUserGetRequest, AuthUserGrantRoleRequest, AuthUserRevokeRoleRequest,
+    },
+    Client, ClientOptions,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // the name and address of all curp members
+    let curp_members = [
+        ("server0", "10.0.0.1:2379"),
+        ("server1", "10.0.0.2:2379"),
+        ("server2", "10.0.0.3:2379"),
+    ];
+
+    let client = Client::connect(curp_members, ClientOptions::default())
+        .await?
+        .auth_client();
+
+    // add user
+    client.user_add(AuthUserAddRequest::new("user1")).await?;
+    client.user_add(AuthUserAddRequest::new("user2")).await?;
+
+    // change user1's password to "123"
+    client
+        .user_change_password(AuthUserChangePasswordRequest::new("user1", "123"))
+        .await?;
+
+    // grant roles
+    client
+        .user_grant_role(AuthUserGrantRoleRequest::new("user1", "role1"))
+        .await?;
+    client
+        .user_grant_role(AuthUserGrantRoleRequest::new("user2", "role2"))
+        .await?;
+
+    // list all users and their roles
+    let resp = client.user_list().await?;
+    for user in resp.users {
+        println!("user: {}", user);
+        let get_resp = client.user_get(AuthUserGetRequest::new(user)).await?;
+        println!("roles:");
+        for role in get_resp.roles.iter() {
+            print!("{} ", role);
+        }
+        println!();
+    }
+
+    // revoke role from user
+    client
+        .user_revoke_role(AuthUserRevokeRoleRequest::new("user1", "role1"))
+        .await?;
+    client
+        .user_revoke_role(AuthUserRevokeRoleRequest::new("user2", "role2"))
+        .await?;
+
+    // delete users
+    client
+        .user_delete(AuthUserDeleteRequest::new("user1"))
+        .await?;
+    client
+        .user_delete(AuthUserDeleteRequest::new("user2"))
+        .await?;
+
+    Ok(())
+}

--- a/xline-client/examples/error_handling.rs
+++ b/xline-client/examples/error_handling.rs
@@ -1,0 +1,48 @@
+//! An example to show how the errors are organized in `xline-client`
+use curp::error::CommandProposeError;
+use xline::storage::ExecuteError;
+use xline_client::{
+    error::{ClientError, Result},
+    types::kv::PutRequest,
+    Client, ClientOptions,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // the name and address of all curp members
+    let curp_members = [
+        ("server0", "10.0.0.1:2379"),
+        ("server1", "10.0.0.2:2379"),
+        ("server2", "10.0.0.3:2379"),
+    ];
+
+    let client = Client::connect(curp_members, ClientOptions::default())
+        .await?
+        .kv_client();
+
+    // We try to update the key using its previous value.
+    // It should return an error and it should be `key not found`
+    // as we did not add it before.
+    let resp = client
+        .put(PutRequest::new("key", "").with_ignore_value(true))
+        .await;
+    let err = resp.unwrap_err();
+
+    // We first match the client error
+    let ClientError::ProposeError(pe) = err else {
+        unreachable!("client.put should not return any errors other than PropseError, but it receives {err:?}")
+    };
+    // Then we match the inner error returned by the Curp server.
+    // The command should failed at execution stage.
+    let CommandProposeError::Execute(ee) = pe else {
+        unreachable!("the propose error should be an Execute error, but it is {pe:?}")
+    };
+
+    assert!(
+        matches!(ee, ExecuteError::KeyNotFound),
+        "the return result should be `KeyNotFound`"
+    );
+    println!("got error: {ee}");
+
+    Ok(())
+}

--- a/xline-client/examples/kv.rs
+++ b/xline-client/examples/kv.rs
@@ -1,11 +1,11 @@
 use xline_client::{
     error::ClientError as Error,
     types::kv::{
-        CompactionRequest, Compare, DeleteRangeRequest, PutRequest, RangeRequest, TxnOp, TxnRequest,
+        CompactionRequest, Compare, CompareResult, DeleteRangeRequest, PutRequest, RangeRequest,
+        TxnOp, TxnRequest,
     },
     Client, ClientOptions,
 };
-use xlineapi::CompareResult;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -72,5 +72,6 @@ async fn main() -> Result<(), Error> {
     // compact
     let rev = resp.header.unwrap().revision;
     let _resp = client.compact(CompactionRequest::new(rev)).await?;
+
     Ok(())
 }

--- a/xline-client/examples/lease.rs
+++ b/xline-client/examples/lease.rs
@@ -1,0 +1,59 @@
+use xline_client::{
+    error::Result,
+    types::lease::{
+        LeaseGrantRequest, LeaseKeepAliveRequest, LeaseRevokeRequest, LeaseTimeToLiveRequest,
+    },
+    Client, ClientOptions,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // the name and address of all curp members
+    let curp_members = [
+        ("server0", "10.0.0.1:2379"),
+        ("server1", "10.0.0.2:2379"),
+        ("server2", "10.0.0.3:2379"),
+    ];
+
+    let mut client = Client::connect(curp_members, ClientOptions::default())
+        .await?
+        .lease_client();
+
+    // grant new lease
+    let resp1 = client.grant(LeaseGrantRequest::new(60)).await?;
+    let resp2 = client.grant(LeaseGrantRequest::new(60)).await?;
+    let lease_id1 = resp1.id;
+    let lease_id2 = resp2.id;
+    println!("lease id 1: {}", lease_id1);
+    println!("lease id 2: {}", lease_id2);
+
+    // get the ttl of lease1
+    let resp = client
+        .time_to_live(LeaseTimeToLiveRequest::new(lease_id1))
+        .await?;
+
+    println!("remaining ttl: {}", resp.ttl);
+
+    // keep alive lease2
+    let (mut keeper, mut stream) = client
+        .keep_alive(LeaseKeepAliveRequest::new(lease_id2))
+        .await?;
+
+    if let Some(resp) = stream.message().await? {
+        println!("new ttl: {}", resp.ttl);
+    }
+
+    // keep alive lease2 again using the keeper
+    keeper.keep_alive()?;
+
+    // list all leases
+    for lease in client.leases().await?.leases {
+        println!("lease: {}", lease.id);
+    }
+
+    // revoke the leases
+    let _resp = client.revoke(LeaseRevokeRequest::new(lease_id1)).await?;
+    let _resp = client.revoke(LeaseRevokeRequest::new(lease_id2)).await?;
+
+    Ok(())
+}

--- a/xline-client/examples/lock.rs
+++ b/xline-client/examples/lock.rs
@@ -1,0 +1,33 @@
+use xline_client::{
+    error::Result,
+    types::lock::{LockRequest, UnlockRequest},
+    Client, ClientOptions,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // the name and address of all curp members
+    let curp_members = [
+        ("server0", "10.0.0.1:2379"),
+        ("server1", "10.0.0.2:2379"),
+        ("server2", "10.0.0.3:2379"),
+    ];
+
+    let client = Client::connect(curp_members, ClientOptions::default())
+        .await?
+        .lock_client();
+
+    // acquire a lock
+    let resp = client
+        .lock(LockRequest::new().with_name("lock-test"))
+        .await?;
+
+    let key = resp.key;
+
+    println!("lock key: {:?}", String::from_utf8_lossy(&key));
+
+    // release the lock
+    client.unlock(UnlockRequest::new().with_key(key)).await?;
+
+    Ok(())
+}

--- a/xline-client/examples/maintenance.rs
+++ b/xline-client/examples/maintenance.rs
@@ -1,0 +1,30 @@
+use xline_client::{error::ClientError as Error, Client, ClientOptions};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    // the name and address of all curp members
+    let curp_members = [
+        ("server0", "10.0.0.1:2379"),
+        ("server1", "10.0.0.2:2379"),
+        ("server2", "10.0.0.3:2379"),
+    ];
+
+    let mut client = Client::connect(curp_members, ClientOptions::default())
+        .await?
+        .maintenance_client();
+
+    // snapshot
+    let mut msg = client.snapshot().await?;
+    let mut snapshot = vec![];
+    loop {
+        if let Some(resp) = msg.message().await? {
+            snapshot.extend_from_slice(&resp.blob);
+            if resp.remaining_bytes == 0 {
+                break;
+            }
+        }
+    }
+    println!("snapshot size: {}", snapshot.len());
+
+    Ok(())
+}

--- a/xline-client/examples/watch.rs
+++ b/xline-client/examples/watch.rs
@@ -1,0 +1,37 @@
+use xline_client::{
+    error::ClientError as Error,
+    types::{kv::PutRequest, watch::WatchRequest},
+    Client, ClientOptions,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    // the name and address of all curp members
+    let curp_members = [
+        ("server0", "10.0.0.1:2379"),
+        ("server1", "10.0.0.2:2379"),
+        ("server2", "10.0.0.3:2379"),
+    ];
+
+    let client = Client::connect(curp_members, ClientOptions::default()).await?;
+    let mut watch_client = client.watch_client();
+    let kv_client = client.kv_client();
+
+    // watch
+    let (mut watcher, mut stream) = watch_client.watch(WatchRequest::new("key1")).await?;
+    kv_client.put(PutRequest::new("key1", "value1")).await?;
+
+    let resp = stream.message().await?.unwrap();
+    let kv = resp.events[0].kv.as_ref().unwrap();
+
+    println!(
+        "got key: {}, value: {}",
+        String::from_utf8_lossy(&kv.key),
+        String::from_utf8_lossy(&kv.value)
+    );
+
+    // cancel the watch
+    watcher.cancel()?;
+
+    Ok(())
+}

--- a/xline-client/src/clients/auth.rs
+++ b/xline-client/src/clients/auth.rs
@@ -66,6 +66,31 @@ impl AuthClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     let _resp = client.auth_enable().await?;
+    ///
+    ///     // auth with some user
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn auth_enable(&self) -> Result<AuthEnableResponse> {
         self.handle_req(xlineapi::AuthEnableRequest {}, false).await
@@ -76,6 +101,31 @@ impl AuthClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     let _resp = client.auth_enable().await?;
+    ///
+    ///     // auth with some user
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn auth_disable(&self) -> Result<AuthDisableResponse> {
         self.handle_req(xlineapi::AuthDisableRequest {}, false)
@@ -87,6 +137,34 @@ impl AuthClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     let resp = client.auth_status().await?;
+    ///     println!("auth status:");
+    ///     println!(
+    ///         "enabled: {}, revision: {}",
+    ///         resp.enabled, resp.auth_revision
+    ///     );
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn auth_status(&self) -> Result<AuthStatusResponse> {
         self.handle_req(xlineapi::AuthStatusRequest {}, true).await
@@ -97,6 +175,33 @@ impl AuthClient {
     /// # Errors
     ///
     /// This function will return an error if the inner RPC client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, types::auth::AuthenticateRequest, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let mut client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     let resp = client
+    ///         .authenticate(AuthenticateRequest::new("root", "rootpw"))
+    ///         .await?;
+    ///
+    ///     println!("auth token: {}", resp.token);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn authenticate(
         &mut self,
@@ -114,6 +219,28 @@ impl AuthClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, types::auth::AuthUserAddRequest, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     client.user_add(AuthUserAddRequest::new("user1")).await?;
+    ///     Ok(())
+    /// }
+    ///```
     #[inline]
     pub async fn user_add(&self, mut request: AuthUserAddRequest) -> Result<AuthUserAddResponse> {
         if request.inner.name.is_empty() {
@@ -140,6 +267,33 @@ impl AuthClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, types::auth::AuthUserGetRequest, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     let resp = client.user_get(AuthUserGetRequest::new("user")).await?;
+    ///
+    ///     for role in resp.roles {
+    ///         print!("{} ", role);
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    ///```
     #[inline]
     pub async fn user_get(&self, request: AuthUserGetRequest) -> Result<AuthUserGetResponse> {
         self.handle_req(request.inner, true).await
@@ -150,6 +304,33 @@ impl AuthClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     let resp = client.user_list().await?;
+    ///
+    ///     for user in resp.users {
+    ///         println!("user: {}", user);
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    ///```
     #[inline]
     pub async fn user_list(&self) -> Result<AuthUserListResponse> {
         self.handle_req(xlineapi::AuthUserListRequest {}, true)
@@ -161,6 +342,35 @@ impl AuthClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     // add the user
+    ///
+    ///     let resp = client.user_list().await?;
+    ///
+    ///     for user in resp.users {
+    ///         println!("user: {}", user);
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    ///```
     #[inline]
     pub async fn user_delete(
         &self,
@@ -174,6 +384,35 @@ impl AuthClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{
+    ///     error::Result, types::auth::AuthUserChangePasswordRequest, Client, ClientOptions,
+    /// };
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     // add the user
+    ///
+    ///     client
+    ///         .user_change_password(AuthUserChangePasswordRequest::new("user", "123"))
+    ///         .await?;
+    ///
+    ///     Ok(())
+    /// }
+    ///```
     #[inline]
     pub async fn user_change_password(
         &self,
@@ -193,6 +432,33 @@ impl AuthClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, types::auth::AuthUserGrantRoleRequest, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     // add user and role
+    ///
+    ///     client
+    ///         .user_grant_role(AuthUserGrantRoleRequest::new("user", "role"))
+    ///         .await?;
+    ///
+    ///     Ok(())
+    /// }
+    ///```
     #[inline]
     pub async fn user_grant_role(
         &self,
@@ -206,6 +472,33 @@ impl AuthClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, types::auth::AuthUserRevokeRoleRequest, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     // grant role
+    ///
+    ///     client
+    ///         .user_revoke_role(AuthUserRevokeRoleRequest::new("user", "role"))
+    ///         .await?;
+    ///
+    ///     Ok(())
+    /// }
+    ///```
     #[inline]
     pub async fn user_revoke_role(
         &self,
@@ -219,6 +512,30 @@ impl AuthClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::types::auth::AuthRoleAddRequest;
+    /// use xline_client::{error::Result, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     client.role_add(AuthRoleAddRequest::new("role")).await?;
+    ///
+    ///     Ok(())
+    /// }
+    ///```
     #[inline]
     pub async fn role_add(&self, request: AuthRoleAddRequest) -> Result<AuthRoleAddResponse> {
         if request.inner.name.is_empty() {
@@ -232,6 +549,35 @@ impl AuthClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::types::auth::AuthRoleGetRequest;
+    /// use xline_client::{error::Result, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     let resp = client.role_get(AuthRoleGetRequest::new("role")).await?;
+    ///
+    ///     println!("permmisions:");
+    ///     for perm in resp.perm {
+    ///         println!("{} {}", perm.perm_type, String::from_utf8_lossy(&perm.key));
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    ///```
     #[inline]
     pub async fn role_get(&self, request: AuthRoleGetRequest) -> Result<AuthRoleGetResponse> {
         self.handle_req(request.inner, true).await
@@ -242,6 +588,34 @@ impl AuthClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     let resp = client.role_list().await?;
+    ///
+    ///     println!("roles:");
+    ///     for role in resp.roles {
+    ///         println!("{}", role);
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    ///```
     #[inline]
     pub async fn role_list(&self) -> Result<AuthRoleListResponse> {
         self.handle_req(xlineapi::AuthRoleListRequest {}, true)
@@ -253,6 +627,33 @@ impl AuthClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, types::auth::AuthRoleDeleteRequest, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     // add the role
+    ///
+    ///     client
+    ///         .role_delete(AuthRoleDeleteRequest::new("role"))
+    ///         .await?;
+    ///
+    ///     Ok(())
+    /// }
+    ///```
     #[inline]
     pub async fn role_delete(
         &self,
@@ -266,6 +667,40 @@ impl AuthClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{
+    ///     error::Result,
+    ///     types::auth::{AuthRoleGrantPermissionRequest, Permission, PermissionType},
+    ///     Client, ClientOptions,
+    /// };
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     // add the role and key
+    ///
+    ///     client
+    ///         .role_grant_permission(AuthRoleGrantPermissionRequest::new(
+    ///             "role",
+    ///             Permission::new(PermissionType::Read, "key"),
+    ///         ))
+    ///         .await?;
+    ///
+    ///     Ok(())
+    /// }
+    ///```
     #[inline]
     pub async fn role_grant_permission(
         &self,
@@ -283,8 +718,36 @@ impl AuthClient {
     ///
     /// # Errors
     ///
-    /// If request fails to send
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{
+    ///     error::Result, types::auth::AuthRoleRevokePermissionRequest, Client, ClientOptions,
+    /// };
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .auth_client();
+    ///
+    ///     // grant the role
+    ///
+    ///     client
+    ///         .role_revoke_permission(AuthRoleRevokePermissionRequest::new("role", "key"))
+    ///         .await?;
+    ///
+    ///     Ok(())
+    /// }
+    ///```
     #[inline]
     pub async fn role_revoke_permission(
         &self,

--- a/xline-client/src/clients/kv.rs
+++ b/xline-client/src/clients/kv.rs
@@ -44,6 +44,29 @@ impl KvClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, types::kv::PutRequest, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let mut client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .kv_client();
+    ///
+    ///     client.put(PutRequest::new("key1", "value1")).await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn put(&self, request: PutRequest) -> Result<PutResponse> {
         let key_ranges = vec![KeyRange::new_one_key(request.key())];
@@ -62,6 +85,37 @@ impl KvClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, types::kv::RangeRequest, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let mut client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .kv_client();
+    ///
+    ///     let resp = client.range(RangeRequest::new("key1")).await?;
+    ///
+    ///     if let Some(kv) = resp.kvs.first() {
+    ///         println!(
+    ///             "got key: {}, value: {}",
+    ///             String::from_utf8_lossy(&kv.key),
+    ///             String::from_utf8_lossy(&kv.value)
+    ///         );
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn range(&self, request: RangeRequest) -> Result<RangeResponse> {
         let key_ranges = vec![KeyRange::new(request.key(), request.range_end())];
@@ -80,6 +134,30 @@ impl KvClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use xline_client::{error::Result, types::kv::DeleteRangeRequest, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let mut client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .kv_client();
+    ///
+    ///     client
+    ///         .delete(DeleteRangeRequest::new("key1").with_prev_kv(true))
+    ///         .await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn delete(&self, request: DeleteRangeRequest) -> Result<DeleteRangeResponse> {
         let key_ranges = vec![KeyRange::new(request.key(), request.range_end())];
@@ -98,6 +176,42 @@ impl KvClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{
+    ///     error::Result,
+    ///     types::kv::{Compare, PutRequest, RangeRequest, TxnOp, TxnRequest, CompareResult},
+    ///     Client, ClientOptions,
+    /// };
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let mut client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .kv_client();
+    ///
+    ///     let txn_req = TxnRequest::new()
+    ///         .when(&[Compare::value("key2", CompareResult::Equal, "value2")][..])
+    ///         .and_then(
+    ///             &[TxnOp::put(
+    ///                 PutRequest::new("key2", "value3").with_prev_kv(true),
+    ///             )][..],
+    ///         )
+    ///         .or_else(&[TxnOp::range(RangeRequest::new("key2"))][..]);
+    ///
+    ///     let _resp = client.txn(txn_req).await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn txn(&self, request: TxnRequest) -> Result<TxnResponse> {
         let key_ranges = request

--- a/xline-client/src/clients/lease.rs
+++ b/xline-client/src/clients/lease.rs
@@ -64,6 +64,30 @@ impl LeaseClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, types::lease::LeaseGrantRequest, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let mut client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .lease_client();
+    ///
+    ///     let resp = client.grant(LeaseGrantRequest::new(60)).await?;
+    ///     println!("lease id: {}", resp.id);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn grant(&self, mut request: LeaseGrantRequest) -> Result<LeaseGrantResponse> {
         let propose_id = self.generate_propose_id();
@@ -84,6 +108,31 @@ impl LeaseClient {
     /// # Errors
     ///
     /// This function will return an error if the inner RPC client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, types::lease::LeaseRevokeRequest, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let mut client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .lease_client();
+    ///
+    ///     // granted a lease id 1
+    ///
+    ///     let _resp = client.revoke(LeaseRevokeRequest::new(1)).await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn revoke(&mut self, request: LeaseRevokeRequest) -> Result<LeaseRevokeResponse> {
         let res = self.lease_client.lease_revoke(request.inner).await?;
@@ -96,6 +145,37 @@ impl LeaseClient {
     /// # Errors
     ///
     /// This function will return an error if the inner RPC client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, types::lease::LeaseKeepAliveRequest, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let mut client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .lease_client();
+    ///
+    ///     // granted a lease id 1
+    ///
+    ///     let (mut keeper, mut stream) = client.keep_alive(LeaseKeepAliveRequest::new(1)).await?;
+    ///
+    ///     if let Some(resp) = stream.message().await? {
+    ///         println!("new ttl: {}", resp.ttl);
+    ///     }
+    ///
+    ///     keeper.keep_alive()?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn keep_alive(
         &mut self,
@@ -130,6 +210,33 @@ impl LeaseClient {
     /// # Errors
     ///
     /// This function will return an error if the inner RPC client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, types::lease::LeaseTimeToLiveRequest, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let mut client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .lease_client();
+    ///
+    ///     // granted a lease id 1
+    ///
+    ///     let resp = client.time_to_live(LeaseTimeToLiveRequest::new(1)).await?;
+    ///
+    ///     println!("remaining ttl: {}", resp.ttl);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn time_to_live(
         &mut self,
@@ -147,6 +254,31 @@ impl LeaseClient {
     /// # Errors
     ///
     /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let mut client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .lease_client();
+    ///
+    ///     for lease in client.leases().await?.leases {
+    ///         println!("lease: {}", lease.id);
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn leases(&self) -> Result<LeaseLeasesResponse> {
         let propose_id = self.generate_propose_id();

--- a/xline-client/src/clients/lock.rs
+++ b/xline-client/src/clients/lock.rs
@@ -81,7 +81,42 @@ impl LockClient {
     ///
     /// # Errors
     ///
-    /// If `CurpClient` fails to send request
+    /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{
+    ///     error::Result,
+    ///     types::lock::{LockRequest, UnlockRequest},
+    ///     Client, ClientOptions,
+    /// };
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     // the name and address of all curp members
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let mut client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .lock_client();
+    ///
+    ///     // acquire a lock
+    ///     let resp = client
+    ///         .lock(LockRequest::new().with_name("lock-test"))
+    ///         .await?;
+    ///
+    ///     let key = resp.key;
+    ///
+    ///     println!("lock key: {:?}", String::from_utf8_lossy(&key));
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn lock(&self, request: LockRequest) -> Result<LockResponse> {
         let mut lease_id = request.inner.lease;
@@ -180,7 +215,37 @@ impl LockClient {
     ///
     /// # Errors
     ///
-    /// If `CurpClient` fails to send request
+    /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{
+    ///     error::Result,
+    ///     types::lock::{LockRequest, UnlockRequest},
+    ///     Client, ClientOptions,
+    /// };
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     // the name and address of all curp members
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let mut client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .lock_client();
+    ///
+    ///     // acquire a lock first
+    ///
+    ///     client.unlock(UnlockRequest::new().with_key("lock_key")).await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn unlock(&self, request: UnlockRequest) -> Result<UnlockResponse> {
         let header = self.delete_key(&request.inner.key).await?;

--- a/xline-client/src/clients/maintenance.rs
+++ b/xline-client/src/clients/maintenance.rs
@@ -33,6 +33,41 @@ impl MaintenanceClient {
     /// # Errors
     ///
     /// This function will return an error if the inner RPC client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{error::Result, Client, ClientOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     // the name and address of all curp members
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let mut client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .maintenance_client();
+    ///
+    ///     // snapshot
+    ///     let mut msg = client.snapshot().await?;
+    ///     let mut snapshot = vec![];
+    ///     loop {
+    ///         if let Some(resp) = msg.message().await? {
+    ///             snapshot.extend_from_slice(&resp.blob);
+    ///             if resp.remaining_bytes == 0 {
+    ///                 break;
+    ///             }
+    ///         }
+    ///     }
+    ///     println!("snapshot size: {}", snapshot.len());
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn snapshot(&mut self) -> Result<Streaming<SnapshotResponse>> {
         Ok(self

--- a/xline-client/src/clients/watch.rs
+++ b/xline-client/src/clients/watch.rs
@@ -45,6 +45,46 @@ impl WatchClient {
     /// # Panics
     ///
     /// This function will panic if the RPC server doesn't return a create watch response
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use xline_client::{
+    ///     error::Result,
+    ///     types::{kv::PutRequest, watch::WatchRequest},
+    ///     Client, ClientOptions,
+    /// };
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default()).await?;
+    ///     let mut watch_client = client.watch_client();
+    ///     let mut kv_client = client.kv_client();
+    ///
+    ///     let (mut watcher, mut stream) = watch_client.watch(WatchRequest::new("key1")).await?;
+    ///     kv_client.put(PutRequest::new("key1", "value1")).await?;
+    ///
+    ///     let resp = stream.message().await?.unwrap();
+    ///     let kv = resp.events[0].kv.as_ref().unwrap();
+    ///
+    ///     println!(
+    ///         "got key: {}, value: {}",
+    ///         String::from_utf8_lossy(&kv.key),
+    ///         String::from_utf8_lossy(&kv.value)
+    ///     );
+    ///
+    ///     // cancel the watch
+    ///     watcher.cancel()?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn watch(
         &mut self,

--- a/xline-client/src/lib.rs
+++ b/xline-client/src/lib.rs
@@ -380,6 +380,26 @@ impl ClientOptions {
     pub fn curp_timeout(&self) -> ClientTimeout {
         self.curp_timeout
     }
+
+    /// Set `user`
+    #[inline]
+    #[must_use]
+    pub fn with_user(self, name: impl Into<String>, password: impl Into<String>) -> Self {
+        Self {
+            user: Some((name.into(), password.into())),
+            curp_timeout: self.curp_timeout,
+        }
+    }
+
+    /// Set `curp_timeout`
+    #[inline]
+    #[must_use]
+    pub fn with_curp_timeout(self, curp_timeout: ClientTimeout) -> Self {
+        Self {
+            user: self.user,
+            curp_timeout,
+        }
+    }
 }
 
 /// Authentication service.


### PR DESCRIPTION
This PR is based on #373 

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    descibed in `Add examples to the crate` section in #369 

* what changes does this pull request make?

   Add use examples to xline client

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)