### PR TITLE
Feature/member add single

### DIFF
--- a/curp/src/log_entry.rs
+++ b/curp/src/log_entry.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use curp_external_api::LogIndex;
+use curp_external_api::{
+    cmd::{Command, ProposeId},
+    LogIndex,
+};
 use serde::{Deserialize, Serialize};
 
 /// Log entry
@@ -10,13 +13,47 @@ pub(crate) struct LogEntry<C> {
     pub(crate) term: u64,
     /// Index
     pub(crate) index: LogIndex,
-    /// The Command
-    pub(crate) cmd: Arc<C>,
+    /// Entry data
+    pub(crate) entry_data: EntryData<C>,
 }
 
-impl<C> LogEntry<C> {
-    /// Create a new `LogEntry`
-    pub(super) fn new(index: LogIndex, term: u64, cmd: Arc<C>) -> Self {
-        Self { term, index, cmd }
+/// Entry data of a `LogEntry`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) enum EntryData<C> {
+    /// `Command` entry
+    Command(Arc<C>),
+    /// `ConfChange` entry
+    ConfChange(ProposeId),
+}
+
+impl<C> LogEntry<C>
+where
+    C: Command,
+{
+    /// Create a new `LogEntry` of a `Command`
+    pub(super) fn new_cmd(index: LogIndex, term: u64, cmd: Arc<C>) -> Self {
+        Self {
+            term,
+            index,
+            entry_data: EntryData::Command(cmd),
+        }
+    }
+
+    /// Create a new `LogEntry` of a `ConfChange`
+    #[allow(dead_code)] // TODO: remove this when we implement conf change
+    pub(super) fn new_conf_change(index: LogIndex, term: u64, id: ProposeId) -> Self {
+        Self {
+            term,
+            index,
+            entry_data: EntryData::ConfChange(id),
+        }
+    }
+
+    /// Get the id of the entry
+    pub(super) fn id(&self) -> &ProposeId {
+        match self.entry_data {
+            EntryData::Command(ref cmd) => cmd.id(),
+            EntryData::ConfChange(ref id) => id,
+        }
     }
 }

--- a/curp/src/rpc/mod.rs
+++ b/curp/src/rpc/mod.rs
@@ -231,7 +231,7 @@ impl AppendEntriesRequest {
         leader_id: ServerId,
         prev_log_index: LogIndex,
         prev_log_term: u64,
-        entries: Vec<LogEntry<C>>,
+        entries: Vec<Arc<LogEntry<C>>>,
         leader_commit: LogIndex,
     ) -> bincode::Result<Self> {
         Ok(Self {

--- a/curp/src/server/raw_curp/log.rs
+++ b/curp/src/server/raw_curp/log.rs
@@ -290,7 +290,7 @@ impl<C: 'static + Command> Log<C> {
         cmd: Arc<C>,
     ) -> Result<Arc<LogEntry<C>>, bincode::Error> {
         let index = self.last_log_index() + 1;
-        let entry = Arc::new(LogEntry::new(index, term, cmd));
+        let entry = Arc::new(LogEntry::new_cmd(index, term, cmd));
 
         self.entries.push_back(Arc::clone(&entry))?;
         self.send_persist(Arc::clone(&entry));
@@ -311,7 +311,7 @@ impl<C: 'static + Command> Log<C> {
 
     /// Get existing cmd ids
     pub(super) fn get_cmd_ids(&self) -> HashSet<&ProposeId> {
-        self.entries.iter().map(|entry| entry.cmd.id()).collect()
+        self.entries.iter().map(|entry| entry.id()).collect()
     }
 
     /// Get previous log entry's term and index
@@ -403,8 +403,8 @@ mod tests {
             Log::<TestCommand>::new(log_tx, default_batch_max_size(), default_log_entries_cap());
         let result = log.try_append_entries(
             vec![
-                LogEntry::new(1, 1, Arc::new(TestCommand::default())),
-                LogEntry::new(2, 1, Arc::new(TestCommand::default())),
+                LogEntry::new_cmd(1, 1, Arc::new(TestCommand::default())),
+                LogEntry::new_cmd(2, 1, Arc::new(TestCommand::default())),
             ],
             0,
             0,
@@ -425,9 +425,9 @@ mod tests {
             Log::<TestCommand>::new(log_tx, default_batch_max_size(), default_log_entries_cap());
         let result = log.try_append_entries(
             vec![
-                LogEntry::new(1, 1, Arc::new(TestCommand::default())),
-                LogEntry::new(2, 1, Arc::new(TestCommand::default())),
-                LogEntry::new(3, 1, Arc::new(TestCommand::default())),
+                LogEntry::new_cmd(1, 1, Arc::new(TestCommand::default())),
+                LogEntry::new_cmd(2, 1, Arc::new(TestCommand::default())),
+                LogEntry::new_cmd(3, 1, Arc::new(TestCommand::default())),
             ],
             0,
             0,
@@ -436,8 +436,8 @@ mod tests {
 
         let result = log.try_append_entries(
             vec![
-                LogEntry::new(2, 2, Arc::new(TestCommand::default())),
-                LogEntry::new(3, 2, Arc::new(TestCommand::default())),
+                LogEntry::new_cmd(2, 2, Arc::new(TestCommand::default())),
+                LogEntry::new_cmd(3, 2, Arc::new(TestCommand::default())),
             ],
             1,
             1,
@@ -453,7 +453,7 @@ mod tests {
         let mut log =
             Log::<TestCommand>::new(log_tx, default_batch_max_size(), default_log_entries_cap());
         let result = log.try_append_entries(
-            vec![LogEntry::new(1, 1, Arc::new(TestCommand::default()))],
+            vec![LogEntry::new_cmd(1, 1, Arc::new(TestCommand::default()))],
             0,
             0,
         );
@@ -461,8 +461,8 @@ mod tests {
 
         let result = log.try_append_entries(
             vec![
-                LogEntry::new(4, 2, Arc::new(TestCommand::default())),
-                LogEntry::new(5, 2, Arc::new(TestCommand::default())),
+                LogEntry::new_cmd(4, 2, Arc::new(TestCommand::default())),
+                LogEntry::new_cmd(5, 2, Arc::new(TestCommand::default())),
             ],
             3,
             1,
@@ -471,8 +471,8 @@ mod tests {
 
         let result = log.try_append_entries(
             vec![
-                LogEntry::new(2, 2, Arc::new(TestCommand::default())),
-                LogEntry::new(3, 2, Arc::new(TestCommand::default())),
+                LogEntry::new_cmd(2, 2, Arc::new(TestCommand::default())),
+                LogEntry::new_cmd(3, 2, Arc::new(TestCommand::default())),
             ],
             1,
             2,
@@ -566,7 +566,7 @@ mod tests {
         let entries = repeat(Arc::clone(&test_cmd))
             .enumerate()
             .take(10)
-            .map(|(idx, cmd)| LogEntry::new((idx + 1).numeric_cast(), 1, cmd))
+            .map(|(idx, cmd)| LogEntry::new_cmd((idx + 1).numeric_cast(), 1, cmd))
             .collect::<Vec<LogEntry<TestCommand>>>();
         let (tx, _rx) = mpsc::unbounded_channel();
         let mut log =

--- a/curp/src/server/raw_curp/mod.rs
+++ b/curp/src/server/raw_curp/mod.rs
@@ -111,7 +111,7 @@ pub(super) struct AppendEntries<C> {
     /// Leader's commit index
     pub(super) leader_commit: LogIndex,
     /// New entries to be appended to the follower
-    pub(super) entries: Vec<LogEntry<C>>,
+    pub(super) entries: Vec<Arc<LogEntry<C>>>,
 }
 
 /// Curp Role
@@ -590,7 +590,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> RawCurp<C, RC> {
         cfg: Arc<CurpConfig>,
         cmd_tx: Arc<dyn CEEventTxApi<C>>,
         sync_events: HashMap<ServerId, Arc<Event>>,
-        log_tx: mpsc::UnboundedSender<LogEntry<C>>,
+        log_tx: mpsc::UnboundedSender<Arc<LogEntry<C>>>,
         role_change: RC,
     ) -> Self {
         let raw_curp = Self {
@@ -638,7 +638,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> RawCurp<C, RC> {
         cfg: &Arc<CurpConfig>,
         cmd_tx: Arc<dyn CEEventTxApi<C>>,
         sync_event: HashMap<ServerId, Arc<Event>>,
-        log_tx: mpsc::UnboundedSender<LogEntry<C>>,
+        log_tx: mpsc::UnboundedSender<Arc<LogEntry<C>>>,
         voted_for: Option<(u64, ServerId)>,
         entries: Vec<LogEntry<C>>,
         last_applied: LogIndex,

--- a/curp/src/server/raw_curp/tests.rs
+++ b/curp/src/server/raw_curp/tests.rs
@@ -294,7 +294,7 @@ fn handle_ae_will_reject_wrong_log() {
         "S2".to_owned(),
         1,
         1,
-        vec![LogEntry::new(2, 1, Arc::new(TestCommand::default()))],
+        vec![LogEntry::new_cmd(2, 1, Arc::new(TestCommand::default()))],
         0,
     );
     assert_eq!(result, Err((1, 1)));
@@ -426,7 +426,7 @@ fn handle_vote_will_reject_outdated_candidate() {
         "S2".to_owned(),
         0,
         0,
-        vec![LogEntry::new(1, 1, Arc::new(TestCommand::default()))],
+        vec![LogEntry::new_cmd(1, 1, Arc::new(TestCommand::default()))],
         0,
     );
     assert!(result.is_ok());
@@ -522,8 +522,8 @@ fn recover_from_spec_pools_will_pick_the_correct_cmds() {
     curp.recover_from_spec_pools(&mut *curp.st.write(), &mut *curp.log.write(), spec_pools);
 
     curp.log.map_read(|log_r| {
-        assert_eq!(log_r[1].cmd.id(), cmd0.id());
-        assert_eq!(log_r[2].cmd.id(), cmd1.id());
+        assert_eq!(log_r[1].id(), cmd0.id());
+        assert_eq!(log_r[2].id(), cmd1.id());
         assert_eq!(log_r.last_log_index(), 2);
     });
 }

--- a/curp/src/server/raw_curp/tests.rs
+++ b/curp/src/server/raw_curp/tests.rs
@@ -68,7 +68,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> RawCurp<C, RC> {
     pub(crate) fn push_cmd(&self, cmd: Arc<C>) -> LogIndex {
         let st_r = self.st.read();
         let mut log_w = self.log.write();
-        log_w.push_cmd(st_r.term, cmd).unwrap()
+        log_w.push_cmd(st_r.term, cmd).unwrap().index
     }
 }
 
@@ -78,7 +78,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> RawCurp<C, RC> {
 fn leader_handle_propose_will_succeed() {
     let curp = {
         let mut exe_tx = MockCEEventTxApi::<TestCommand>::default();
-        exe_tx.expect_send_sp_exe().returning(|_, _| {});
+        exe_tx.expect_send_sp_exe().returning(|_| {});
         RawCurp::new_test(3, exe_tx, mock_role_change())
     };
     let cmd = Arc::new(TestCommand::default());
@@ -93,7 +93,7 @@ fn leader_handle_propose_will_succeed() {
 fn leader_handle_propose_will_reject_conflicted() {
     let curp = {
         let mut exe_tx = MockCEEventTxApi::<TestCommand>::default();
-        exe_tx.expect_send_sp_exe().returning(|_, _| {});
+        exe_tx.expect_send_sp_exe().returning(|_| {});
         RawCurp::new_test(3, exe_tx, mock_role_change())
     };
 
@@ -122,7 +122,7 @@ fn leader_handle_propose_will_reject_conflicted() {
 fn leader_handle_propose_will_reject_duplicated() {
     let curp = {
         let mut exe_tx = MockCEEventTxApi::<TestCommand>::default();
-        exe_tx.expect_send_sp_exe().returning(|_, _| {});
+        exe_tx.expect_send_sp_exe().returning(|_| {});
         RawCurp::new_test(3, exe_tx, mock_role_change())
     };
     let cmd = Arc::new(TestCommand::default());
@@ -558,7 +558,7 @@ fn leader_retires_after_log_compact_will_succeed() {
 fn leader_retires_should_cleanup() {
     let curp = {
         let mut exe_tx = MockCEEventTxApi::<TestCommand>::default();
-        exe_tx.expect_send_sp_exe().returning(|_, _| {});
+        exe_tx.expect_send_sp_exe().returning(|_| {});
         RawCurp::new_test(3, exe_tx, mock_role_change())
     };
 

--- a/curp/src/server/storage/db.rs
+++ b/curp/src/server/storage/db.rs
@@ -107,9 +107,9 @@ mod tests {
             let s = DB::<TestCommand>::open(&storage_cfg)?;
             s.flush_voted_for(1, "S2".to_string()).await?;
             s.flush_voted_for(3, "S1".to_string()).await?;
-            let entry0 = LogEntry::new(1, 3, Arc::new(TestCommand::default()));
-            let entry1 = LogEntry::new(2, 3, Arc::new(TestCommand::default()));
-            let entry2 = LogEntry::new(3, 3, Arc::new(TestCommand::default()));
+            let entry0 = LogEntry::new_cmd(1, 3, Arc::new(TestCommand::default()));
+            let entry1 = LogEntry::new_cmd(2, 3, Arc::new(TestCommand::default()));
+            let entry2 = LogEntry::new_cmd(3, 3, Arc::new(TestCommand::default()));
             s.put_log_entry(&entry0).await?;
             s.put_log_entry(&entry1).await?;
             s.put_log_entry(&entry2).await?;

--- a/curp/src/server/storage/db.rs
+++ b/curp/src/server/storage/db.rs
@@ -34,8 +34,8 @@ impl<C: 'static + Command> StorageApi for DB<C> {
         Ok(())
     }
 
-    async fn put_log_entry(&self, entry: LogEntry<Self::Command>) -> Result<(), StorageError> {
-        let bytes = bincode::serialize(&entry)?;
+    async fn put_log_entry(&self, entry: &LogEntry<Self::Command>) -> Result<(), StorageError> {
+        let bytes = bincode::serialize(entry)?;
         let op = WriteOperation::new_put(CF, entry.index.to_be_bytes().to_vec(), bytes);
         self.db.write_batch(vec![op], false)?;
 
@@ -110,9 +110,9 @@ mod tests {
             let entry0 = LogEntry::new(1, 3, Arc::new(TestCommand::default()));
             let entry1 = LogEntry::new(2, 3, Arc::new(TestCommand::default()));
             let entry2 = LogEntry::new(3, 3, Arc::new(TestCommand::default()));
-            s.put_log_entry(entry0).await?;
-            s.put_log_entry(entry1).await?;
-            s.put_log_entry(entry2).await?;
+            s.put_log_entry(&entry0).await?;
+            s.put_log_entry(&entry1).await?;
+            s.put_log_entry(&entry2).await?;
             sleep_secs(2).await;
         }
 

--- a/curp/src/server/storage/mod.rs
+++ b/curp/src/server/storage/mod.rs
@@ -25,7 +25,7 @@ pub(super) trait StorageApi: Send + Sync {
     async fn flush_voted_for(&self, term: u64, voted_for: ServerId) -> Result<(), StorageError>;
 
     /// Put log entries in storage
-    async fn put_log_entry(&self, entry: LogEntry<Self::Command>) -> Result<(), StorageError>;
+    async fn put_log_entry(&self, entry: &LogEntry<Self::Command>) -> Result<(), StorageError>;
 
     /// Recover from persisted storage
     /// Return `voted_for` and all log entries


### PR DESCRIPTION
Please briefly answer these questions:
First PR of #306 
* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
make curp manage content other than Command.
* what changes does this pull request make?
use `Arc` to share `LogEntry`, let conflict checked mpmc channel process `LogEntry` instead of `Command`
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no