### PR TITLE
fix: try fix CurpGroup

### DIFF
--- a/curp/tests/common/curp_group.rs
+++ b/curp/tests/common/curp_group.rs
@@ -40,7 +40,7 @@ pub struct CurpNode {
     pub exe_rx: mpsc::UnboundedReceiver<(TestCommand, TestCommandResult)>,
     pub as_rx: mpsc::UnboundedReceiver<(TestCommand, LogIndex)>,
     pub store: Arc<Engine>,
-    pub rt: Runtime,
+    pub rt: Option<Runtime>,
     pub storage_path: PathBuf,
     pub role_change_arc: Arc<TestRoleChangeInner>,
 }
@@ -85,28 +85,26 @@ impl CurpGroup {
                     .enable_all()
                     .build()
                     .unwrap();
-                let handle = rt.handle().clone();
 
                 let storage_path_c = storage_path.clone();
                 let role_change_cb = TestRoleChange::default();
                 let role_change_arc = role_change_cb.get_inner_arc();
-                thread::spawn(move || {
-                    handle.spawn(Rpc::run_from_listener(
-                        cluster_info,
-                        i == 0,
-                        listener,
-                        ce,
-                        Box::new(MemorySnapshotAllocator),
-                        role_change_cb,
-                        Arc::new(
-                            CurpConfigBuilder::default()
-                                .data_dir(storage_path_c)
-                                .log_entries_cap(10)
-                                .build()
-                                .unwrap(),
-                        ),
-                    ));
-                });
+
+                rt.spawn(Rpc::run_from_listener(
+                    cluster_info,
+                    i == 0,
+                    listener,
+                    ce,
+                    Box::new(MemorySnapshotAllocator),
+                    role_change_cb,
+                    Arc::new(
+                        CurpConfigBuilder::default()
+                            .data_dir(storage_path_c)
+                            .log_entries_cap(10)
+                            .build()
+                            .unwrap(),
+                    ),
+                ));
 
                 (
                     id.clone(),
@@ -116,7 +114,7 @@ impl CurpGroup {
                         exe_rx,
                         as_rx,
                         store,
-                        rt,
+                        rt: Some(rt),
                         storage_path,
                         role_change_arc,
                     },
@@ -155,11 +153,15 @@ impl CurpGroup {
             .values()
             .map(|node| node.storage_path.clone())
             .collect_vec();
-        thread::spawn(move || {
-            self.nodes.clear();
-        })
-        .join()
-        .unwrap();
+
+        for node in self.nodes.values_mut() {
+            if let Some(rt) = node.rt.take() {
+                rt.shutdown_background();
+            }
+        }
+
+        self.nodes.clear();
+
         for path in paths {
             std::fs::remove_dir_all(path).unwrap();
         }

--- a/curp/tests/server.rs
+++ b/curp/tests/server.rs
@@ -13,7 +13,7 @@ use crate::common::curp_group::{
 };
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[abort_on_panic]
 async fn basic_propose() {
     init_logger();
@@ -36,7 +36,7 @@ async fn basic_propose() {
     group.stop();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[abort_on_panic]
 async fn synced_propose() {
     init_logger();
@@ -65,7 +65,7 @@ async fn synced_propose() {
 }
 
 // Each command should be executed once and only once on each node
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[abort_on_panic]
 async fn exe_exact_n_times() {
     init_logger();
@@ -103,7 +103,7 @@ async fn exe_exact_n_times() {
 }
 
 // To verify PR #86 is fixed
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[abort_on_panic]
 async fn fast_round_is_slower_than_slow_round() {
     init_logger();
@@ -143,7 +143,7 @@ async fn fast_round_is_slower_than_slow_round() {
     group.stop();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[abort_on_panic]
 async fn concurrent_cmd_order() {
     init_logger();
@@ -200,7 +200,7 @@ async fn concurrent_cmd_order() {
 }
 
 /// This test case ensures that the issue 228 is fixed.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[abort_on_panic]
 async fn concurrent_cmd_order_should_have_correct_revision() {
     init_logger();


### PR DESCRIPTION
When I run `cargo test --package curp --test server -- basic_propose --exact --nocapture` on this branch, and possibly if the test passed, cargo still return an error `(signal: 11, SIGSEGV: invalid memory reference)`


```
    Finished test [unoptimized + debuginfo] target(s) in 0.10s
     Running tests/server.rs (target/debug/deps/server-05c4d04ef7eaa3c8)

running 1 test
   0.024148559s DEBUG curp::rpc::connect: successfully establish connection with http://0.0.0.0:40707
   0.024188659s DEBUG curp::rpc::connect: successfully establish connection with http://0.0.0.0:45697
   0.024239819s DEBUG curp::server::raw_curp: S0 becomes the leader
   0.024356989s DEBUG curp::rpc::connect: successfully establish connection with http://0.0.0.0:40707
   0.024406059s DEBUG curp::rpc::connect: successfully establish connection with http://0.0.0.0:43353
   0.024798039s DEBUG curp::rpc::connect: successfully establish connection with http://0.0.0.0:43353
   0.024827479s DEBUG curp::rpc::connect: successfully establish connection with http://0.0.0.0:45697
   0.024892959s DEBUG curp::server::curp_node: S0 send ae to S1
   0.025009459s DEBUG curp::server::curp_node: S0 send ae to S2
   0.025783260s DEBUG curp_append_entries: curp::server::raw_curp: S1 received append_entries from S0: term(0), commit(0), prev_log_index(0), prev_log_term(0), 0 entries
   0.025836050s DEBUG curp_append_entries: curp::server::raw_curp: S2 received append_entries from S0: term(0), commit(0), prev_log_index(0), prev_log_term(0), 0 entries
   0.026354700s DEBUG curp::server::curp_node: S0 send ae to S1
   0.026765230s DEBUG curp::server::curp_node: S0 send ae to S2
   0.026878370s DEBUG curp_append_entries: curp::server::raw_curp: S1 received append_entries from S0: term(0), commit(0), prev_log_index(0), prev_log_term(0), 0 entries
   0.027251840s DEBUG curp_append_entries: curp::server::raw_curp: S2 received append_entries from S0: term(0), commit(0), prev_log_index(0), prev_log_term(0), 0 entries
   0.307797220s DEBUG curp::rpc::connect: successfully establish connection with http://0.0.0.0:40707
   0.307862030s DEBUG curp::rpc::connect: successfully establish connection with http://0.0.0.0:43353
   0.307873050s DEBUG curp::rpc::connect: successfully establish connection with http://0.0.0.0:45697
   0.307984340s DEBUG propose:fast_round: curp::client: fast round for cmd("1") started cmd_id="1"
   0.308368791s DEBUG propose:slow_round: curp::client: slow round for cmd("1") started cmd_id="1"
   0.309293701s DEBUG curp_propose: curp::server::raw_curp: S0 gets proposal for cmd("1")
   0.309352931s DEBUG curp_propose: curp::server::spec_pool: insert cmd("1") into spec pool
   0.309397101s DEBUG curp_propose: curp::server::raw_curp: S0 gets new log[1]
   0.309490901s DEBUG curp::server::cmd_worker::conflict_checked_mpmc: new ce event: SpecExeReady(ProposeId("1"), 1)
   0.309796881s DEBUG curp_propose: curp::server::raw_curp: S1 gets proposal for cmd("1")
   0.309934061s DEBUG curp_propose: curp::server::spec_pool: insert cmd("1") into spec pool
   0.310255371s DEBUG curp_propose: curp::server::raw_curp: S2 gets proposal for cmd("1")
   0.310359021s DEBUG curp_propose: curp::server::spec_pool: insert cmd("1") into spec pool
   0.310684351s DEBUG curp_test_utils::test_cmd: S0 execute cmd("1")
   0.310758441s DEBUG curp::server::cmd_worker: S0 cmd("1") is speculatively executed, exe status: true
   0.311332142s DEBUG propose:fast_round: curp::client: client update its leader to S0 cmd_id="1"
   0.311393482s DEBUG propose:slow_round: curp::client: wait synced request sent to S0 cmd_id="1"
   0.312218682s DEBUG curp_wait_synced: curp::server::curp_node: S0 get wait synced request for cmd("1")
   0.317456054s DEBUG curp::server::curp_node: S0 send ae to S2
   0.318576384s DEBUG curp_append_entries: curp::server::raw_curp: S2 received append_entries from S0: term(0), commit(0), prev_log_index(0), prev_log_term(0), 1 entries
   0.318923554s DEBUG curp::server::curp_node: S0 send ae to S1
   0.319303075s DEBUG curp::server::raw_curp::state: follower S2's match_index updated to 1
   0.319338525s DEBUG curp::server::raw_curp: S0 updates commit index to 1
   0.319361885s DEBUG curp::server::raw_curp: S0 committed log[1], last_applied updated to 1
   0.319395385s DEBUG curp::server::cmd_worker::conflict_checked_mpmc: new ce event: ASReady(ProposeId("1"), 1)
   0.320147265s DEBUG curp_append_entries: curp::server::raw_curp: S1 received append_entries from S0: term(0), commit(0), prev_log_index(0), prev_log_term(0), 1 entries
   0.320556095s DEBUG curp_test_utils::test_cmd: cmd Put(0)-"1" revision is 1
   0.320600435s DEBUG curp_test_utils::test_cmd: S0 after sync cmd(Put(0) - "1"), index: 1
   0.320632235s DEBUG curp::server::spec_pool: cmd("1") is removed from spec pool
   0.320645345s DEBUG curp::server::cmd_worker: S0 cmd("1") after sync is called
   0.320712875s DEBUG curp_wait_synced: curp::server::curp_node: S0 wait synced for cmd("1") finishes
   0.320979005s DEBUG curp::server::raw_curp::state: follower S1's match_index updated to 1
   0.321237285s DEBUG propose:slow_round: curp::client: slow round for cmd("1") succeeded cmd_id="1"
   0.321345595s DEBUG propose:fast_round: curp::client: fast round for cmd("2") started cmd_id="2"
   0.321619335s DEBUG propose:slow_round: curp::client: slow round for cmd("2") started cmd_id="2"
   0.321654975s DEBUG propose:slow_round: curp::client: wait synced request sent to S0 cmd_id="2"
   0.322378716s DEBUG curp_propose: curp::server::raw_curp: S2 gets proposal for cmd("2")
   0.322455846s DEBUG curp_propose: curp::server::raw_curp: S0 gets proposal for cmd("2")
   0.322500706s DEBUG curp_propose: curp::server::spec_pool: insert cmd("2") into spec pool
   0.322552636s DEBUG curp_propose: curp::server::raw_curp: S0 gets new log[2]
   0.322583266s DEBUG curp_propose: curp::server::raw_curp: S1 gets proposal for cmd("2")
   0.322665826s DEBUG curp::server::cmd_worker::conflict_checked_mpmc: new ce event: SpecExeReady(ProposeId("2"), 2)
   0.323039336s DEBUG curp_wait_synced: curp::server::curp_node: S0 get wait synced request for cmd("2")
   0.323115776s  WARN propose:fast_round: curp::client: Propose error: key conflict error cmd_id="2"
   0.323319396s  WARN propose:fast_round: curp::client: Propose error: key conflict error cmd_id="2"
   0.324187976s DEBUG curp_test_utils::test_cmd: S0 execute cmd("2")
   0.324244966s DEBUG curp::server::cmd_worker: S0 cmd("2") is speculatively executed, exe status: true
   0.325421707s DEBUG curp::server::curp_node: S0 send ae to S2
   0.325426257s DEBUG curp::server::curp_node: S0 send ae to S1
   0.326427137s DEBUG curp_append_entries: curp::server::raw_curp: S1 received append_entries from S0: term(0), commit(1), prev_log_index(1), prev_log_term(0), 1 entries
   0.326480457s DEBUG curp_append_entries: curp::server::raw_curp: S2 received append_entries from S0: term(0), commit(1), prev_log_index(1), prev_log_term(0), 1 entries
   0.326553897s DEBUG curp_append_entries: curp::server::raw_curp: S1 committed log[1], last_applied updated to 1
   0.326595987s DEBUG curp_append_entries: curp::server::raw_curp: S2 committed log[1], last_applied updated to 1
   0.326803397s DEBUG curp::server::cmd_worker::conflict_checked_mpmc: new ce event: ASReady(ProposeId("1"), 1)
   0.326804047s DEBUG curp::server::cmd_worker::conflict_checked_mpmc: new ce event: ASReady(ProposeId("1"), 1)
   0.327155377s DEBUG curp::server::raw_curp::state: follower S1's match_index updated to 2
   0.327190727s DEBUG curp::server::raw_curp: S0 updates commit index to 2
   0.327209827s DEBUG curp::server::raw_curp: S0 committed log[2], last_applied updated to 2
   0.327243347s DEBUG curp::server::cmd_worker::conflict_checked_mpmc: new ce event: ASReady(ProposeId("2"), 2)
   0.327475847s DEBUG curp::server::raw_curp::state: follower S2's match_index updated to 2
   0.328074188s DEBUG curp_test_utils::test_cmd: S2 execute cmd("1")
   0.328119218s DEBUG curp_test_utils::test_cmd: S1 execute cmd("1")
   0.328183568s DEBUG curp::server::cmd_worker: S2 cmd("1") is speculatively executed, exe status: true
   0.328240428s DEBUG curp::server::cmd_worker: S1 cmd("1") is speculatively executed, exe status: true
   0.328379298s DEBUG curp_test_utils::test_cmd: S0 after sync cmd(Get - "2"), index: 2
   0.328429408s DEBUG curp::server::spec_pool: cmd("2") is removed from spec pool
   0.328445508s DEBUG curp::server::cmd_worker: S0 cmd("2") after sync is called
   0.328520788s DEBUG curp_wait_synced: curp::server::curp_node: S0 wait synced for cmd("2") finishes
   0.329446288s DEBUG curp_test_utils::test_cmd: cmd Put(0)-"1" revision is 1
   0.329485918s DEBUG curp_test_utils::test_cmd: cmd Put(0)-"1" revision is 1
   0.329518218s DEBUG curp_test_utils::test_cmd: S2 after sync cmd(Put(0) - "1"), index: 1
   0.329549178s DEBUG curp_test_utils::test_cmd: S1 after sync cmd(Put(0) - "1"), index: 1
   0.329564608s DEBUG curp::server::spec_pool: cmd("1") is removed from spec pool
   0.329585838s DEBUG curp::server::cmd_worker: S2 cmd("1") after sync is called
   0.329594858s DEBUG curp::server::spec_pool: cmd("1") is removed from spec pool
   0.329616598s DEBUG curp::server::cmd_worker: S1 cmd("1") after sync is called
   0.366445871s DEBUG propose:slow_round: curp::client: slow round for cmd("2") succeeded cmd_id="2"
test basic_propose ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.37s

error: test failed, to rerun pass `-p curp --test server`

Caused by:
  process didn't exit successfully: `/home/guanyu/Xline/target/debug/deps/server-05c4d04ef7eaa3c8 basic_propose --exact --nocapture` (signal: 11, SIGSEGV: invalid memory reference)

```