### PR TITLE
feat: implement client compact

### DIFF
--- a/xline-client/examples/kv.rs
+++ b/xline-client/examples/kv.rs
@@ -1,0 +1,76 @@
+use xline_client::{
+    error::ClientError as Error,
+    types::kv::{
+        CompactionRequest, Compare, DeleteRangeRequest, PutRequest, RangeRequest, Txn, TxnOp,
+    },
+    Client, ClientOptions,
+};
+use xlineapi::CompareResult;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    // the name and address of all curp members
+    let curp_members = [
+        ("server0", "10.0.0.1:2379"),
+        ("server1", "10.0.0.2:2379"),
+        ("server2", "10.0.0.3:2379"),
+    ];
+
+    let client = Client::connect(curp_members, ClientOptions::default())
+        .await?
+        .kv_client();
+
+    // put
+    client.put(PutRequest::new("key1", "value1")).await?;
+    client.put(PutRequest::new("key2", "value2")).await?;
+
+    // range
+    let resp = client.range(RangeRequest::new("key1")).await?;
+
+    if let Some(kv) = resp.kvs.first() {
+        println!(
+            "got key: {}, value: {}",
+            String::from_utf8_lossy(&kv.key),
+            String::from_utf8_lossy(&kv.value)
+        );
+    }
+
+    // delete
+    let resp = client
+        .delete(DeleteRangeRequest::new("key1").with_prev_kv(true))
+        .await?;
+
+    for kv in resp.prev_kvs {
+        println!(
+            "deleted key: {}, value: {}",
+            String::from_utf8_lossy(&kv.key),
+            String::from_utf8_lossy(&kv.value)
+        );
+    }
+
+    // txn
+    let txn_req = Txn::new()
+        .when(&[Compare::value("key2", CompareResult::Equal, "value2")][..])
+        .and_then(
+            &[TxnOp::put(
+                PutRequest::new("key2", "value3").with_prev_kv(true),
+            )][..],
+        )
+        .or_else(&[TxnOp::range(RangeRequest::new("key2"))][..]);
+
+    let _resp = client.txn(txn_req).await?;
+    let resp = client.range(RangeRequest::new("key2")).await?;
+    // should print "value3"
+    if let Some(kv) = resp.kvs.first() {
+        println!(
+            "got key: {}, value: {}",
+            String::from_utf8_lossy(&kv.key),
+            String::from_utf8_lossy(&kv.value)
+        );
+    }
+
+    // compact
+    let rev = resp.header.unwrap().revision;
+    let _resp = client.compact(CompactionRequest::new(rev)).await?;
+    Ok(())
+}

--- a/xline-client/src/clients/kv.rs
+++ b/xline-client/src/clients/kv.rs
@@ -114,11 +114,42 @@ impl KvClient {
         Ok(res_wrapper.into())
     }
 
-    /// Send `CompactionRequest` by `CurpClient`
+    /// Compacts the key-value store up to a given revision. All superseded keys
+    /// with a revision less than the compaction revision will be removed.
     ///
     /// # Errors
     ///
-    /// If `CurpClient` failed to send request
+    /// This function will return an error if the inner CURP client encountered a propose failure
+    ///
+    /// # Examples
+    ///
+    ///```no_run
+    /// use xline_client::{
+    ///     error::Result,
+    ///     types::kv::{CompactionRequest, PutRequest},
+    ///     Client, ClientOptions,
+    /// };
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let curp_members = [
+    ///         ("server0", "10.0.0.1:2379"),
+    ///         ("server1", "10.0.0.2:2379"),
+    ///         ("server2", "10.0.0.3:2379"),
+    ///     ];
+    ///
+    ///     let client = Client::connect(curp_members, ClientOptions::default())
+    ///         .await?
+    ///         .kv_client();
+    ///
+    ///     let resp_put = client.put(PutRequest::new("key", "val")).await?;
+    ///     let rev = resp_put.header.unwrap().revision;
+    ///
+    ///     let _resp = client.compact(CompactionRequest::new(rev)).await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     pub async fn compact(&self, request: CompactionRequest) -> Result<CompactionResponse> {
         let use_fast_path = request.physical();

--- a/xline-client/src/clients/kv.rs
+++ b/xline-client/src/clients/kv.rs
@@ -114,8 +114,12 @@ impl KvClient {
         Ok(res_wrapper.into())
     }
 
-    /// Compacts the key-value store up to a given revision. All superseded keys
-    /// with a revision less than the compaction revision will be removed.
+    /// Compacts the key-value store up to a given revision.
+    /// All keys with revisions less than the given revision will be compacted.
+    /// The compaction process will remove all historical versions of these keys, except for the most recent one.  
+    /// For example, here is a revision list: [(A, 1), (A, 2), (A, 3), (A, 4), (A, 5)].
+    /// We compact at revision 3. After the compaction, the revision list will become [(A, 3), (A, 4), (A, 5)].
+    /// All revisions less than 3 are deleted. The latest revision, 3, will be kept.
     ///
     /// # Errors
     ///

--- a/xline-client/src/types/kv.rs
+++ b/xline-client/src/types/kv.rs
@@ -674,3 +674,51 @@ impl From<Txn> for xlineapi::TxnRequest {
         txn.req
     }
 }
+
+/// Compaction Request compacts the key-value store up to a given revision.
+/// All superseded keys with a revision less than the compaction revision will be removed.
+#[derive(Debug)]
+pub struct CompactionRequest {
+    /// The inner request
+    inner: xlineapi::CompactionRequest,
+}
+
+impl CompactionRequest {
+    /// Creates a new `CompactionRequest`
+    ///
+    /// `Revision` is the key-value store revision for the compaction operation.
+    #[inline]
+    #[must_use]
+    pub fn new(revision: i64) -> Self {
+        Self {
+            inner: xlineapi::CompactionRequest {
+                revision,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Physical is set so the RPC will wait until the compaction is physically
+    /// applied to the local database such that compacted entries are totally
+    /// removed from the backend database.
+    #[inline]
+    #[must_use]
+    pub fn with_physical(mut self) -> Self {
+        self.inner.physical = true;
+        self
+    }
+
+    /// Get `physical`
+    #[inline]
+    #[must_use]
+    pub fn physical(&self) -> bool {
+        self.inner.physical
+    }
+}
+
+impl From<CompactionRequest> for xlineapi::CompactionRequest {
+    #[inline]
+    fn from(req: CompactionRequest) -> Self {
+        req.inner
+    }
+}

--- a/xline-client/src/types/kv.rs
+++ b/xline-client/src/types/kv.rs
@@ -676,7 +676,11 @@ impl From<Txn> for xlineapi::TxnRequest {
 }
 
 /// Compaction Request compacts the key-value store up to a given revision.
-/// All superseded keys with a revision less than the compaction revision will be removed.
+/// All keys with revisions less than the given revision will be compacted.
+/// The compaction process will remove all historical versions of these keys, except for the most recent one.  
+/// For example, here is a revision list: [(A, 1), (A, 2), (A, 3), (A, 4), (A, 5)].
+/// We compact at revision 3. After the compaction, the revision list will become [(A, 3), (A, 4), (A, 5)].
+/// All revisions less than 3 are deleted. The latest revision, 3, will be kept.
 #[derive(Debug)]
 pub struct CompactionRequest {
     /// The inner request


### PR DESCRIPTION
based on: #311

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    The compact method in `xline-client` can be implement after #311

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)