### PR TITLE
refactor: request validation check

### DIFF
--- a/xline-client/tests/kv.rs
+++ b/xline-client/tests/kv.rs
@@ -254,16 +254,13 @@ async fn compact_should_remove_previous_revision() -> Result<()> {
         .await?;
     assert_eq!(rev1_resp.kvs[0].value, b"1");
 
-    client.compact(CompactionRequest::new(4)).await?;
+    client.compact(CompactionRequest::new(3)).await?;
 
     // after compacting
     let rev0_resp = client
         .range(RangeRequest::new("compact").with_revision(2))
-        .await?;
-    assert!(
-        rev0_resp.kvs.is_empty(),
-        "kvs should be empty after compaction"
-    );
+        .await;
+    assert!(rev0_resp.is_err(), "should be err after compaction");
     let rev1_resp = client
         .range(RangeRequest::new("compact").with_revision(3))
         .await?;

--- a/xline-client/tests/kv.rs
+++ b/xline-client/tests/kv.rs
@@ -260,7 +260,10 @@ async fn compact_should_remove_previous_revision() -> Result<()> {
     let rev0_resp = client
         .range(RangeRequest::new("compact").with_revision(2))
         .await;
-    assert!(rev0_resp.is_err(), "should be err after compaction");
+    assert!(
+        rev0_resp.is_err(),
+        "client.range should receive an err after compaction, but it receives: {rev0_resp:?}"
+    );
     let rev1_resp = client
         .range(RangeRequest::new("compact").with_revision(3))
         .await?;

--- a/xline/src/lib.rs
+++ b/xline/src/lib.rs
@@ -161,6 +161,8 @@ mod revision_number;
 mod rpc {
     pub use xlineapi::*;
 }
+/// Request validation module
+mod request_validation;
 /// Xline server
 pub mod server;
 /// State of current node

--- a/xline/src/lib.rs
+++ b/xline/src/lib.rs
@@ -163,6 +163,8 @@ mod rpc {
 }
 /// Request validation module
 mod request_validation;
+/// Revision check
+mod revision_check;
 /// Xline server
 pub mod server;
 /// State of current node

--- a/xline/src/request_validation.rs
+++ b/xline/src/request_validation.rs
@@ -153,7 +153,7 @@ pub(crate) fn check_range_compacted(
     range_revision: i64,
     compacted_revision: i64,
 ) -> Result<(), ValidationError> {
-    (range_revision >= compacted_revision)
+    (range_revision >= compacted_revision || range_revision <= 0)
             .then_some(())
             .ok_or(ValidationError::new(format!(
                 "required revision {range_revision} has been compacted, compacted revision is {compacted_revision}"

--- a/xline/src/request_validation.rs
+++ b/xline/src/request_validation.rs
@@ -1,0 +1,247 @@
+use std::collections::HashSet;
+
+use thiserror::Error;
+
+use crate::{
+    rpc::{
+        CompactionRequest, DeleteRangeRequest, PutRequest, RangeRequest, Request, RequestOp,
+        SortOrder, SortTarget, TxnRequest,
+    },
+    server::KeyRange,
+    storage::ExecuteError,
+};
+
+/// Default max txn ops
+const DEFAULT_MAX_TXN_OPS: usize = 128;
+
+/// Trait for request validation
+pub(crate) trait RequestValidator {
+    /// Extra arguments to in validating the request
+    type Args;
+
+    /// Validate the request
+    fn validation(&self, args: Self::Args) -> Result<(), ValidationError>;
+}
+
+impl RequestValidator for RangeRequest {
+    type Args = (i64, i64);
+
+    fn validation(
+        &self,
+        (compacted_revision, current_revision): (i64, i64),
+    ) -> Result<(), ValidationError> {
+        if self.key.is_empty() {
+            return Err(ValidationError::new("key is not provided"));
+        }
+        if !SortOrder::is_valid(self.sort_order) || !SortTarget::is_valid(self.sort_target) {
+            return Err(ValidationError::new("invalid sort option"));
+        }
+        if self.revision > current_revision {
+            Err(ValidationError::new(format!(
+                "required revision {} is higher than current revision {}",
+                self.revision, current_revision
+            )))
+        } else {
+            check_range_compacted(self.revision, compacted_revision)
+        }
+    }
+}
+
+impl RequestValidator for CompactionRequest {
+    type Args = (i64, i64);
+
+    fn validation(
+        &self,
+        (compacted_revision, current_revision): (i64, i64),
+    ) -> Result<(), ValidationError> {
+        debug_assert!(
+            compacted_revision <= current_revision,
+            "compacted revision should not larger than current revision"
+        );
+        if self.revision <= compacted_revision {
+            Err(ValidationError::new(format!(
+                "required revision {} has been compacted, compacted revision is {}",
+                self.revision, compacted_revision
+            )))
+        } else if self.revision > current_revision {
+            Err(ValidationError::new(format!(
+                "required revision {} is higher than current revision {}",
+                self.revision, current_revision
+            )))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl RequestValidator for PutRequest {
+    type Args = ();
+
+    fn validation(&self, _args: ()) -> Result<(), ValidationError> {
+        if self.key.is_empty() {
+            return Err(ValidationError::new("key is not provided"));
+        }
+        if self.ignore_value && !self.value.is_empty() {
+            return Err(ValidationError::new("value is provided"));
+        }
+        if self.ignore_lease && self.lease != 0 {
+            return Err(ValidationError::new("lease is provided"));
+        }
+
+        Ok(())
+    }
+}
+
+impl RequestValidator for DeleteRangeRequest {
+    type Args = ();
+
+    fn validation(&self, _args: ()) -> Result<(), ValidationError> {
+        if self.key.is_empty() {
+            return Err(ValidationError::new("key is not provided"));
+        }
+
+        Ok(())
+    }
+}
+
+impl RequestValidator for TxnRequest {
+    type Args = (i64, i64);
+
+    fn validation(
+        &self,
+        (compacted_revision, current_revision): (i64, i64),
+    ) -> Result<(), ValidationError> {
+        let opc = self
+            .compare
+            .len()
+            .max(self.success.len())
+            .max(self.failure.len());
+        if opc > DEFAULT_MAX_TXN_OPS {
+            return Err(ValidationError::new("too many operations in txn selfuest"));
+        }
+        for c in &self.compare {
+            if c.key.is_empty() {
+                return Err(ValidationError::new("key is not provided"));
+            }
+        }
+        for op in self.success.iter().chain(self.failure.iter()) {
+            if let Some(ref request) = op.request {
+                match *request {
+                    Request::RequestRange(ref r) => {
+                        r.validation((compacted_revision, current_revision))
+                    }
+                    Request::RequestPut(ref r) => r.validation(()),
+                    Request::RequestDeleteRange(ref r) => r.validation(()),
+                    Request::RequestTxn(ref r) => {
+                        r.validation((compacted_revision, current_revision))
+                    }
+                }?;
+            } else {
+                return Err(ValidationError::new("key not found"));
+            }
+        }
+
+        let _ignore_success = check_intervals(&self.success)?;
+        let _ignore_failure = check_intervals(&self.failure)?;
+
+        Ok(())
+    }
+}
+
+/// check whether the required revision is compacted or not
+pub(crate) fn check_range_compacted(
+    range_revision: i64,
+    compacted_revision: i64,
+) -> Result<(), ValidationError> {
+    (range_revision >= compacted_revision)
+            .then_some(())
+            .ok_or(ValidationError::new(format!(
+                "required revision {range_revision} has been compacted, compacted revision is {compacted_revision}"
+            )))
+}
+
+/// Check if puts and deletes overlap
+fn check_intervals(ops: &[RequestOp]) -> Result<(HashSet<&[u8]>, Vec<KeyRange>), ValidationError> {
+    // TODO: use interval tree is better?
+
+    let mut dels = Vec::new();
+
+    for op in ops {
+        if let Some(Request::RequestDeleteRange(ref req)) = op.request {
+            // collect dels
+            let del = KeyRange::new(req.key.as_slice(), req.range_end.as_slice());
+            dels.push(del);
+        }
+    }
+
+    let mut puts: HashSet<&[u8]> = HashSet::new();
+
+    for op in ops {
+        if let Some(Request::RequestTxn(ref req)) = op.request {
+            // handle child txn request
+            let (success_puts, mut success_dels) = check_intervals(&req.success)?;
+            let (failure_puts, mut failure_dels) = check_intervals(&req.failure)?;
+
+            for k in &success_puts {
+                if !puts.insert(k) {
+                    return Err(ValidationError::new("duplicate key given in txn request"));
+                }
+                if dels.iter().any(|del| del.contains_key(k)) {
+                    return Err(ValidationError::new("duplicate key given in txn request"));
+                }
+            }
+
+            for k in failure_puts {
+                if !puts.insert(k) && !success_puts.contains(k) {
+                    // only keys in the puts and not in the success_puts is overlap
+                    return Err(ValidationError::new("duplicate key given in txn request"));
+                }
+                if dels.iter().any(|del| del.contains_key(k)) {
+                    return Err(ValidationError::new("duplicate key given in txn request"));
+                }
+            }
+
+            dels.append(&mut success_dels);
+            dels.append(&mut failure_dels);
+        }
+    }
+
+    for op in ops {
+        if let Some(Request::RequestPut(ref req)) = op.request {
+            // check puts in this level
+            if !puts.insert(&req.key) {
+                return Err(ValidationError::new("duplicate key given in txn request"));
+            }
+            if dels.iter().any(|del| del.contains_key(&req.key)) {
+                return Err(ValidationError::new("duplicate key given in txn request"));
+            }
+        }
+    }
+    Ok((puts, dels))
+}
+
+/// Error type in Validation
+#[derive(Error, Debug)]
+#[error("{0}")]
+pub struct ValidationError(String);
+
+impl ValidationError {
+    /// Creates a new `ValidationError`
+    fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl From<ValidationError> for tonic::Status {
+    #[inline]
+    fn from(err: ValidationError) -> Self {
+        tonic::Status::invalid_argument(err.0)
+    }
+}
+
+impl From<ValidationError> for ExecuteError {
+    #[inline]
+    fn from(err: ValidationError) -> Self {
+        ExecuteError::InvalidRequest(err.0)
+    }
+}

--- a/xline/src/revision_check.rs
+++ b/xline/src/revision_check.rs
@@ -1,0 +1,102 @@
+use crate::{
+    rpc::{CompactionRequest, RangeRequest, Request, TxnRequest},
+    storage::ExecuteError,
+};
+
+/// A union of requests that need revision check
+pub(crate) enum RevisionRequest<'a> {
+    /// Compaction request
+    Compaction(&'a CompactionRequest),
+    /// Range request
+    Range(&'a RangeRequest),
+    /// Txn request
+    Txn(&'a TxnRequest),
+}
+
+impl<'a> From<&'a CompactionRequest> for RevisionRequest<'a> {
+    fn from(req: &'a CompactionRequest) -> Self {
+        RevisionRequest::Compaction(req)
+    }
+}
+
+impl<'a> From<&'a RangeRequest> for RevisionRequest<'a> {
+    fn from(req: &'a RangeRequest) -> Self {
+        RevisionRequest::Range(req)
+    }
+}
+
+impl<'a> From<&'a TxnRequest> for RevisionRequest<'a> {
+    fn from(req: &'a TxnRequest) -> Self {
+        RevisionRequest::Txn(req)
+    }
+}
+
+/// Revision check
+pub(crate) trait RevisionCheck {
+    /// check if the request is valid given the compacted and current revision
+    fn check_revision(
+        self,
+        compacted_revision: i64,
+        current_revision: i64,
+    ) -> Result<(), ExecuteError>;
+}
+
+impl<'a, T> RevisionCheck for &'a T
+where
+    &'a T: Into<RevisionRequest<'a>>,
+{
+    fn check_revision(
+        self,
+        compacted_revision: i64,
+        current_revision: i64,
+    ) -> Result<(), ExecuteError> {
+        debug_assert!(
+            compacted_revision <= current_revision,
+            "compacted revision should not larger than current revision"
+        );
+        let request = self.into();
+        match request {
+            RevisionRequest::Compaction(r) => {
+                if r.revision <= compacted_revision {
+                    Err(ExecuteError::RevisionCompacted(
+                        r.revision,
+                        compacted_revision,
+                    ))
+                } else if r.revision > current_revision {
+                    Err(ExecuteError::RevisionTooLarge(r.revision, current_revision))
+                } else {
+                    Ok(())
+                }
+            }
+            RevisionRequest::Range(r) => {
+                if r.revision > current_revision {
+                    Err(ExecuteError::RevisionTooLarge(r.revision, current_revision))
+                } else {
+                    (r.revision >= compacted_revision || r.revision <= 0)
+                        .then_some(())
+                        .ok_or(ExecuteError::RevisionCompacted(
+                            r.revision,
+                            compacted_revision,
+                        ))
+                }
+            }
+            RevisionRequest::Txn(r) => {
+                for op in r.success.iter().chain(r.failure.iter()) {
+                    if let Some(ref req) = op.request {
+                        match *req {
+                            Request::RequestRange(ref req) => {
+                                req.check_revision(compacted_revision, current_revision)?;
+                            }
+                            Request::RequestTxn(ref req) => {
+                                req.check_revision(compacted_revision, current_revision)?;
+                            }
+                            Request::RequestPut(_) | Request::RequestDeleteRange(_) => (),
+                        }
+                    }
+                }
+
+                Ok(())
+            }
+        }
+    }
+}

--- a/xline/src/server/auth_server.rs
+++ b/xline/src/server/auth_server.rs
@@ -207,7 +207,7 @@ where
     ) -> Result<tonic::Response<AuthUserAddResponse>, tonic::Status> {
         debug!("Receive AuthUserAddRequest {:?}", request);
         let user_add_req = request.get_mut();
-        user_add_req.validation(())?;
+        user_add_req.validation()?;
         let hashed_password = Self::hash_password(user_add_req.password.as_bytes());
         user_add_req.hashed_password = hashed_password;
         user_add_req.password = String::new();
@@ -273,7 +273,7 @@ where
         request: tonic::Request<AuthRoleAddRequest>,
     ) -> Result<tonic::Response<AuthRoleAddResponse>, tonic::Status> {
         debug!("Receive AuthRoleAddRequest {:?}", request);
-        request.get_ref().validation(())?;
+        request.get_ref().validation()?;
         self.handle_req(request, false).await
     }
 
@@ -308,7 +308,7 @@ where
         request: tonic::Request<AuthRoleGrantPermissionRequest>,
     ) -> Result<tonic::Response<AuthRoleGrantPermissionResponse>, tonic::Status> {
         debug!("Receive AuthRoleGrantPermissionRequest {:?}", request);
-        request.get_ref().validation(())?;
+        request.get_ref().validation()?;
         self.handle_req(request, false).await
     }
 

--- a/xline/src/storage/auth_store/store.rs
+++ b/xline/src/storage/auth_store/store.rs
@@ -24,6 +24,7 @@ use super::{
 };
 use crate::{
     header_gen::HeaderGenerator,
+    request_validation::RequestValidator,
     revision_number::RevisionNumberGenerator,
     rpc::{
         AuthDisableRequest, AuthDisableResponse, AuthEnableRequest, AuthEnableResponse,
@@ -295,6 +296,7 @@ where
         req: &AuthUserAddRequest,
     ) -> Result<AuthUserAddResponse, ExecuteError> {
         debug!("handle_user_add_request");
+        req.validation(())?;
         if self.backend.get_user(&req.name).is_ok() {
             return Err(ExecuteError::UserAlreadyExists(req.name.clone()));
         }
@@ -404,6 +406,7 @@ where
         req: &AuthRoleAddRequest,
     ) -> Result<AuthRoleAddResponse, ExecuteError> {
         debug!("handle_role_add_request");
+        req.validation(())?;
         if self.backend.get_role(&req.name).is_ok() {
             return Err(ExecuteError::RoleAlreadyExists(req.name.clone()));
         }
@@ -474,6 +477,7 @@ where
         req: &AuthRoleGrantPermissionRequest,
     ) -> Result<AuthRoleGrantPermissionResponse, ExecuteError> {
         debug!("handle_role_grant_permission_request");
+        req.validation(())?;
         let _role = self.backend.get_role(&req.name)?;
         Ok(AuthRoleGrantPermissionResponse {
             header: Some(self.header_gen.gen_auth_header()),

--- a/xline/src/storage/auth_store/store.rs
+++ b/xline/src/storage/auth_store/store.rs
@@ -296,7 +296,7 @@ where
         req: &AuthUserAddRequest,
     ) -> Result<AuthUserAddResponse, ExecuteError> {
         debug!("handle_user_add_request");
-        req.validation(())?;
+        req.validation()?;
         if self.backend.get_user(&req.name).is_ok() {
             return Err(ExecuteError::UserAlreadyExists(req.name.clone()));
         }
@@ -406,7 +406,7 @@ where
         req: &AuthRoleAddRequest,
     ) -> Result<AuthRoleAddResponse, ExecuteError> {
         debug!("handle_role_add_request");
-        req.validation(())?;
+        req.validation()?;
         if self.backend.get_role(&req.name).is_ok() {
             return Err(ExecuteError::RoleAlreadyExists(req.name.clone()));
         }
@@ -477,7 +477,7 @@ where
         req: &AuthRoleGrantPermissionRequest,
     ) -> Result<AuthRoleGrantPermissionResponse, ExecuteError> {
         debug!("handle_role_grant_permission_request");
-        req.validation(())?;
+        req.validation()?;
         let _role = self.backend.get_role(&req.name)?;
         Ok(AuthRoleGrantPermissionResponse {
             header: Some(self.header_gen.gen_auth_header()),

--- a/xline/src/storage/execute_error.rs
+++ b/xline/src/storage/execute_error.rs
@@ -12,6 +12,12 @@ pub enum ExecuteError {
     /// Key not found
     #[error("key not found")]
     KeyNotFound,
+    /// Revision is higher than current
+    #[error("required revision {0} is higher than current revision {1}")]
+    RevisionTooLarge(i64, i64),
+    /// Revision compacted
+    #[error("required revision {0} has been compacted, compacted revision is {1}")]
+    RevisionCompacted(i64, i64),
 
     /// Lease not found
     #[error("lease {0} not found")]
@@ -113,7 +119,9 @@ impl From<ExecuteError> for tonic::Status {
             | ExecuteError::RootRoleNotExist
             | ExecuteError::PermissionNotGranted
             | ExecuteError::TokenManagerNotInit => tonic::Code::FailedPrecondition,
-            ExecuteError::LeaseTtlTooLarge(_) => tonic::Code::OutOfRange,
+            ExecuteError::LeaseTtlTooLarge(_)
+            | ExecuteError::RevisionTooLarge(_, _)
+            | ExecuteError::RevisionCompacted(_, _) => tonic::Code::OutOfRange,
             ExecuteError::DbError(_) => tonic::Code::Internal,
             ExecuteError::InvalidAuthToken | ExecuteError::TokenOldRevision(_, _) => {
                 tonic::Code::Unauthenticated

--- a/xline/src/storage/kv_store.rs
+++ b/xline/src/storage/kv_store.rs
@@ -497,7 +497,7 @@ where
 
     /// Handle `RangeRequest`
     fn handle_range_request(&self, req: &RangeRequest) -> Result<RangeResponse, ExecuteError> {
-        req.validation((self.compacted_revision(), self.revision()))?;
+        req.validation()?;
 
         let storage_fetch_limit = if (req.sort_order() != SortOrder::None)
             || (req.max_mod_revision != 0)
@@ -548,7 +548,7 @@ where
 
     /// Handle `PutRequest`
     fn handle_put_request(&self, req: &PutRequest) -> Result<PutResponse, ExecuteError> {
-        req.validation(())?;
+        req.validation()?;
 
         let mut response = PutResponse {
             header: Some(self.header_gen.gen_header()),
@@ -571,7 +571,7 @@ where
         &self,
         req: &DeleteRangeRequest,
     ) -> Result<DeleteRangeResponse, ExecuteError> {
-        req.validation(())?;
+        req.validation()?;
 
         let prev_kvs = self.get_range(&req.key, &req.range_end, 0)?;
         let mut response = DeleteRangeResponse {
@@ -587,7 +587,7 @@ where
 
     /// Handle `TxnRequest`
     fn handle_txn_request(&self, req: &TxnRequest) -> Result<TxnResponse, ExecuteError> {
-        req.validation((self.compacted_revision(), self.revision()))?;
+        req.validation()?;
 
         let success = req
             .compare
@@ -615,8 +615,6 @@ where
         &self,
         req: &CompactionRequest,
     ) -> Result<CompactionResponse, ExecuteError> {
-        req.validation((self.compacted_revision(), self.revision()))?;
-
         let target_revision = req.revision;
         debug_assert!(
             target_revision > self.compacted_revision(),


### PR DESCRIPTION
Described in: #398
Based on: #399

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    Currently some of the validation checks are done in the RPC server. However, these checks are not applied in the storage request handlers (eg. `handle_range_request`), so that the request from outside client will not be checked.

* what changes does this pull request make?

    This pull request applied the validation check in both RPC server and the storage handlers.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)