### PR TITLE
refactor: xlinectl printer

### DIFF
--- a/xlinectl/src/command/get.rs
+++ b/xlinectl/src/command/get.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::{arg, value_parser, ArgMatches, Command};
 use xline_client::{types::kv::RangeRequest, Client};
-use xlineapi::{RangeResponse, SortOrder, SortTarget};
+use xlineapi::{SortOrder, SortTarget};
 
 use crate::utils::printer::Printer;
 
@@ -110,20 +110,9 @@ pub(crate) fn build_request(matches: &ArgMatches) -> RangeRequest {
 pub(crate) async fn execute(client: &mut Client, matches: &ArgMatches) -> Result<()> {
     let req = build_request(matches);
     let resp = client.kv_client().range(req).await?;
-
-    print_resp(&resp);
+    resp.print();
 
     Ok(())
-}
-
-/// Printer of range response
-fn print_resp(resp: &RangeResponse) {
-    Printer::header(resp.header.as_ref());
-    println!("kvs:");
-    for kv in &resp.kvs {
-        Printer::kv(kv);
-    }
-    println!("more: {}, count: {}", resp.more, resp.count);
 }
 
 #[cfg(test)]

--- a/xlinectl/src/command/put.rs
+++ b/xlinectl/src/command/put.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use clap::{arg, value_parser, ArgMatches, Command};
 use xline_client::{types::kv::PutRequest, Client};
-use xlineapi::PutResponse;
 
 use crate::utils::printer::Printer;
 
@@ -44,18 +43,9 @@ pub(crate) fn build_request(matches: &ArgMatches) -> PutRequest {
 pub(crate) async fn execute(client: &mut Client, matches: &ArgMatches) -> Result<()> {
     let req = build_request(matches);
     let resp = client.kv_client().put(req).await?;
-
-    print_resp(&resp);
+    resp.print();
 
     Ok(())
-}
-
-/// Printer of put response
-fn print_resp(resp: &PutResponse) {
-    Printer::header(resp.header.as_ref());
-    if let Some(pre_kv) = resp.prev_kv.as_ref() {
-        Printer::kv(pre_kv);
-    }
 }
 
 #[cfg(test)]

--- a/xlinectl/src/utils/printer.rs
+++ b/xlinectl/src/utils/printer.rs
@@ -1,11 +1,88 @@
-use xlineapi::{KeyValue, ResponseHeader};
+use std::sync::OnceLock;
 
-/// Printer of common response types
-pub(crate) struct Printer;
+use xlineapi::{KeyValue, PutResponse, RangeResponse, ResponseHeader};
 
-impl Printer {
+/// The global printer type config
+static PRINTER_TYPE: OnceLock<PrinterType> = OnceLock::new();
+
+/// The type of the Printer
+pub(crate) enum PrinterType {
+    /// Simple printer, which print simplified result
+    Simple,
+    /// Filed printer, which print every fields of the result
+    Field,
+}
+
+/// Set the type of the printer
+pub(crate) fn set_printer_type(printer_type: PrinterType) {
+    let _ignore = PRINTER_TYPE.get_or_init(|| printer_type);
+}
+
+/// The printer implementation trait
+pub(crate) trait Printer {
+    /// Print the simplified result
+    fn simple(&self);
+    /// Print every fields of the result
+    fn field(&self);
+    /// Print according to the config set
+    fn print(&self) {
+        match *PRINTER_TYPE
+            .get()
+            .unwrap_or_else(|| unreachable!("the printer type should be initialized"))
+        {
+            PrinterType::Simple => self.simple(),
+            PrinterType::Field => self.field(),
+        }
+    }
+}
+
+impl Printer for PutResponse {
+    fn simple(&self) {
+        println!("OK");
+    }
+
+    fn field(&self) {
+        FieldPrinter::header(self.header.as_ref());
+        if let Some(pre_kv) = self.prev_kv.as_ref() {
+            FieldPrinter::kv(pre_kv);
+        }
+    }
+}
+
+impl Printer for RangeResponse {
+    fn simple(&self) {
+        for kv in &self.kvs {
+            SimplePrinter::utf8(&kv.key);
+            SimplePrinter::utf8(&kv.value);
+        }
+    }
+
+    fn field(&self) {
+        FieldPrinter::header(self.header.as_ref());
+        println!("kvs:");
+        for kv in &self.kvs {
+            FieldPrinter::kv(kv);
+        }
+        println!("more: {}, count: {}", self.more, self.count);
+    }
+}
+
+/// Simple Printer of common response types
+struct SimplePrinter;
+
+impl SimplePrinter {
+    /// Print utf8 bytes as string
+    fn utf8(vec: &[u8]) {
+        println!("{}", String::from_utf8_lossy(vec));
+    }
+}
+
+/// Field Printer of common response types
+struct FieldPrinter;
+
+impl FieldPrinter {
     /// Response header printer
-    pub(crate) fn header(header: Option<&ResponseHeader>) {
+    fn header(header: Option<&ResponseHeader>) {
         let Some(header) = header else { return };
         println!("header:");
         println!(
@@ -15,7 +92,7 @@ impl Printer {
     }
 
     /// Response key-value printer
-    pub(crate) fn kv(kv: &KeyValue) {
+    fn kv(kv: &KeyValue) {
         println!(
             "key: {}, value: {}",
             String::from_utf8_lossy(&kv.key),


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    add more printer format option for xlinectl

* what changes does this pull request make?

   add a new `Printer` trait, and implement it for each response type.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)