### PR TITLE
refactor: build client without `ServerId`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,7 @@ dependencies = [
  "clippy-utilities 0.2.0",
  "curp-external-api",
  "curp-test-utils",
+ "dashmap",
  "derive_builder",
  "engine",
  "event-listener",
@@ -731,12 +732,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
 dependencies = [
  "cfg-if",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.0",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1415,9 +1416,9 @@ checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1743,9 +1744,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opentelemetry"
@@ -1873,15 +1874,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2200,6 +2201,15 @@ name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -2538,7 +2548,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "remove_dir_all",
  "winapi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,7 @@ dependencies = [
  "clippy-utilities 0.2.0",
  "curp-external-api",
  "curp-test-utils",
+ "derive_builder",
  "engine",
  "event-listener",
  "flume",

--- a/benchmark/src/args.rs
+++ b/benchmark/src/args.rs
@@ -1,7 +1,4 @@
-use std::collections::HashMap;
-
 use clap::{Parser, Subcommand};
-use utils::parse_members;
 
 #[derive(Parser, Debug)]
 #[non_exhaustive]
@@ -9,10 +6,10 @@ use utils::parse_members;
 /// Args of Benchmark
 pub struct Benchmark {
     /// The address of the server
-    #[clap(long, value_parser = parse_members)]
-    pub endpoints: HashMap<String, String>,
+    #[clap(long, value_delimiter = ',', default_value = "127.0.0.1:2379")]
+    pub endpoints: Vec<String>,
     /// Clients number
-    #[clap(long, required = true)]
+    #[clap(long, default_value_t = 1)]
     pub clients: usize,
     /// Use curp or not
     #[clap(long)]

--- a/curp/Cargo.toml
+++ b/curp/Cargo.toml
@@ -22,6 +22,7 @@ chrono = { version = "0.4.24", default-features = false, features = [
 ] }
 clippy-utilities = "0.2.0"
 curp-external-api = { path = "../curp-external-api" }
+dashmap = "5.5.0"
 derive_builder = "0.12.0"
 engine = { path = "../engine" }
 event-listener = "2.5.2"

--- a/curp/Cargo.toml
+++ b/curp/Cargo.toml
@@ -9,18 +9,26 @@ name = "curp"
 readme = "README.md"
 repository = "https://github.com/xline-kv/Xline/tree/master/curp"
 version = "0.1.0"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-stream = "0.3.4"
 async-trait = "0.1.53"
 bincode = "1.3.3"
+bytes = "1.4.0"
+chrono = { version = "0.4.24", default-features = false, features = [
+  "clock",
+  "std",
+] }
 clippy-utilities = "0.2.0"
-event-listener = "2.5.2"
-futures = "0.3.21"
-itertools = "0.10.3"
-utils = { path = "../utils", version = "0.1.0", features = ["parking_lot"] }
 curp-external-api = { path = "../curp-external-api" }
+derive_builder = "0.12.0"
+engine = { path = "../engine" }
+event-listener = "2.5.2"
+flume = "0.10.14"
+futures = "0.3.21"
+indexmap = "1.9.2"
+itertools = "0.10.3"
 madsim = { version = "0.2.22", features = ["rpc", "macros"] }
 opentelemetry = "0.18.0"
 parking_lot = "0.12.1"
@@ -34,31 +42,23 @@ tokio-stream = { git = "https://github.com/madsim-rs/tokio.git", rev = "ab251ad"
   "net",
 ] }
 tonic = { version = "0.3.0", package = "madsim-tonic" }
+tower = { version = "0.4.13", features = ["filter"] }
 tracing = { version = "0.1.34", features = ["std", "log", "attributes"] }
 tracing-opentelemetry = "0.18.0"
-flume = "0.10.14"
-indexmap = "1.9.2"
-tower = { version = "0.4.13", features = ["filter"] }
-engine = { path = "../engine" }
-async-stream = "0.3.4"
-chrono = { version = "0.4.24", default-features = false, features = [
-  "clock",
-  "std",
-] }
+utils = { path = "../utils", version = "0.1.0", features = ["parking_lot"] }
 uuid = { version = "1.3.1", features = ["v4"] }
-bytes = "1.4.0"
 
 [dev-dependencies]
+anyhow = "1.0.66"
 curp-test-utils = { path = "../curp-test-utils" }
 itertools = "0.10.3"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter", "time"] }
-tracing-test = "0.2.4"
-anyhow = "1.0.66"
 mockall = "0.11.3"
 once_cell = "1.17.0"
 tempfile = "3"
 test-macros = { path = "../test-macros" }
+tracing-subscriber = { version = "0.3.16", features = ["env-filter", "time"] }
+tracing-test = "0.2.4"
 
 [build-dependencies]
-tonic-build = { version = "0.3.0", package = "madsim-tonic-build" }
 prost-build = "0.11"
+tonic-build = { version = "0.3.0", package = "madsim-tonic-build" }

--- a/curp/proto/message.proto
+++ b/curp/proto/message.proto
@@ -28,6 +28,15 @@ message FetchLeaderResponse {
     uint64 term = 2;
 }
 
+message FetchClusterRequest {
+}
+
+message FetchClusterResponse {
+    optional string leader_id = 1;
+    map<string, string> all_members = 2;
+    uint64 term = 3;
+}
+
 message WaitSyncedRequest {
     bytes id = 1;
 }
@@ -105,7 +114,8 @@ service Protocol {
     rpc WaitSynced (WaitSyncedRequest) returns (WaitSyncedResponse);
     rpc AppendEntries (AppendEntriesRequest) returns (AppendEntriesResponse);
     rpc Vote (VoteRequest) returns (VoteResponse);
-    rpc FetchLeader (FetchLeaderRequest) returns (FetchLeaderResponse);
     rpc InstallSnapshot (stream InstallSnapshotRequest) returns (InstallSnapshotResponse);
+    rpc FetchLeader (FetchLeaderRequest) returns (FetchLeaderResponse);
+    rpc FetchCluster (FetchClusterRequest) returns (FetchClusterResponse);
     rpc FetchReadState (FetchReadStateRequest) returns (FetchReadStateResponse);
 }

--- a/curp/src/error.rs
+++ b/curp/src/error.rs
@@ -6,6 +6,42 @@ use thiserror::Error;
 
 use crate::{cmd::ProposeId, ServerId};
 
+/// Error type of client builder
+#[allow(clippy::module_name_repetitions)] // this-error generate code false-positive
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ClientBuildError {
+    /// Rpc error
+    #[error("Rpc error: {0}")]
+    RpcError(String),
+    /// Invalid arguments
+    #[error("Invalid arguments: {0}")]
+    InvalidArguments(String),
+}
+
+impl ClientBuildError {
+    /// Create a new `ClientBuildError::InvalidArguments`
+    #[inline]
+    #[must_use]
+    pub fn invalid_aurguments(msg: &str) -> Self {
+        Self::InvalidArguments(msg.to_owned())
+    }
+}
+
+impl From<tonic::transport::Error> for ClientBuildError {
+    #[inline]
+    fn from(e: tonic::transport::Error) -> Self {
+        Self::RpcError(e.to_string())
+    }
+}
+
+impl From<tonic::Status> for ClientBuildError {
+    #[inline]
+    fn from(e: tonic::Status) -> Self {
+        Self::RpcError(e.to_string())
+    }
+}
+
 /// Server side error
 #[allow(clippy::module_name_repetitions)] // this-error generate code false-positive
 #[non_exhaustive]

--- a/curp/src/rpc/connect.rs
+++ b/curp/src/rpc/connect.rs
@@ -59,7 +59,7 @@ pub(crate) async fn connect(
 /// Connect interface
 #[cfg_attr(test, automock)]
 #[async_trait]
-pub(crate) trait ConnectApi: Send + Sync + 'static {
+pub(crate) trait ConnectApi: Send + Sync + 'static + Debug {
     /// Get server id
     fn id(&self) -> &ServerId;
 

--- a/curp/src/rpc/connect.rs
+++ b/curp/src/rpc/connect.rs
@@ -30,7 +30,7 @@ const SNAPSHOT_CHUNK_SIZE: u64 = 64 * 1024;
 /// Convert a vec of addr string to a vec of `Connect`
 pub(crate) async fn connect(
     addrs: HashMap<ServerId, String>,
-) -> HashMap<ServerId, Arc<dyn ConnectApi>> {
+) -> impl Iterator<Item = (ServerId, Arc<dyn ConnectApi>)> {
     futures::future::join_all(addrs.into_iter().map(|(id, mut addr)| async move {
         // Addrs must start with "http" to communicate with the server
         if !addr.starts_with("http://") {
@@ -53,13 +53,12 @@ pub(crate) async fn connect(
         });
         (id, connect)
     })
-    .collect()
 }
 
 /// Connect interface
 #[cfg_attr(test, automock)]
 #[async_trait]
-pub(crate) trait ConnectApi: Send + Sync + 'static + Debug {
+pub(crate) trait ConnectApi: Send + Sync + 'static {
     /// Get server id
     fn id(&self) -> &ServerId;
 

--- a/curp/src/rpc/mod.rs
+++ b/curp/src/rpc/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -7,9 +7,9 @@ pub(crate) use self::proto::{
     propose_response::ExeResult,
     protocol_server::Protocol,
     wait_synced_response::{Success, SyncResult as SyncResultRaw},
-    AppendEntriesRequest, AppendEntriesResponse, FetchReadStateRequest, FetchReadStateResponse,
-    IdSet, InstallSnapshotRequest, InstallSnapshotResponse, VoteRequest, VoteResponse,
-    WaitSyncedRequest, WaitSyncedResponse,
+    AppendEntriesRequest, AppendEntriesResponse, FetchClusterRequest, FetchClusterResponse,
+    FetchReadStateRequest, FetchReadStateResponse, IdSet, InstallSnapshotRequest,
+    InstallSnapshotResponse, VoteRequest, VoteResponse, WaitSyncedRequest, WaitSyncedResponse,
 };
 pub use self::proto::{
     propose_response, protocol_client, protocol_server::ProtocolServer, FetchLeaderRequest,
@@ -56,6 +56,28 @@ impl FetchLeaderResponse {
     /// Create a new `FetchLeaderResponse`
     pub(crate) fn new(leader_id: Option<ServerId>, term: u64) -> Self {
         Self { leader_id, term }
+    }
+}
+
+impl FetchClusterRequest {
+    /// Create a new `FetchClusterRequest`
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+impl FetchClusterResponse {
+    /// Create a new `FetchClusterResponse`
+    pub(crate) fn new(
+        leader_id: Option<ServerId>,
+        all_members: HashMap<ServerId, String>,
+        term: u64,
+    ) -> Self {
+        Self {
+            leader_id,
+            all_members,
+            term,
+        }
     }
 }
 

--- a/curp/src/server/curp_node.rs
+++ b/curp/src/server/curp_node.rs
@@ -30,8 +30,9 @@ use crate::{
     members::ClusterMember,
     role_change::RoleChange,
     rpc::{
-        self, connect::ConnectApi, AppendEntriesRequest, AppendEntriesResponse, FetchLeaderRequest,
-        FetchLeaderResponse, FetchReadStateRequest, FetchReadStateResponse, InstallSnapshotRequest,
+        self, connect::ConnectApi, AppendEntriesRequest, AppendEntriesResponse,
+        FetchClusterRequest, FetchClusterResponse, FetchLeaderRequest, FetchLeaderResponse,
+        FetchReadStateRequest, FetchReadStateResponse, InstallSnapshotRequest,
         InstallSnapshotResponse, ProposeRequest, ProposeResponse, VoteRequest, VoteResponse,
         WaitSyncedRequest, WaitSyncedResponse,
     },
@@ -191,6 +192,17 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
     ) -> Result<FetchLeaderResponse, CurpError> {
         let (leader_id, term) = self.curp.leader();
         Ok(FetchLeaderResponse::new(leader_id, term))
+    }
+
+    /// Handle fetch cluster requests
+    #[allow(clippy::unnecessary_wraps, clippy::needless_pass_by_value)] // To keep type consistent with other request handlers
+    pub(super) fn fetch_cluster(
+        &self,
+        _req: FetchClusterRequest,
+    ) -> Result<FetchClusterResponse, CurpError> {
+        let (leader_id, term) = self.curp.leader();
+        let all_members = self.curp.cluster().all_members();
+        Ok(FetchClusterResponse::new(leader_id, all_members, term))
     }
 
     /// Install snapshot

--- a/curp/src/server/curp_node.rs
+++ b/curp/src/server/curp_node.rs
@@ -525,7 +525,9 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
         shutdown_trigger: Arc<Event>,
         log_rx: tokio::sync::mpsc::UnboundedReceiver<LogEntry<C>>,
     ) {
-        let connects = rpc::connect(cluster_info.peers()).await;
+        let connects = rpc::connect(cluster_info.peers())
+            .await
+            .collect::<HashMap<_, _>>();
         let election_task = tokio::spawn(Self::election_task(Arc::clone(&curp), connects.clone()));
         let sync_task_daemons = connects
             .into_iter()

--- a/curp/src/server/mod.rs
+++ b/curp/src/server/mod.rs
@@ -18,10 +18,10 @@ use crate::{
     members::ClusterMember,
     role_change::RoleChange,
     rpc::{
-        AppendEntriesRequest, AppendEntriesResponse, FetchLeaderRequest, FetchLeaderResponse,
-        FetchReadStateRequest, FetchReadStateResponse, InstallSnapshotRequest,
-        InstallSnapshotResponse, ProposeRequest, ProposeResponse, ProtocolServer, VoteRequest,
-        VoteResponse, WaitSyncedRequest, WaitSyncedResponse,
+        AppendEntriesRequest, AppendEntriesResponse, FetchClusterRequest, FetchClusterResponse,
+        FetchLeaderRequest, FetchLeaderResponse, FetchReadStateRequest, FetchReadStateResponse,
+        InstallSnapshotRequest, InstallSnapshotResponse, ProposeRequest, ProposeResponse,
+        ProtocolServer, VoteRequest, VoteResponse, WaitSyncedRequest, WaitSyncedResponse,
     },
     ServerId, SnapshotAllocator,
 };
@@ -110,6 +110,16 @@ impl<C: 'static + Command, RC: RoleChange + 'static> crate::rpc::Protocol for Rp
     ) -> Result<tonic::Response<FetchLeaderResponse>, tonic::Status> {
         Ok(tonic::Response::new(
             self.inner.fetch_leader(request.into_inner())?,
+        ))
+    }
+
+    #[instrument(skip_all, name = "curp_fetch_cluster")]
+    async fn fetch_cluster(
+        &self,
+        request: tonic::Request<FetchClusterRequest>,
+    ) -> Result<tonic::Response<FetchClusterResponse>, tonic::Status> {
+        Ok(tonic::Response::new(
+            self.inner.fetch_cluster(request.into_inner())?,
         ))
     }
 

--- a/curp/src/server/raw_curp/mod.rs
+++ b/curp/src/server/raw_curp/mod.rs
@@ -686,6 +686,11 @@ impl<C: 'static + Command, RC: RoleChange + 'static> RawCurp<C, RC> {
         self.st.map_read(|st_r| (st_r.leader_id.clone(), st_r.term))
     }
 
+    /// Get cluster info
+    pub(super) fn cluster(&self) -> &ClusterMember {
+        self.ctx.cluster_info.as_ref()
+    }
+
     /// Get self's id
     pub(super) fn id(&self) -> &ServerId {
         self.ctx.cluster_info.self_id()

--- a/curp/tests/common/curp_group.rs
+++ b/curp/tests/common/curp_group.rs
@@ -135,9 +135,8 @@ impl CurpGroup {
 
     pub async fn new_client(&self, timeout: ClientTimeout) -> Client<TestCommand> {
         Client::builder()
-            .addrs(self.all.values().cloned().collect_vec())
             .timeout(timeout)
-            .build()
+            .build_from_addrs(self.all.values().cloned().collect_vec())
             .await
             .unwrap()
     }

--- a/curp/tests/common/curp_group.rs
+++ b/curp/tests/common/curp_group.rs
@@ -134,7 +134,12 @@ impl CurpGroup {
     }
 
     pub async fn new_client(&self, timeout: ClientTimeout) -> Client<TestCommand> {
-        Client::<TestCommand>::new(None, self.all.clone(), timeout).await
+        Client::builder()
+            .addrs(self.all.values().cloned().collect_vec())
+            .timeout(timeout)
+            .build()
+            .await
+            .unwrap()
     }
 
     pub fn exe_rxs(

--- a/curp/tests/server.rs
+++ b/curp/tests/server.rs
@@ -3,6 +3,7 @@
 use std::{sync::Arc, time::Duration};
 
 use clippy_utilities::NumericCast;
+use curp::client::Builder;
 use curp_test_utils::{init_logger, sleep_millis, sleep_secs, test_cmd::TestCommand};
 use madsim::rand::{thread_rng, Rng};
 use test_macros::abort_on_panic;
@@ -11,6 +12,7 @@ use utils::config::ClientTimeout;
 use crate::common::curp_group::{
     proto::propose_response::ExeResult, CurpGroup, ProposeRequest, ProposeResponse,
 };
+
 mod common;
 
 #[tokio::test]
@@ -37,6 +39,22 @@ async fn basic_propose() {
             .0,
         (vec![0], vec![1])
     );
+
+    group.stop();
+}
+
+#[tokio::test]
+#[abort_on_panic]
+async fn fetch_cluster() {
+    init_logger();
+    let group = CurpGroup::new(3).await;
+
+    let all_addrs = group.all.values().cloned().collect::<Vec<_>>();
+    let client_builder = Builder::<TestCommand>::default()
+        .addrs(all_addrs)
+        .timeout(ClientTimeout::default());
+
+    let _client = client_builder.build().await.unwrap();
 
     group.stop();
 }

--- a/curp/tests/server.rs
+++ b/curp/tests/server.rs
@@ -50,11 +50,11 @@ async fn fetch_cluster() {
     let group = CurpGroup::new(3).await;
 
     let all_addrs = group.all.values().cloned().collect::<Vec<_>>();
-    let client_builder = Builder::<TestCommand>::default()
-        .addrs(all_addrs)
-        .timeout(ClientTimeout::default());
-
-    let _client = client_builder.build().await.unwrap();
+    let _client = Builder::<TestCommand>::default()
+        .timeout(ClientTimeout::default())
+        .build_from_addrs(all_addrs)
+        .await
+        .unwrap();
 
     group.stop();
 }

--- a/simulation/src/curp_group.rs
+++ b/simulation/src/curp_group.rs
@@ -157,9 +157,8 @@ impl CurpGroup {
         SimClient {
             inner: Arc::new(
                 Client::<TestCommand>::builder()
-                    .all_members(all_members)
                     .timeout(timeout)
-                    .build()
+                    .build_from_all_members(all_members)
                     .await
                     .unwrap(),
             ),

--- a/simulation/src/curp_group.rs
+++ b/simulation/src/curp_group.rs
@@ -149,13 +149,20 @@ impl CurpGroup {
     }
 
     pub async fn new_client(&self, timeout: ClientTimeout) -> SimClient<TestCommand> {
-        let addrs = self
+        let all_members = self
             .nodes
             .iter()
             .map(|(id, node)| (id.clone(), node.addr.clone()))
             .collect();
         SimClient {
-            inner: Arc::new(Client::<TestCommand>::new(None, addrs, timeout).await),
+            inner: Arc::new(
+                Client::<TestCommand>::builder()
+                    .all_members(all_members)
+                    .timeout(timeout)
+                    .build()
+                    .await
+                    .unwrap(),
+            ),
             handle: self.client_node.clone(),
         }
     }

--- a/xline-client/README.md
+++ b/xline-client/README.md
@@ -86,11 +86,7 @@ To create a xline client:
  #[tokio::main]
  async fn main() -> Result<(), Error> {
      // the name and address of all curp members
-     let curp_members = [
-         ("server0", "10.0.0.1:2379"),
-         ("server1", "10.0.0.2:2379"),
-         ("server2", "10.0.0.3:2379"),
-     ];
+     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
 
      let mut client = Client::connect(curp_members, ClientOptions::default())
          .await?

--- a/xline-client/examples/auth.rs
+++ b/xline-client/examples/auth.rs
@@ -3,11 +3,7 @@ use xline_client::{error::Result, Client, ClientOptions};
 #[tokio::main]
 async fn main() -> Result<()> {
     // the name and address of all curp members
-    let curp_members = [
-        ("server0", "10.0.0.1:2379"),
-        ("server1", "10.0.0.2:2379"),
-        ("server2", "10.0.0.3:2379"),
-    ];
+    let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
 
     let client = Client::connect(curp_members, ClientOptions::default())
         .await?

--- a/xline-client/examples/auth_role.rs
+++ b/xline-client/examples/auth_role.rs
@@ -11,11 +11,7 @@ use xline_client::{
 #[tokio::main]
 async fn main() -> Result<()> {
     // the name and address of all curp members
-    let curp_members = [
-        ("server0", "10.0.0.1:2379"),
-        ("server1", "10.0.0.2:2379"),
-        ("server2", "10.0.0.3:2379"),
-    ];
+    let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
 
     let client = Client::connect(curp_members, ClientOptions::default())
         .await?

--- a/xline-client/examples/auth_user.rs
+++ b/xline-client/examples/auth_user.rs
@@ -10,11 +10,7 @@ use xline_client::{
 #[tokio::main]
 async fn main() -> Result<()> {
     // the name and address of all curp members
-    let curp_members = [
-        ("server0", "10.0.0.1:2379"),
-        ("server1", "10.0.0.2:2379"),
-        ("server2", "10.0.0.3:2379"),
-    ];
+    let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
 
     let client = Client::connect(curp_members, ClientOptions::default())
         .await?

--- a/xline-client/examples/error_handling.rs
+++ b/xline-client/examples/error_handling.rs
@@ -10,11 +10,7 @@ use xline_client::{
 #[tokio::main]
 async fn main() -> Result<()> {
     // the name and address of all curp members
-    let curp_members = [
-        ("server0", "10.0.0.1:2379"),
-        ("server1", "10.0.0.2:2379"),
-        ("server2", "10.0.0.3:2379"),
-    ];
+    let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
 
     let client = Client::connect(curp_members, ClientOptions::default())
         .await?

--- a/xline-client/examples/kv.rs
+++ b/xline-client/examples/kv.rs
@@ -10,11 +10,7 @@ use xline_client::{
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     // the name and address of all curp members
-    let curp_members = [
-        ("server0", "10.0.0.1:2379"),
-        ("server1", "10.0.0.2:2379"),
-        ("server2", "10.0.0.3:2379"),
-    ];
+    let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
 
     let client = Client::connect(curp_members, ClientOptions::default())
         .await?

--- a/xline-client/examples/lease.rs
+++ b/xline-client/examples/lease.rs
@@ -9,11 +9,7 @@ use xline_client::{
 #[tokio::main]
 async fn main() -> Result<()> {
     // the name and address of all curp members
-    let curp_members = [
-        ("server0", "10.0.0.1:2379"),
-        ("server1", "10.0.0.2:2379"),
-        ("server2", "10.0.0.3:2379"),
-    ];
+    let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
 
     let mut client = Client::connect(curp_members, ClientOptions::default())
         .await?

--- a/xline-client/examples/lock.rs
+++ b/xline-client/examples/lock.rs
@@ -7,11 +7,7 @@ use xline_client::{
 #[tokio::main]
 async fn main() -> Result<()> {
     // the name and address of all curp members
-    let curp_members = [
-        ("server0", "10.0.0.1:2379"),
-        ("server1", "10.0.0.2:2379"),
-        ("server2", "10.0.0.3:2379"),
-    ];
+    let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
 
     let client = Client::connect(curp_members, ClientOptions::default())
         .await?

--- a/xline-client/examples/maintenance.rs
+++ b/xline-client/examples/maintenance.rs
@@ -3,11 +3,7 @@ use xline_client::{error::ClientError as Error, Client, ClientOptions};
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     // the name and address of all curp members
-    let curp_members = [
-        ("server0", "10.0.0.1:2379"),
-        ("server1", "10.0.0.2:2379"),
-        ("server2", "10.0.0.3:2379"),
-    ];
+    let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
 
     let mut client = Client::connect(curp_members, ClientOptions::default())
         .await?

--- a/xline-client/examples/watch.rs
+++ b/xline-client/examples/watch.rs
@@ -7,11 +7,7 @@ use xline_client::{
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     // the name and address of all curp members
-    let curp_members = [
-        ("server0", "10.0.0.1:2379"),
-        ("server1", "10.0.0.2:2379"),
-        ("server2", "10.0.0.3:2379"),
-    ];
+    let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
 
     let client = Client::connect(curp_members, ClientOptions::default()).await?;
     let mut watch_client = client.watch_client();

--- a/xline-client/src/clients/auth.rs
+++ b/xline-client/src/clients/auth.rs
@@ -74,11 +74,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -109,11 +105,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -145,11 +137,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -183,11 +171,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let mut client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -227,11 +211,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -275,11 +255,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -312,11 +288,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -350,11 +322,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -394,11 +362,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -440,11 +404,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -480,11 +440,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -521,11 +477,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -558,11 +510,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -596,11 +544,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -635,11 +579,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -679,11 +619,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -729,11 +665,7 @@ impl AuthClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?

--- a/xline-client/src/clients/kv.rs
+++ b/xline-client/src/clients/kv.rs
@@ -52,11 +52,7 @@ impl KvClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let mut client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -93,11 +89,7 @@ impl KvClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let mut client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -141,11 +133,7 @@ impl KvClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let mut client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -188,11 +176,7 @@ impl KvClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let mut client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -236,7 +220,7 @@ impl KvClient {
 
     /// Compacts the key-value store up to a given revision.
     /// All keys with revisions less than the given revision will be compacted.
-    /// The compaction process will remove all historical versions of these keys, except for the most recent one.  
+    /// The compaction process will remove all historical versions of these keys, except for the most recent one.
     /// For example, here is a revision list: [(A, 1), (A, 2), (A, 3), (A, 4), (A, 5)].
     /// We compact at revision 3. After the compaction, the revision list will become [(A, 3), (A, 4), (A, 5)].
     /// All revisions less than 3 are deleted. The latest revision, 3, will be kept.
@@ -256,11 +240,7 @@ impl KvClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?

--- a/xline-client/src/clients/lease.rs
+++ b/xline-client/src/clients/lease.rs
@@ -72,11 +72,7 @@ impl LeaseClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let mut client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -116,11 +112,7 @@ impl LeaseClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let mut client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -153,11 +145,7 @@ impl LeaseClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let mut client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -218,11 +206,7 @@ impl LeaseClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let mut client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -262,11 +246,7 @@ impl LeaseClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let mut client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?

--- a/xline-client/src/clients/lock.rs
+++ b/xline-client/src/clients/lock.rs
@@ -95,11 +95,7 @@ impl LockClient {
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
     ///     // the name and address of all curp members
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let mut client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?
@@ -229,11 +225,7 @@ impl LockClient {
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
     ///     // the name and address of all curp members
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let mut client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?

--- a/xline-client/src/clients/maintenance.rs
+++ b/xline-client/src/clients/maintenance.rs
@@ -42,11 +42,7 @@ impl MaintenanceClient {
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
     ///     // the name and address of all curp members
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let mut client = Client::connect(curp_members, ClientOptions::default())
     ///         .await?

--- a/xline-client/src/clients/watch.rs
+++ b/xline-client/src/clients/watch.rs
@@ -57,11 +57,7 @@ impl WatchClient {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///     let curp_members = [
-    ///         ("server0", "10.0.0.1:2379"),
-    ///         ("server1", "10.0.0.2:2379"),
-    ///         ("server2", "10.0.0.3:2379"),
-    ///     ];
+    ///     let curp_members = ["10.0.0.1:2379", "10.0.0.2:2379", "10.0.0.3:2379"];
     ///
     ///     let client = Client::connect(curp_members, ClientOptions::default()).await?;
     ///     let mut watch_client = client.watch_client();

--- a/xline-client/src/error.rs
+++ b/xline-client/src/error.rs
@@ -1,3 +1,4 @@
+use curp::error::ClientBuildError;
 use thiserror::Error;
 use xline::server::Command;
 
@@ -26,6 +27,9 @@ pub enum ClientError {
     /// Error in lease client
     #[error("Lease client error: {0}")]
     LeaseError(String),
+    /// Curp client build error
+    #[error("Curp client build error: {0}")]
+    BuildError(#[from] ClientBuildError),
 }
 
 impl From<tonic::transport::Error> for ClientError {

--- a/xline-client/src/lib.rs
+++ b/xline-client/src/lib.rs
@@ -216,7 +216,13 @@ impl Client {
             .collect();
         let name = String::from("client");
         let channel = Self::build_channel(all_members.values().cloned().collect()).await?;
-        let curp_client = Arc::new(CurpClient::new(None, all_members, options.curp_timeout).await);
+        let curp_client = Arc::new(
+            CurpClient::builder()
+                .addrs(all_members.into_values().collect())
+                .timeout(options.curp_timeout)
+                .build()
+                .await?,
+        );
         let id_gen = Arc::new(lease_gen::LeaseIdGenerator::new());
 
         let token = match options.user {

--- a/xline-test-utils/src/bin/test_cluster.rs
+++ b/xline-test-utils/src/bin/test_cluster.rs
@@ -9,7 +9,7 @@ async fn main() {
 
     println!("cluster running");
 
-    for (id, addr) in cluster.addrs() {
+    for (id, addr) in cluster.all_members() {
         println!("server id: {} addr: {}", id, addr);
     }
 

--- a/xline-test-utils/src/lib.rs
+++ b/xline-test-utils/src/lib.rs
@@ -107,18 +107,26 @@ impl Cluster {
     /// Create or get the client with the specified index
     pub async fn client(&mut self) -> &mut Client {
         if self.client.is_none() {
-            let client = Client::new(self.all_members.clone(), true, ClientTimeout::default())
-                .await
-                .unwrap_or_else(|e| {
-                    panic!("Client connect error: {:?}", e);
-                });
+            let client = Client::new(
+                self.all_members.values().cloned().collect(),
+                true,
+                ClientTimeout::default(),
+            )
+            .await
+            .unwrap_or_else(|e| {
+                panic!("Client connect error: {:?}", e);
+            });
             self.client = Some(client);
         }
         self.client.as_mut().unwrap()
     }
 
-    pub fn addrs(&self) -> &HashMap<ServerId, String> {
+    pub fn all_members(&self) -> &HashMap<ServerId, String> {
         &self.all_members
+    }
+
+    pub fn addrs(&self) -> Vec<String> {
+        self.all_members.values().cloned().collect()
     }
 
     fn test_key_pair() -> Option<(EncodingKey, DecodingKey)> {

--- a/xline/src/client/errors.rs
+++ b/xline/src/client/errors.rs
@@ -1,3 +1,4 @@
+use curp::error::ClientBuildError;
 use thiserror::Error;
 
 use crate::server::Command;
@@ -18,6 +19,9 @@ pub enum ClientError {
     /// Engine error
     #[error("Engine error {0}")]
     EngineError(#[from] engine::EngineError),
+    /// Build error
+    #[error("Build error {0}")]
+    BuildError(#[from] ClientBuildError),
 }
 
 impl From<etcd_client::Error> for ClientError {

--- a/xline/src/client/mod.rs
+++ b/xline/src/client/mod.rs
@@ -71,7 +71,11 @@ impl Client {
         let name = String::from("client");
         let etcd_client =
             EtcdClient::connect(all_members.values().cloned().collect_vec(), None).await?;
-        let curp_client = CurpClient::new(None, all_members, timeout).await;
+        let curp_client = CurpClient::builder()
+            .addrs(all_members.into_values().collect())
+            .timeout(timeout)
+            .build()
+            .await?;
         Ok(Self {
             name,
             curp_client,

--- a/xline/src/client/mod.rs
+++ b/xline/src/client/mod.rs
@@ -1,11 +1,10 @@
-use std::{collections::HashMap, fmt::Debug};
+use std::fmt::Debug;
 
-use curp::{client::Client as CurpClient, cmd::ProposeId, ServerId};
+use curp::{client::Client as CurpClient, cmd::ProposeId};
 use etcd_client::{
     AuthClient, Client as EtcdClient, KvClient, LeaseClient, LeaseKeepAliveStream, LeaseKeeper,
     LockClient, MaintenanceClient, WatchClient,
 };
-use itertools::Itertools;
 use utils::config::ClientTimeout;
 use uuid::Uuid;
 
@@ -64,17 +63,15 @@ impl Client {
     /// If `EtcdClient::connect` fails.
     #[inline]
     pub async fn new(
-        all_members: HashMap<ServerId, String>,
+        addrs: Vec<String>,
         use_curp_client: bool,
         timeout: ClientTimeout,
     ) -> Result<Self, ClientError> {
         let name = String::from("client");
-        let etcd_client =
-            EtcdClient::connect(all_members.values().cloned().collect_vec(), None).await?;
+        let etcd_client = EtcdClient::connect(addrs.clone(), None).await?;
         let curp_client = CurpClient::builder()
-            .addrs(all_members.into_values().collect())
             .timeout(timeout)
-            .build()
+            .build_from_addrs(addrs)
             .await?;
         Ok(Self {
             name,

--- a/xline/src/server/xline_server.rs
+++ b/xline/src/server/xline_server.rs
@@ -319,12 +319,12 @@ impl XlineServer {
         };
 
         let client = Arc::new(
-            CurpClient::new(
-                Some(self.cluster_info.self_id().clone()),
-                self.cluster_info.all_members(),
-                self.client_timeout,
-            )
-            .await,
+            CurpClient::builder()
+                .all_members(self.cluster_info.all_members())
+                .local_server_id(self.cluster_info.self_id().clone())
+                .timeout(self.client_timeout)
+                .build()
+                .await?,
         );
 
         let auto_compactor = if let Some(auto_config_cfg) = *self.compact_cfg.auto_compact_config()

--- a/xline/src/server/xline_server.rs
+++ b/xline/src/server/xline_server.rs
@@ -320,10 +320,9 @@ impl XlineServer {
 
         let client = Arc::new(
             CurpClient::builder()
-                .all_members(self.cluster_info.all_members())
                 .local_server_id(self.cluster_info.self_id().clone())
                 .timeout(self.client_timeout)
-                .build()
+                .build_from_all_members(self.cluster_info.all_members())
                 .await?,
         );
 

--- a/xline/tests/auth_test.rs
+++ b/xline/tests/auth_test.rs
@@ -45,7 +45,7 @@ async fn test_auth_token_with_disable() -> Result<(), Box<dyn Error>> {
 
     enable_auth(&mut auth_client).await?;
     let mut authed_client = etcd_client::Client::connect(
-        vec![cluster.addrs()["server0"].to_string()],
+        vec![cluster.all_members()["server0"].to_string()],
         Some(ConnectOptions::new().with_user("root", "123")),
     )
     .await?;
@@ -102,12 +102,12 @@ async fn test_kv_authorization() -> Result<(), Box<dyn Error>> {
     enable_auth(&mut auth_client).await?;
 
     let mut u1_client = etcd_client::Client::connect(
-        vec![cluster.addrs()["server0"].to_string()],
+        vec![cluster.all_members()["server0"].to_string()],
         Some(ConnectOptions::new().with_user("u1", "123")),
     )
     .await?;
     let mut u2_client = etcd_client::Client::connect(
-        vec![cluster.addrs()["server0"].to_string()],
+        vec![cluster.all_members()["server0"].to_string()],
         Some(ConnectOptions::new().with_user("u2", "123")),
     )
     .await?;
@@ -158,12 +158,12 @@ async fn test_no_root_user_do_admin_ops() -> Result<(), Box<dyn Error>> {
     set_user(&mut auth_client, "u", "123", "r", &[], &[]).await?;
     enable_auth(&mut auth_client).await?;
     let mut user_client = etcd_client::Client::connect(
-        vec![cluster.addrs()["server0"].to_string()],
+        vec![cluster.all_members()["server0"].to_string()],
         Some(ConnectOptions::new().with_user("u", "123")),
     )
     .await?;
     let mut root_client = etcd_client::Client::connect(
-        vec![cluster.addrs()["server0"].to_string()],
+        vec![cluster.all_members()["server0"].to_string()],
         Some(ConnectOptions::new().with_user("root", "123")),
     )
     .await?;
@@ -190,14 +190,14 @@ async fn test_auth_wrong_password() -> Result<(), Box<dyn Error>> {
     enable_auth(&mut auth_client).await?;
 
     let result = etcd_client::Client::connect(
-        vec![cluster.addrs()["server0"].to_string()],
+        vec![cluster.all_members()["server0"].to_string()],
         Some(ConnectOptions::new().with_user("root", "456")),
     )
     .await;
     assert!(result.is_err());
 
     let result = etcd_client::Client::connect(
-        vec![cluster.addrs()["server0"].to_string()],
+        vec![cluster.all_members()["server0"].to_string()],
         Some(ConnectOptions::new().with_user("root", "123")),
     )
     .await;

--- a/xline/tests/kv_test.rs
+++ b/xline/tests/kv_test.rs
@@ -165,7 +165,7 @@ async fn test_range_redirect() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;
 
-    let addr = cluster.addrs()["server1"].clone();
+    let addr = cluster.all_members()["server1"].clone();
     let mut kv_client = Client::connect([addr], None).await?.kv_client();
     let _ignore = kv_client.put("foo", "bar", None).await?;
     tokio::time::sleep(Duration::from_millis(300)).await;

--- a/xline/tests/lease_test.rs
+++ b/xline/tests/lease_test.rs
@@ -36,7 +36,7 @@ async fn test_lease_expired() -> Result<(), Box<dyn Error>> {
 async fn test_lease_keep_alive() -> Result<(), Box<dyn Error>> {
     let mut cluster = Cluster::new(3).await;
     cluster.start().await;
-    let non_leader_ep = cluster.addrs()["server1"].to_string();
+    let non_leader_ep = cluster.all_members()["server1"].to_string();
     let client = cluster.client().await;
 
     let res = client.lease_grant(LeaseGrantRequest::new(1)).await?;

--- a/xline/tests/maintenance.rs
+++ b/xline/tests/maintenance.rs
@@ -22,7 +22,7 @@ async fn test_snapshot_and_restore() -> Result<(), Box<dyn std::error::Error>> {
         let _ignore = client.put(PutRequest::new("key", "value")).await?;
         tokio::time::sleep(Duration::from_millis(100)).await; // TODO: use `propose_index` and remove this sleep after we finished our client.
         let mut maintenance_client =
-            etcd_client::Client::connect(vec![cluster.addrs()["server0"].to_string()], None)
+            etcd_client::Client::connect(vec![cluster.all_members()["server0"].to_string()], None)
                 .await?
                 .maintenance_client();
         let mut stream = maintenance_client.snapshot().await?;

--- a/xlinectl/README.md
+++ b/xlinectl/README.md
@@ -5,21 +5,21 @@ This crate provides a command line client for Xline.
 ## Global Options
 
 - endpoints <SERVER_NAME ADDR>... -- Set Xline endpoints, which are separated by ','
-  
+
   ```bash
   # connect to servers with specific addresses
-  ./xlinectl --endpoints "server0 127.0.0.1:2379"
+  ./xlinectl --endpoints "127.0.0.1:2379"
   ```
 
 - user <USERNAME[:PASSWD]> -- The name of the user, this provide a shorthand to set password
-  
+
   ```bash
   # connect to servers using user `foo` with password `bar`
   ./xlinectl --user foo:bar
   ```
 
 - password <PASSWD> -- The password of the user, should exist if password not set in `--user`
-  
+
   ```bash
   # connect to servers using user `foo` with password `bar`
   ./xlinectl --user foo --password bar
@@ -118,11 +118,11 @@ get [options] <key> [range_end]
 #### Examples
 
 ```bash
-./xlinectl put foo bar      
+./xlinectl put foo bar
 OK
-./xlinectl put foo1 bar1      
+./xlinectl put foo1 bar1
 OK
-./xlinectl put foo2 bar2      
+./xlinectl put foo2 bar2
 OK
 
 # get the key `foo`

--- a/xlinectl/src/main.rs
+++ b/xlinectl/src/main.rs
@@ -148,7 +148,6 @@
         clippy::integer_arithmetic
     )
 )]
-#![allow(unused)]
 
 extern crate utils as ext_utils;
 
@@ -157,7 +156,6 @@ use std::time::Duration;
 use anyhow::Result;
 use clap::{arg, value_parser, Command};
 use ext_utils::config::ClientTimeout;
-use itertools::Itertools;
 use xline_client::{Client, ClientOptions};
 
 use crate::{

--- a/xlinectl/src/main.rs
+++ b/xlinectl/src/main.rs
@@ -148,6 +148,7 @@
         clippy::integer_arithmetic
     )
 )]
+#![allow(unused)]
 
 extern crate utils as ext_utils;
 
@@ -156,12 +157,13 @@ use std::time::Duration;
 use anyhow::Result;
 use clap::{arg, value_parser, Command};
 use ext_utils::config::ClientTimeout;
+use itertools::Itertools;
 use xline_client::{Client, ClientOptions};
 
 use crate::{
     command::{get, put},
     utils::{
-        parser::{parse_endpoints, parse_user},
+        parser::parse_user,
         printer::{set_printer_type, PrinterType},
     },
 };
@@ -182,9 +184,9 @@ fn cli() -> Command {
         .arg_required_else_help(true)
         .allow_external_subcommands(true)
         .arg(
-            arg!(--endpoints <"SERVER_NAME ADDR"> "Xline endpoints, using the format of [name0 addr0, name1 addr1, ...]")
+            arg!(--endpoints <"SERVER_NAME ADDR"> "Xline endpoints, using the format of [addr0, addr1, ...]")
                 .num_args(1..)
-                .default_values(["server0 127.0.0.1:2379"])
+                .default_values(["127.0.0.1:2379"])
                 .value_delimiter(',')
                 .global(true)
                 .help_heading(GLOBAL_HEADING),
@@ -228,7 +230,7 @@ fn cli() -> Command {
 async fn main() -> Result<()> {
     let matches = cli().get_matches();
     let user_opt = parse_user(&matches)?;
-    let endpoints = parse_endpoints(&matches)?;
+    let endpoints = matches.get_many::<String>("endpoints").expect("Required");
     let client_timeout_opt = ClientTimeout::new(
         Duration::from_secs(*matches.get_one("wait_synced_timeout").expect("Required")),
         Duration::from_secs(*matches.get_one("wait_synced_timeout").expect("Required")),

--- a/xlinectl/src/utils/parser.rs
+++ b/xlinectl/src/utils/parser.rs
@@ -1,8 +1,5 @@
-use std::collections::HashMap;
-
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use clap::ArgMatches;
-use itertools::Itertools;
 
 /// Parser user name and password
 pub(crate) fn parse_user(matches: &ArgMatches) -> Result<Option<(String, String)>> {
@@ -35,18 +32,4 @@ pub(crate) fn parse_user(matches: &ArgMatches) -> Result<Option<(String, String)
     } else {
         Ok(None)
     }
-}
-
-/// Parser of endpoints
-pub(crate) fn parse_endpoints(matches: &ArgMatches) -> Result<HashMap<String, String>> {
-    matches
-        .get_many::<String>("endpoints")
-        .expect("Required")
-        .map(|s| {
-            s.split_whitespace()
-                .map(std::borrow::ToOwned::to_owned)
-                .collect_tuple()
-                .ok_or(anyhow!("endpoints argument is invalid"))
-        })
-        .collect::<Result<_>>()
 }


### PR DESCRIPTION

Please briefly answer these questions:
#306 

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
build client without `ServerId`
* what changes does this pull request make?
add client builder
add `fetch_cluster` rpc
allows the client to build without `ServerId`, which automatically fetch the cluster information from the server
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
yes, `Client::new` is removed, use client builder instead