### PR TITLE
refactor: use u64 as ServerId

### DIFF
--- a/curp/proto/message.proto
+++ b/curp/proto/message.proto
@@ -10,7 +10,7 @@ message ProposeRequest {
 }
 
 message ProposeResponse {
-    optional string leader_id = 1;
+    optional uint64 leader_id = 1;
     uint64 term = 2;
     oneof exe_result {
         // The original type is Command::ER
@@ -24,7 +24,7 @@ message FetchLeaderRequest {
 }
 
 message FetchLeaderResponse {
-    optional string leader_id = 1;
+    optional uint64 leader_id = 1;
     uint64 term = 2;
 }
 
@@ -32,8 +32,8 @@ message FetchClusterRequest {
 }
 
 message FetchClusterResponse {
-    optional string leader_id = 1;
-    map<string, string> all_members = 2;
+    optional uint64 leader_id = 1;
+    map<uint64, string> all_members = 2;
     uint64 term = 3;
 }
 
@@ -54,7 +54,7 @@ message WaitSyncedResponse {
 
 message AppendEntriesRequest {
     uint64 term = 1;
-    string leader_id = 2;
+    uint64 leader_id = 2;
     uint64 prev_log_index = 3;
     uint64 prev_log_term = 4;
     repeated bytes entries = 5;
@@ -69,7 +69,7 @@ message AppendEntriesResponse {
 
 message VoteRequest {
     uint64 term = 1;
-    string candidate_id = 2;
+    uint64 candidate_id = 2;
     uint64 last_log_index = 3;
     uint64 last_log_term = 4;
 }
@@ -82,7 +82,7 @@ message VoteResponse {
 
 message InstallSnapshotRequest {
     uint64 term = 1;
-    string leader_id = 2;
+    uint64 leader_id = 2;
     uint64 last_included_index = 3;
     uint64 last_included_term = 4;
     uint64 offset = 5;

--- a/curp/src/client.rs
+++ b/curp/src/client.rs
@@ -67,7 +67,7 @@ impl<C: Command> Builder<C> {
         };
         let connects = rpc::connect(all_members).await.collect();
         let client = Client::<C> {
-            local_server_id: self.local_server_id.clone(),
+            local_server_id: self.local_server_id,
             state: RwLock::new(State::new(None, 0)),
             timeout,
             connects,
@@ -125,7 +125,7 @@ impl<C: Command> Builder<C> {
             .await?;
         let connects = rpc::connect(res.all_members).await.collect();
         let client = Client::<C> {
-            local_server_id: self.local_server_id.clone(),
+            local_server_id: self.local_server_id,
             state: RwLock::new(State::new(res.leader_id, res.term)),
             timeout,
             connects,

--- a/curp/src/error.rs
+++ b/curp/src/error.rs
@@ -4,7 +4,7 @@ use curp_external_api::cmd::Command;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{cmd::ProposeId, ServerId};
+use crate::{cmd::ProposeId, members::ServerId};
 
 /// Error type of client builder
 #[allow(clippy::module_name_repetitions)] // this-error generate code false-positive

--- a/curp/src/lib.rs
+++ b/curp/src/lib.rs
@@ -165,9 +165,6 @@ pub use rpc::{
 };
 pub use snapshot::SnapshotAllocator;
 
-/// Server Id
-pub type ServerId = String;
-
 /// Client side, sending requests and determining requests' state
 pub mod client;
 

--- a/curp/src/members.rs
+++ b/curp/src/members.rs
@@ -1,4 +1,3 @@
-use clippy_utilities::OverflowArithmetic;
 use itertools::Itertools;
 use std::{
     collections::{hash_map::DefaultHasher, HashMap},
@@ -156,13 +155,14 @@ impl ClusterInfo {
     /// Get length of peers
     #[must_use]
     #[inline]
-    pub fn peers_len(&self) -> usize {
-        self.members.len().overflow_sub(1)
+    pub fn members_len(&self) -> usize {
+        self.members.len()
     }
 
     /// Get id by name
     #[must_use]
     #[inline]
+    #[cfg(test)]
     pub fn get_id_by_name(&self, name: &str) -> Option<ServerId> {
         self.members
             .iter()
@@ -210,7 +210,7 @@ mod tests {
         let node1_url = node1.self_address();
         assert!(!peers.contains_key(&node1_id));
         assert_eq!(peers.len(), 2);
-        assert_eq!(node1.peers_len(), peers.len());
+        assert_eq!(node1.members_len(), peers.len() + 1);
 
         let peer_urls = peers.values().collect::<Vec<_>>();
 

--- a/curp/src/rpc/mod.rs
+++ b/curp/src/rpc/mod.rs
@@ -19,7 +19,8 @@ use crate::{
     cmd::{Command, ProposeId},
     error::{CommandSyncError, ProposeError, SyncError},
     log_entry::LogEntry,
-    LogIndex, ServerId,
+    members::ServerId,
+    LogIndex,
 };
 
 /// Rpc connect
@@ -302,7 +303,7 @@ impl VoteRequest {
     /// Create a new vote request
     pub fn new(
         term: u64,
-        candidate_id: String,
+        candidate_id: ServerId,
         last_log_index: LogIndex,
         last_log_term: u64,
     ) -> Self {

--- a/curp/src/server/cmd_worker/mod.rs
+++ b/curp/src/server/cmd_worker/mod.rs
@@ -273,8 +273,9 @@ mod tests {
     use tokio::{sync::mpsc, time::Instant};
     use tracing_test::traced_test;
 
-    use super::*;
     use crate::log_entry::LogEntry;
+
+    use super::*;
 
     // This should happen in fast path in most cases
     #[traced_test]
@@ -568,9 +569,10 @@ mod tests {
         let ce1 = Arc::new(TestCE::new("S1".to_owned(), er_tx, as_tx));
         let (ce_event_tx, task_rx, done_tx) = conflict_checked_mpmc::channel(Arc::clone(&ce1));
         let curp = RawCurp::new_test(3, ce_event_tx.clone(), mock_role_change());
+        let s2_id = curp.cluster().get_id_by_name("S2").unwrap();
         curp.handle_append_entries(
             1,
-            "S3".to_owned(),
+            s2_id,
             0,
             0,
             vec![LogEntry::new_cmd(1, 1, Arc::new(TestCommand::default()))],

--- a/curp/src/server/mod.rs
+++ b/curp/src/server/mod.rs
@@ -15,7 +15,7 @@ use self::curp_node::{CurpError, CurpNode};
 use crate::{
     cmd::{Command, CommandExecutor},
     error::ServerError,
-    members::ClusterMember,
+    members::{ClusterInfo, ServerId},
     role_change::RoleChange,
     rpc::{
         AppendEntriesRequest, AppendEntriesResponse, FetchClusterRequest, FetchClusterResponse,
@@ -23,7 +23,7 @@ use crate::{
         InstallSnapshotRequest, InstallSnapshotResponse, ProposeRequest, ProposeResponse,
         ProtocolServer, VoteRequest, VoteResponse, WaitSyncedRequest, WaitSyncedResponse,
     },
-    ServerId, SnapshotAllocator,
+    SnapshotAllocator,
 };
 
 /// Command worker to do execution and after sync
@@ -89,7 +89,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> crate::rpc::Protocol for Rp
         request: tonic::Request<AppendEntriesRequest>,
     ) -> Result<tonic::Response<AppendEntriesResponse>, tonic::Status> {
         Ok(tonic::Response::new(
-            self.inner.append_entries(request.into_inner())?,
+            self.inner.append_entries(request.get_ref())?,
         ))
     }
 
@@ -154,7 +154,7 @@ impl<C: Command + 'static, RC: RoleChange + 'static> Rpc<C, RC> {
     /// Panic if storage creation failed
     #[inline]
     pub async fn new<CE: CommandExecutor<C> + 'static>(
-        cluster_info: Arc<ClusterMember>,
+        cluster_info: Arc<ClusterInfo>,
         is_leader: bool,
         executor: CE,
         snapshot_allocator: Box<dyn SnapshotAllocator>,
@@ -192,7 +192,7 @@ impl<C: Command + 'static, RC: RoleChange + 'static> Rpc<C, RC> {
     #[allow(clippy::too_many_arguments)]
     #[inline]
     pub async fn run<CE>(
-        cluster_info: Arc<ClusterMember>,
+        cluster_info: Arc<ClusterInfo>,
         is_leader: bool,
         server_port: Option<u16>,
         executor: CE,
@@ -237,7 +237,7 @@ impl<C: Command + 'static, RC: RoleChange + 'static> Rpc<C, RC> {
     #[allow(clippy::too_many_arguments)]
     #[inline]
     pub async fn run_from_listener<CE>(
-        cluster_info: Arc<ClusterMember>,
+        cluster_info: Arc<ClusterInfo>,
         is_leader: bool,
         listener: TcpListener,
         executor: CE,
@@ -275,7 +275,7 @@ impl<C: Command + 'static, RC: RoleChange + 'static> Rpc<C, RC> {
     #[allow(clippy::too_many_arguments)]
     #[inline]
     pub async fn run_from_addr<CE>(
-        cluster_info: Arc<ClusterMember>,
+        cluster_info: Arc<ClusterInfo>,
         is_leader: bool,
         addr: std::net::SocketAddr,
         executor: CE,

--- a/curp/src/server/raw_curp/mod.rs
+++ b/curp/src/server/raw_curp/mod.rs
@@ -472,14 +472,15 @@ impl<C: 'static + Command, RC: RoleChange + 'static> RawCurp<C, RC> {
             return Err(());
         }
 
+        let mut cst_w = self.cst.lock();
+        let _ig = cst_w.votes_received.insert(id, vote_granted);
+
         if !vote_granted {
             return Ok(false);
         }
 
-        let mut cst_w = self.cst.lock();
         debug!("{}'s vote is granted by server {}", self.id(), id);
 
-        let _ig = cst_w.votes_received.insert(id, vote_granted);
         assert!(
             cst_w.sps.insert(id, spec_pool).is_none(),
             "a server can't vote twice"
@@ -1009,7 +1010,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> RawCurp<C, RC> {
 
     /// Get quorum: the smallest number of servers who must be online for the cluster to work
     fn quorum(&self) -> u64 {
-        ((self.ctx.cluster_info.peers_len() + 1) / 2 + 1).numeric_cast()
+        (self.ctx.cluster_info.members_len() / 2 + 1).numeric_cast()
     }
 
     /// Get `recover_quorum`: the smallest number of servers who must contain a command in speculative pool for it to be recovered

--- a/curp/src/server/storage/db.rs
+++ b/curp/src/server/storage/db.rs
@@ -5,7 +5,7 @@ use engine::{Engine, EngineType, StorageEngine, WriteOperation};
 use utils::config::StorageConfig;
 
 use super::{StorageApi, StorageError};
-use crate::{cmd::Command, log_entry::LogEntry, ServerId};
+use crate::{cmd::Command, log_entry::LogEntry, members::ServerId};
 
 /// Key for persisted state
 const VOTE_FOR: &[u8] = b"VoteFor";
@@ -105,8 +105,8 @@ mod tests {
         let storage_cfg = StorageConfig::RocksDB(db_dir.clone());
         {
             let s = DB::<TestCommand>::open(&storage_cfg)?;
-            s.flush_voted_for(1, "S2".to_string()).await?;
-            s.flush_voted_for(3, "S1".to_string()).await?;
+            s.flush_voted_for(1, 222).await?;
+            s.flush_voted_for(3, 111).await?;
             let entry0 = LogEntry::new_cmd(1, 3, Arc::new(TestCommand::default()));
             let entry1 = LogEntry::new_cmd(2, 3, Arc::new(TestCommand::default()));
             let entry2 = LogEntry::new_cmd(3, 3, Arc::new(TestCommand::default()));
@@ -119,7 +119,7 @@ mod tests {
         {
             let s = DB::<TestCommand>::open(&storage_cfg)?;
             let (voted_for, entries) = s.recover().await?;
-            assert_eq!(voted_for, Some((3, "S1".to_string())));
+            assert_eq!(voted_for, Some((3, 111)));
             assert_eq!(entries[0].index, 1);
             assert_eq!(entries[1].index, 2);
             assert_eq!(entries[2].index, 3);

--- a/curp/src/server/storage/mod.rs
+++ b/curp/src/server/storage/mod.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use engine::EngineError;
 use thiserror::Error;
 
-use crate::{cmd::Command, log_entry::LogEntry, ServerId};
+use crate::{cmd::Command, log_entry::LogEntry, members::ServerId};
 
 /// Storage layer error
 #[derive(Error, Debug)]

--- a/curp/tests/server.rs
+++ b/curp/tests/server.rs
@@ -45,7 +45,7 @@ async fn basic_propose() {
 
 #[tokio::test]
 #[abort_on_panic]
-async fn fetch_cluster() {
+async fn client_build_from_addrs_shoulde_fetch_cluster_from_server() {
     init_logger();
     let group = CurpGroup::new(3).await;
 

--- a/simulation/tests/it/curp/server_election.rs
+++ b/simulation/tests/it/curp/server_election.rs
@@ -1,25 +1,26 @@
+use curp::members::ServerId;
 use curp_test_utils::{init_logger, sleep_secs, test_cmd::TestCommand};
 use simulation::curp_group::CurpGroup;
 use utils::config::ClientTimeout;
 
 /// Wait some time for the election to finish, and get the leader to ensure that the election is
 /// completed.
-async fn wait_for_election(group: &CurpGroup) -> (String, u64) {
+async fn wait_for_election(group: &CurpGroup) -> (ServerId, u64) {
     sleep_secs(15).await;
     group.get_leader().await
 }
 
-fn check_leader_state(group: &CurpGroup, leader: &String) {
-    let node = group.nodes.get(leader).unwrap();
+fn check_leader_state(group: &CurpGroup, leader: ServerId) {
+    let node = group.nodes.get(&leader).unwrap();
     assert!(node.role_change_arc.get_is_leader());
 }
 
-fn check_non_leader_state(group: &CurpGroup, group_size: usize, leader: &str) {
+fn check_non_leader_state(group: &CurpGroup, group_size: usize, leader: ServerId) {
     let majority: usize = group_size / 2 + 1;
     let non_leader_node_cnt = group
         .nodes
         .iter()
-        .filter(|(id, node)| id.as_str() != leader && !node.role_change_arc.get_is_leader())
+        .filter(|(id, node)| **id != leader && !node.role_change_arc.get_is_leader())
         .count();
     assert!(
         non_leader_node_cnt >= majority - 1,
@@ -27,7 +28,7 @@ fn check_non_leader_state(group: &CurpGroup, group_size: usize, leader: &str) {
     );
 }
 
-fn check_role_state(group: &CurpGroup, group_size: usize, leader: &String) {
+fn check_role_state(group: &CurpGroup, group_size: usize, leader: ServerId) {
     check_leader_state(group, leader);
     check_non_leader_state(group, group_size, leader);
 }
@@ -39,13 +40,13 @@ async fn election() {
 
     let group = CurpGroup::new(5).await;
     let leader0 = group.get_leader().await.0;
-    check_role_state(&group, 5, &leader0);
-    group.disable_node(&leader0);
+    check_role_state(&group, 5, leader0);
+    group.disable_node(leader0);
 
     // check whether there is exact one leader in the group
     let (leader1, _term) = wait_for_election(&group).await;
     let term1 = group.get_term_checked().await;
-    check_role_state(&group, 5, &leader0);
+    check_role_state(&group, 5, leader0);
 
     // check after some time, the term and the leader is still not changed
     sleep_secs(15).await;
@@ -55,7 +56,7 @@ async fn election() {
         .expect("There should be one leader")
         .0;
     let term2 = group.get_term_checked().await;
-    check_role_state(&group, 5, &leader0);
+    check_role_state(&group, 5, leader0);
 
     assert_ne!(leader0, leader1);
     assert_eq!(term1, term2);
@@ -74,25 +75,25 @@ async fn reelect() {
     // check whether there is exact one leader in the group
     let leader1 = group.get_leader().await.0;
     let term1 = group.get_term_checked().await;
-    check_role_state(&group, 5, &leader1);
+    check_role_state(&group, 5, leader1);
     // disable leader 1
-    group.disable_node(&leader1);
+    group.disable_node(leader1);
     println!("disable leader {leader1}");
 
     // after some time, a new leader should be elected
     let (leader2, term2) = wait_for_election(&group).await;
-    check_role_state(&group, 5, &leader2);
+    check_role_state(&group, 5, leader2);
 
     assert_ne!(term1, term2);
     assert_ne!(leader1, leader2);
 
     // disable leader 2
-    group.disable_node(&leader2);
+    group.disable_node(leader2);
     println!("disable leader {leader2}");
 
     // after some time, a new leader should be elected
     let (leader3, term3) = wait_for_election(&group).await;
-    check_role_state(&group, 5, &leader3);
+    check_role_state(&group, 5, leader3);
 
     assert_ne!(term1, term3);
     assert_ne!(term2, term3);
@@ -100,7 +101,7 @@ async fn reelect() {
     assert_ne!(leader2, leader3);
 
     // disable leader 3
-    group.disable_node(&leader3);
+    group.disable_node(leader3);
     println!("disable leader {leader3}");
 
     // after some time, no leader should be elected
@@ -109,12 +110,12 @@ async fn reelect() {
 
     // recover network partition
     println!("enable all");
-    group.enable_node(&leader1);
-    group.enable_node(&leader2);
-    group.enable_node(&leader3);
+    group.enable_node(leader1);
+    group.enable_node(leader2);
+    group.enable_node(leader3);
 
     let (final_leader, final_term) = wait_for_election(&group).await;
-    check_role_state(&group, 5, &final_leader);
+    check_role_state(&group, 5, final_leader);
     assert!(final_term > term3);
 
     group.stop().await;
@@ -137,8 +138,8 @@ async fn propose_after_reelect() {
     );
 
     let leader1 = group.get_leader().await.0;
-    check_role_state(&group, 5, &leader1);
-    group.disable_node(&leader1);
+    check_role_state(&group, 5, leader1);
+    group.disable_node(leader1);
 
     let (_leader, _term) = wait_for_election(&group).await;
     assert_eq!(

--- a/xline-test-utils/src/lib.rs
+++ b/xline-test-utils/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
     sync::Arc,
 };
 
-use curp::{members::ClusterMember, ServerId};
+use curp::members::ClusterInfo;
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use tokio::{
@@ -20,7 +20,7 @@ pub struct Cluster {
     /// listeners of members
     listeners: BTreeMap<usize, TcpListener>,
     /// address of members
-    all_members: HashMap<ServerId, String>,
+    all_members: HashMap<String, String>,
     /// Client of cluster
     client: Option<Client>,
     /// Stop sender
@@ -74,7 +74,7 @@ impl Cluster {
                 path
             };
             let db: Arc<DB> = DB::open(&StorageConfig::RocksDB(path.clone())).unwrap();
-            let cluster_info = ClusterMember::new(self.all_members.clone(), name.clone());
+            let cluster_info = ClusterInfo::new(self.all_members.clone(), &name);
             tokio::spawn(async move {
                 let server = XlineServer::new(
                     cluster_info.into(),
@@ -121,7 +121,7 @@ impl Cluster {
         self.client.as_mut().unwrap()
     }
 
-    pub fn all_members(&self) -> &HashMap<ServerId, String> {
+    pub fn all_members(&self) -> &HashMap<String, String> {
         &self.all_members
     }
 

--- a/xline/src/header_gen.rs
+++ b/xline/src/header_gen.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use curp::members::ServerId;
 use parking_lot::Mutex;
 
 use crate::{revision_number::RevisionNumberGenerator, rpc::ResponseHeader};
@@ -21,7 +22,7 @@ pub(crate) struct HeaderGenerator {
 
 impl HeaderGenerator {
     /// New `HeaderGenerator`
-    pub(crate) fn new(cluster_id: u64, member_id: u64) -> Self {
+    pub(crate) fn new(cluster_id: u64, member_id: ServerId) -> Self {
         Self {
             cluster_id,
             member_id,

--- a/xline/src/id_gen.rs
+++ b/xline/src/id_gen.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use clippy_utilities::{Cast, OverflowArithmetic};
+use curp::members::ServerId;
 
 /// Generator of unique id
 /// id format:
@@ -21,7 +22,7 @@ pub(crate) struct IdGenerator {
 
 impl IdGenerator {
     /// New `IdGenerator`
-    pub(crate) fn new(member_id: u64) -> Self {
+    pub(crate) fn new(member_id: ServerId) -> Self {
         let prefix = member_id.overflowing_shl(48).0;
         let mut ts = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/xline/src/main.rs
+++ b/xline/src/main.rs
@@ -140,7 +140,7 @@ use std::{collections::HashMap, env, net::ToSocketAddrs, path::PathBuf, time::Du
 
 use anyhow::{anyhow, Result};
 use clap::Parser;
-use curp::{members::ClusterMember, ServerId};
+use curp::members::ClusterInfo;
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use opentelemetry::{global, runtime::Tokio, sdk::propagation::TraceContextPropagator};
 use opentelemetry_contrib::trace::exporter::jaeger_json::JaegerJsonExporter;
@@ -172,9 +172,9 @@ struct ServerArgs {
     /// Node name
     #[clap(long)]
     name: String,
-    /// Cluster peers. eg: 192.168.x.x:8080 192.168.x.x:8080
-    #[clap(long,value_parser = parse_members)]
-    members: HashMap<ServerId, String>,
+    /// Cluster peers. eg: node1=192.168.x.x:8080,node2=192.168.x.x:8080
+    #[clap(long, value_parser = parse_members)]
+    members: HashMap<String, String>,
     /// If node is leader
     #[clap(long)]
     is_leader: bool,
@@ -513,7 +513,7 @@ async fn main() -> Result<()> {
 
     let name = cluster_config.name().clone();
     let all_members = cluster_config.members().clone();
-    let cluster_info = ClusterMember::new(all_members, name);
+    let cluster_info = ClusterInfo::new(all_members, &name);
 
     let db_proxy = DB::open(storage_config)?;
     let server = XlineServer::new(


### PR DESCRIPTION
Please briefly answer these questions:
#306 
Based on #412 
* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
If we use `String` as the server ID, it is not compatible with the `etcd`'s membership change interface, and using String as the server ID will require clone in many cases, So we need to turn server ID into u64.
* what changes does this pull request make?
use u64 as ServerId instead of String, and  refactor check vote logic
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
yes, All server ID related parts need to be replaced with `u64`