### PR TITLE
chore: disallow use of EventListener::wait

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,5 @@
+disallowed-methods = [
+    { path = "event_listener::EventListener::wait", reason = "no blocking single-thread runtime, please use .await instead" },
+    { path = "event_listener::EventListener::wait_timeout", reason = "no blocking single-thread runtime, please use .await instead" },
+    { path = "event_listener::EventListener::wait_deadline", reason = "no blocking single-thread runtime, please use .await instead" },
+]


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    Described in `clippy.toml`

* what changes does this pull request make?

    As the title said

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

    No