### PR TITLE
fix: improve readability of bootstrap errors

### DIFF
--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -177,6 +177,9 @@ pub enum ConfigParseError {
     /// Invalid values
     #[error("Invalid Value: {0}")]
     InvalidValue(String),
+    /// Invalid config file path
+    #[error("Couldn't read file {0}")]
+    IoError(String, #[source] std::io::Error),
 }
 
 /// parse members from string

--- a/xline/src/main.rs
+++ b/xline/src/main.rs
@@ -472,7 +472,12 @@ async fn main() -> Result<()> {
     let config: XlineServerConfig = if env::args_os().len() == 1 {
         let path =
             env::var("XLINE_SERVER_CONFIG").unwrap_or_else(|_| "/etc/xline_server.conf".to_owned());
-        let config_file = fs::read_to_string(&path).await?;
+        let config_file = match fs::read_to_string(&path).await {
+            Ok(config_file) => config_file,
+            Err(e) => {
+                panic!("read {:?} failed: {:?}", &path, e);
+            }
+        };
         toml::from_str(&config_file)?
     } else {
         let server_args: ServerArgs = ServerArgs::parse();


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
#330 
When the configuration file doesn't exist, Xline will throw out an error message, "Error: No such file or directory (os error 2)", which lacks readability. We need to improve its readability by adding the configuration file name in this error message.

* what changes does this pull request make?
Add error messages when reading of the config file fails.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)