### PR TITLE
feature: add `apply_conf_change` method for `RawCurp`

### DIFF
--- a/curp/proto/message.proto
+++ b/curp/proto/message.proto
@@ -89,11 +89,35 @@ message ShutdownResponse {
     optional bytes error = 3;
 }
 
+
+
+message ProposeConfChangeRequest {
+    enum ConfChangeType {
+        Add = 0;
+        AddLearner = 1;
+        Remove = 2;
+        Update = 3;
+    }
+    message ConfChange {
+        ConfChangeType change_type = 1;
+        uint64 node_id = 2;
+        string address = 3;
+    }
+    string id = 1;
+    repeated ConfChange changes = 2;
+}
+
+message ProposeConfChangeResponse {
+    bool ok = 1;
+}
+
+
 service Protocol {
     rpc Propose(commandpb.ProposeRequest) returns (commandpb.ProposeResponse);
     rpc WaitSynced(commandpb.WaitSyncedRequest)
         returns (commandpb.WaitSyncedResponse);
     rpc Shutdown(ShutdownRequest) returns (ShutdownResponse);
+    rpc ProposeConfChange (ProposeConfChangeRequest) returns (ProposeConfChangeResponse);
     rpc AppendEntries(AppendEntriesRequest) returns (AppendEntriesResponse);
     rpc Vote(VoteRequest) returns (VoteResponse);
     rpc InstallSnapshot(stream InstallSnapshotRequest)

--- a/curp/proto/message.proto
+++ b/curp/proto/message.proto
@@ -89,8 +89,6 @@ message ShutdownResponse {
     optional bytes error = 3;
 }
 
-
-
 message ProposeConfChangeRequest {
     enum ConfChangeType {
         Add = 0;
@@ -101,14 +99,27 @@ message ProposeConfChangeRequest {
     message ConfChange {
         ConfChangeType change_type = 1;
         uint64 node_id = 2;
-        string address = 3;
+        repeated string address = 3;
     }
     string id = 1;
     repeated ConfChange changes = 2;
 }
 
+message Member {
+    uint64 id = 1;
+    string name = 2;
+    string addrs = 3;
+    bool is_learner = 4;
+};
+
 message ProposeConfChangeResponse {
-    bool ok = 1;
+    enum ConfChangeError {
+        InvalidConfig = 0;
+        NodeNotExists = 1;
+        NodeAlreadyExists = 2;
+    }
+    optional ConfChangeError error = 1;
+    repeated Member members = 2;
 }
 
 

--- a/curp/src/error.rs
+++ b/curp/src/error.rs
@@ -304,6 +304,22 @@ impl<C: Command> From<WaitSyncError> for CommandSyncError<C> {
     }
 }
 
+/// Error type of `apply_conf_change`
+#[derive(Error, Debug, Clone, Copy)]
+#[allow(clippy::module_name_repetitions)] // this-error generate code false-positive
+#[non_exhaustive]
+pub enum ApplyConfChangeError {
+    /// Config is invalid after applying the conf change
+    #[error("invalid config")]
+    InvalidConfig,
+    /// The node to be removed does not exist
+    #[error("node {0} does not exist")]
+    NodeNotExists(ServerId),
+    /// The node to be added already exists
+    #[error("node {0} already exists")]
+    NodeAlreadyExists(ServerId),
+}
+
 #[cfg(test)]
 mod test {
     use curp_test_utils::test_cmd::{ExecuteError, TestCommand};

--- a/curp/src/members.rs
+++ b/curp/src/members.rs
@@ -81,7 +81,7 @@ impl ClusterInfo {
     /// Get all members
     #[must_use]
     #[inline]
-    pub fn get_members(&self) -> HashMap<ServerId, Member> {
+    pub fn all_members(&self) -> HashMap<ServerId, Member> {
         self.members
             .iter()
             .map(|t| (t.id, t.value().clone()))
@@ -113,10 +113,7 @@ impl ClusterInfo {
     #[must_use]
     #[inline]
     pub fn address(&self, id: ServerId) -> Option<String> {
-        self.members
-            .iter()
-            .find(|t| t.id == id)
-            .map(|t| t.address.clone())
+        self.members.get(&id).map(|t| t.address.clone())
     }
 
     /// Get the current member

--- a/curp/src/rpc/mod.rs
+++ b/curp/src/rpc/mod.rs
@@ -453,7 +453,7 @@ impl ConfChange {
         Self {
             change_type: ConfChangeType::Add as i32,
             node_id,
-            address,
+            address: vec![address],
         }
     }
 
@@ -462,7 +462,7 @@ impl ConfChange {
         Self {
             change_type: ConfChangeType::Remove as i32,
             node_id,
-            address: String::new(),
+            address: vec![],
         }
     }
 
@@ -471,7 +471,7 @@ impl ConfChange {
         Self {
             change_type: ConfChangeType::Update as i32,
             node_id,
-            address,
+            address: vec![address],
         }
     }
 
@@ -480,7 +480,7 @@ impl ConfChange {
         Self {
             change_type: ConfChangeType::AddLearner as i32,
             node_id,
-            address,
+            address: vec![address],
         }
     }
 }

--- a/curp/src/rpc/mod.rs
+++ b/curp/src/rpc/mod.rs
@@ -445,8 +445,8 @@ impl ShutdownRequest {
     }
 }
 
-#[allow(dead_code)] // TODO: remove
-#[allow(clippy::as_conversions)] // those conversions are safe
+#[allow(dead_code)] // TODO: remove this when we implement conf change
+#[allow(clippy::as_conversions)] // ConfChangeType is so small that it won't exceed the range of i32 type.
 impl ConfChange {
     /// Create a new `ConfChange` to add a node
     pub(crate) fn add(node_id: ServerId, address: String) -> Self {

--- a/curp/src/rpc/mod.rs
+++ b/curp/src/rpc/mod.rs
@@ -18,9 +18,12 @@ pub(crate) use self::proto::{
         RedirectData, WaitSyncError as PbWaitSyncErrorOuter,
     },
     messagepb::{
-        fetch_read_state_response::ReadState, protocol_server::Protocol, AppendEntriesRequest,
-        AppendEntriesResponse, FetchClusterRequest, FetchClusterResponse, FetchReadStateRequest,
-        FetchReadStateResponse, IdSet, InstallSnapshotRequest, InstallSnapshotResponse,
+        fetch_read_state_response::ReadState,
+        propose_conf_change_request::{ConfChange, ConfChangeType},
+        protocol_server::Protocol,
+        AppendEntriesRequest, AppendEntriesResponse, FetchClusterRequest, FetchClusterResponse,
+        FetchReadStateRequest, FetchReadStateResponse, IdSet, InstallSnapshotRequest,
+        InstallSnapshotResponse, ProposeConfChangeRequest, ProposeConfChangeResponse,
         ShutdownRequest, ShutdownResponse, VoteRequest, VoteResponse,
     },
 };
@@ -439,5 +442,45 @@ impl ShutdownRequest {
     /// Create a new shutdown request
     pub(crate) fn new(id: ProposeId) -> Self {
         Self { id: id.into() }
+    }
+}
+
+#[allow(dead_code)] // TODO: remove
+#[allow(clippy::as_conversions)] // those conversions are safe
+impl ConfChange {
+    /// Create a new `ConfChange` to add a node
+    pub(crate) fn add(node_id: ServerId, address: String) -> Self {
+        Self {
+            change_type: ConfChangeType::Add as i32,
+            node_id,
+            address,
+        }
+    }
+
+    /// Create a new `ConfChange` to remove a node
+    pub(crate) fn remove(node_id: ServerId) -> Self {
+        Self {
+            change_type: ConfChangeType::Remove as i32,
+            node_id,
+            address: String::new(),
+        }
+    }
+
+    /// Create a new `ConfChange` to update a node
+    pub(crate) fn update(node_id: ServerId, address: String) -> Self {
+        Self {
+            change_type: ConfChangeType::Update as i32,
+            node_id,
+            address,
+        }
+    }
+
+    /// Create a new `ConfChange` to add a learner node
+    pub(crate) fn add_learner(node_id: ServerId, address: String) -> Self {
+        Self {
+            change_type: ConfChangeType::AddLearner as i32,
+            node_id,
+            address,
+        }
     }
 }

--- a/curp/src/server/cmd_worker/mod.rs
+++ b/curp/src/server/cmd_worker/mod.rs
@@ -246,7 +246,7 @@ struct TaskRx<C: Command>(flume::Receiver<Task<C>>);
 
 /// Send cmd to background execution worker
 #[cfg_attr(test, automock)]
-pub(super) trait CEEventTxApi<C: Command + 'static>: Send + Sync + 'static + Debug {
+pub(super) trait CEEventTxApi<C: Command + 'static>: Send + Sync + 'static {
     /// Send cmd to background cmd worker for speculative execution
     fn send_sp_exe(&self, entry: Arc<LogEntry<C>>);
 

--- a/curp/src/server/cmd_worker/mod.rs
+++ b/curp/src/server/cmd_worker/mod.rs
@@ -246,7 +246,7 @@ struct TaskRx<C: Command>(flume::Receiver<Task<C>>);
 
 /// Send cmd to background execution worker
 #[cfg_attr(test, automock)]
-pub(super) trait CEEventTxApi<C: Command + 'static>: Send + Sync + 'static {
+pub(super) trait CEEventTxApi<C: Command + 'static>: Send + Sync + 'static + Debug {
     /// Send cmd to background cmd worker for speculative execution
     fn send_sp_exe(&self, entry: Arc<LogEntry<C>>);
 

--- a/curp/src/server/curp_node.rs
+++ b/curp/src/server/curp_node.rs
@@ -142,7 +142,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
         Ok(resp)
     }
 
-    /// Handle `propose_shutdown` requests
+    /// Handle `Shutdown` requests
     pub(super) async fn shutdown(
         &self,
         request: ShutdownRequest,
@@ -213,7 +213,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
         Ok(resp)
     }
 
-    /// handle "wait synced" request
+    /// handle `WaitSynced` requests
     pub(super) async fn wait_synced(
         &self,
         req: WaitSyncedRequest,
@@ -233,7 +233,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
         Ok(resp)
     }
 
-    /// Handle fetch leader requests
+    /// Handle `FetchLeader` requests
     #[allow(clippy::unnecessary_wraps, clippy::needless_pass_by_value)] // To keep type consistent with other request handlers
     pub(super) fn fetch_leader(
         &self,
@@ -243,7 +243,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
         Ok(FetchLeaderResponse::new(leader_id, term))
     }
 
-    /// Handle fetch cluster requests
+    /// Handle `FetchCluster` requests
     #[allow(clippy::unnecessary_wraps, clippy::needless_pass_by_value)] // To keep type consistent with other request handlers
     pub(super) fn fetch_cluster(
         &self,
@@ -254,7 +254,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
         Ok(FetchClusterResponse::new(leader_id, all_members, term))
     }
 
-    /// Install snapshot
+    /// Handle `InstallSnapshot` stream
     #[allow(clippy::integer_arithmetic)] // can't overflow
     pub(super) async fn install_snapshot(
         &self,
@@ -320,7 +320,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
         ))
     }
 
-    /// Handle fetch read state requests
+    /// Handle `FetchReadState` requests
     #[allow(clippy::needless_pass_by_value)] // To keep type consistent with other request handlers
     pub(super) fn fetch_read_state(
         &self,

--- a/curp/src/server/curp_node.rs
+++ b/curp/src/server/curp_node.rs
@@ -163,7 +163,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
     }
 
     /// Handle `ProposeConfChange` requests
-    #[allow(clippy::todo, clippy::unused_async)] // TODO: implement this
+    #[allow(clippy::todo, clippy::unused_async)] // TODO: this method will be implemented in #437
     pub(super) async fn propose_conf_change(
         &self,
         _req: ProposeConfChangeRequest,

--- a/curp/src/server/mod.rs
+++ b/curp/src/server/mod.rs
@@ -21,9 +21,10 @@ use crate::{
     rpc::{
         AppendEntriesRequest, AppendEntriesResponse, FetchClusterRequest, FetchClusterResponse,
         FetchLeaderRequest, FetchLeaderResponse, FetchReadStateRequest, FetchReadStateResponse,
-        InstallSnapshotRequest, InstallSnapshotResponse, ProposeRequest, ProposeResponse,
-        ProtocolServer, ShutdownRequest, ShutdownResponse, VoteRequest, VoteResponse,
-        WaitSyncedRequest, WaitSyncedResponse,
+        InstallSnapshotRequest, InstallSnapshotResponse, ProposeConfChangeRequest,
+        ProposeConfChangeResponse, ProposeRequest, ProposeResponse, ProtocolServer,
+        ShutdownRequest, ShutdownResponse, VoteRequest, VoteResponse, WaitSyncedRequest,
+        WaitSyncedResponse,
     },
 };
 
@@ -81,6 +82,17 @@ impl<C: 'static + Command, RC: RoleChange + 'static> crate::rpc::Protocol for Rp
         request.metadata().extract_span();
         Ok(tonic::Response::new(
             self.inner.shutdown(request.into_inner()).await?,
+        ))
+    }
+
+    #[instrument(skip_all, name = "curp_propose_conf_change")]
+    async fn propose_conf_change(
+        &self,
+        request: tonic::Request<ProposeConfChangeRequest>,
+    ) -> Result<tonic::Response<ProposeConfChangeResponse>, tonic::Status> {
+        request.metadata().extract_span();
+        Ok(tonic::Response::new(
+            self.inner.propose_conf_change(request.into_inner()).await?,
         ))
     }
 

--- a/curp/src/server/raw_curp/mod.rs
+++ b/curp/src/server/raw_curp/mod.rs
@@ -130,7 +130,6 @@ enum Role {
 }
 
 /// Relevant context for Curp
-#[derive(Debug)]
 struct Context<C: Command, RC: RoleChange> {
     /// Cluster information
     cluster_info: Arc<ClusterInfo>,
@@ -154,6 +153,24 @@ struct Context<C: Command, RC: RoleChange> {
     leader_event: Arc<Event>,
     /// Leader change callback
     role_change: RC,
+}
+
+impl<C: Command, RC: RoleChange> Debug for Context<C, RC> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Context")
+            .field("cluster_info", &self.cluster_info)
+            .field("cfg", &self.cfg)
+            .field("cb", &self.cb)
+            .field("sp", &self.sp)
+            .field("ucp", &self.ucp)
+            .field("leader_tx", &self.leader_tx)
+            .field("election_tick", &self.election_tick)
+            .field("cmd_tx", &"CEEventTxApi")
+            .field("sync_events", &self.sync_events)
+            .field("leader_event", &self.leader_event)
+            .field("role_change", &self.role_change)
+            .finish()
+    }
 }
 
 // Tick
@@ -853,7 +870,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> RawCurp<C, RC> {
     }
 
     /// Apply conf changes and return true if self node is removed
-    #[allow(unused)] // TODO: remove
+    #[allow(unused)] // TODO: remove this when we implement conf change
     pub(super) fn apply_conf_change(
         &self,
         changes: Vec<ConfChange>,
@@ -869,7 +886,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> RawCurp<C, RC> {
     }
 
     /// Check if the new config is valid
-    #[allow(clippy::unimplemented)] // TODO: remove
+    #[allow(clippy::unimplemented)] // TODO: remove this when we implement conf change
     fn check_new_config(&self, conf_change: &ConfChange) -> Result<(), ApplyConfChangeError> {
         let mut statuses_ids = self
             .lst

--- a/curp/src/server/raw_curp/state.rs
+++ b/curp/src/server/raw_curp/state.rs
@@ -120,7 +120,7 @@ impl LeaderState {
         }
     }
 
-    /// Get all status for a server
+    /// Get statuses for all servers
     pub(super) fn get_all_statuses(&self) -> HashMap<ServerId, FollowerStatus> {
         self.statuses
             .iter()

--- a/curp/src/server/raw_curp/tests.rs
+++ b/curp/src/server/raw_curp/tests.rs
@@ -30,7 +30,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> RawCurp<C, RC> {
     }
 
     fn contains(&self, id: ServerId) -> bool {
-        self.cluster().get_members().contains_key(&id)
+        self.cluster().all_members().contains_key(&id)
             && self.ctx.sync_events.contains_key(&id)
             && self.lst.get_all_statuses().contains_key(&id)
             && self.cst.lock().config.voters().contains(&id)
@@ -680,7 +680,7 @@ fn is_synced_should_return_true_when_followers_caught_up_with_leader() {
 
 #[traced_test]
 #[test]
-fn add_node() {
+fn add_node_should_add_new_node_to_curp() {
     let curp = {
         let exe_tx = MockCEEventTxApi::<TestCommand>::default();
         Arc::new(RawCurp::new_test(3, exe_tx, mock_role_change()))
@@ -692,7 +692,7 @@ fn add_node() {
 
 #[traced_test]
 #[test]
-fn add_exists_node() {
+fn add_exists_node_should_return_node_already_exists_error() {
     let curp = {
         let exe_tx = MockCEEventTxApi::<TestCommand>::default();
         Arc::new(RawCurp::new_test(3, exe_tx, mock_role_change()))
@@ -709,7 +709,7 @@ fn add_exists_node() {
 
 #[traced_test]
 #[test]
-fn remove_node() {
+fn remove_node_should_remove_node_from_curp() {
     let curp = {
         let exe_tx = MockCEEventTxApi::<TestCommand>::default();
         Arc::new(RawCurp::new_test(5, exe_tx, mock_role_change()))
@@ -723,7 +723,7 @@ fn remove_node() {
 
 #[traced_test]
 #[test]
-fn remove_self_node() {
+fn apply_conf_change_shoulde_return_true_when_remove_self_node() {
     let curp = {
         let exe_tx = MockCEEventTxApi::<TestCommand>::default();
         Arc::new(RawCurp::new_test(5, exe_tx, mock_role_change()))
@@ -736,7 +736,7 @@ fn remove_self_node() {
 
 #[traced_test]
 #[test]
-fn remove_non_exists_node() {
+fn remove_non_exists_node_should_return_node_not_exists_error() {
     let curp = {
         let exe_tx = MockCEEventTxApi::<TestCommand>::default();
         Arc::new(RawCurp::new_test(5, exe_tx, mock_role_change()))
@@ -748,7 +748,7 @@ fn remove_non_exists_node() {
 
 #[traced_test]
 #[test]
-fn remove_node_less_than_3() {
+fn remove_node_should_return_invalid_config_error_when_nodes_count_less_than_3() {
     let curp = {
         let exe_tx = MockCEEventTxApi::<TestCommand>::default();
         Arc::new(RawCurp::new_test(3, exe_tx, mock_role_change()))
@@ -761,7 +761,7 @@ fn remove_node_less_than_3() {
 
 #[traced_test]
 #[test]
-fn update_node() {
+fn update_node_should_update_the_address_of_node() {
     let curp = {
         let exe_tx = MockCEEventTxApi::<TestCommand>::default();
         Arc::new(RawCurp::new_test(3, exe_tx, mock_role_change()))

--- a/curp/tests/common/curp_group.rs
+++ b/curp/tests/common/curp_group.rs
@@ -118,7 +118,7 @@ impl CurpGroup {
                 let ce = TestCE::new(name.clone(), exe_tx, as_tx, xline_storage_config);
 
                 let cluster_info = Arc::new(ClusterInfo::new(all_members.clone(), &name));
-                all = cluster_info.all_members();
+                all = cluster_info.all_members_addrs();
                 let id = cluster_info.self_id();
 
                 let role_change_cb = TestRoleChange::default();

--- a/simulation/src/curp_group.rs
+++ b/simulation/src/curp_group.rs
@@ -75,7 +75,7 @@ impl CurpGroup {
                 let store = Arc::new(Mutex::new(None));
 
                 let cluster_info = Arc::new(ClusterInfo::new(all.clone(), &name));
-                all_members = cluster_info.all_members();
+                all_members = cluster_info.all_members_addrs();
                 let id = cluster_info.self_id();
                 let storage_cfg = StorageConfig::RocksDB(storage_path.clone());
                 let store_c = Arc::clone(&store);

--- a/xline/src/server/lease_server.rs
+++ b/xline/src/server/lease_server.rs
@@ -246,7 +246,7 @@ where
                     )
                 });
                 break self
-                    .follower_keep_alive(request_stream, leader_addr)
+                    .follower_keep_alive(request_stream, &leader_addr)
                     .await?;
             }
         };

--- a/xline/src/server/xline_server.rs
+++ b/xline/src/server/xline_server.rs
@@ -326,7 +326,7 @@ impl XlineServer {
             CurpClient::builder()
                 .local_server_id(self.cluster_info.self_id())
                 .config(self.client_config)
-                .build_from_all_members(self.cluster_info.all_members())
+                .build_from_all_members(self.cluster_info.all_members_addrs())
                 .await?,
         );
 
@@ -366,13 +366,13 @@ impl XlineServer {
                 id_barrier,
                 *self.server_timeout.range_retry_timeout(),
                 Arc::clone(&client),
-                self.cluster_info.self_name().to_owned(),
+                self.cluster_info.self_name(),
             ),
             LockServer::new(
                 Arc::clone(&client),
                 Arc::clone(&id_gen),
-                self.cluster_info.self_name().to_owned(),
-                self.cluster_info.self_address().to_owned(),
+                self.cluster_info.self_name(),
+                self.cluster_info.self_address(),
             ),
             LeaseServer::new(
                 lease_storage,
@@ -381,11 +381,7 @@ impl XlineServer {
                 id_gen,
                 Arc::clone(&self.cluster_info),
             ),
-            AuthServer::new(
-                auth_storage,
-                client,
-                self.cluster_info.self_name().to_owned(),
-            ),
+            AuthServer::new(auth_storage, client, self.cluster_info.self_name()),
             WatchServer::new(
                 watcher,
                 Arc::clone(&header_gen),


### PR DESCRIPTION
Please briefly answer these questions:
#306 
* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
apply config change to curp
* what changes does this pull request make?
refactor data structures via `DashMap`, and modify them when apply_conf_change
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no