### PR TITLE
fix: check the password on leader

### DIFF
--- a/xline/src/server/lease_server.rs
+++ b/xline/src/server/lease_server.rs
@@ -111,7 +111,7 @@ where
         let token = get_token(request.metadata());
         let wrapper = RequestWithToken::new_with_token(request.into_inner().into(), token);
         let cmd = command_from_request_wrapper(
-            generate_propose_id(self.cluster_info.self_name()),
+            generate_propose_id(self.cluster_info.self_name().as_str()),
             wrapper,
             Some(self.lease_storage.as_ref()),
         );

--- a/xline/src/server/xline_server.rs
+++ b/xline/src/server/xline_server.rs
@@ -376,12 +376,12 @@ impl XlineServer {
             ),
             LeaseServer::new(
                 lease_storage,
-                Arc::clone(&auth_storage),
+                auth_storage,
                 Arc::clone(&client),
                 id_gen,
                 Arc::clone(&self.cluster_info),
             ),
-            AuthServer::new(auth_storage, client, self.cluster_info.self_name()),
+            AuthServer::new(client, self.cluster_info.self_name()),
             WatchServer::new(
                 watcher,
                 Arc::clone(&header_gen),

--- a/xline/src/storage/auth_store/store.rs
+++ b/xline/src/storage/auth_store/store.rs
@@ -283,6 +283,7 @@ where
         if !self.is_enabled() {
             return Err(ExecuteError::AuthNotEnabled);
         }
+        self.check_password(&req.name, &req.password)?;
         let token = self.assign(&req.name)?;
         Ok(AuthenticateResponse {
             header: Some(self.header_gen.gen_auth_header()),
@@ -868,7 +869,7 @@ where
         &self,
         username: &str,
         password: &str,
-    ) -> Result<i64, ExecuteError> {
+    ) -> Result<(), ExecuteError> {
         if !self.is_enabled() {
             return Err(ExecuteError::AuthNotEnabled);
         }
@@ -885,7 +886,7 @@ where
             .verify_password(password.as_bytes(), &hash)
             .map_err(|_ignore| ExecuteError::AuthFailed)?;
 
-        Ok(self.revision())
+        Ok(())
     }
 
     /// Check if the request need admin permission


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    `AuthServer::authenticate` should not check password locally.
   
* what changes does this pull request make?

    Move the `check_password` to the leader.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

    No