### PR TITLE
refactor: refactor ProposeId implement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,6 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "utils",
- "uuid",
 ]
 
 [[package]]
@@ -664,6 +663,7 @@ dependencies = [
  "prost",
  "serde",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -3098,9 +3098,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom",
 ]
@@ -3468,7 +3468,6 @@ dependencies = [
  "thiserror",
  "tower",
  "utils",
- "uuid",
  "xline",
  "xline-test-utils",
  "xlineapi",

--- a/curp-external-api/Cargo.toml
+++ b/curp-external-api/Cargo.toml
@@ -17,3 +17,4 @@ mockall = "0.11.3"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 prost = "0.11"
 thiserror = "1.0.31"
+uuid = { version = "1.1.2", features = ["v4"] }

--- a/curp-external-api/src/cmd.rs
+++ b/curp-external-api/src/cmd.rs
@@ -1,9 +1,10 @@
-use std::{fmt::Display, hash::Hash};
+use std::hash::Hash;
 
 use async_trait::async_trait;
 use engine::Snapshot;
 use prost::DecodeError;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
+use uuid::Uuid;
 
 use crate::LogIndex;
 
@@ -76,38 +77,13 @@ pub trait Command:
 }
 
 /// Command Id wrapper, abstracting underlying implementation
-#[allow(clippy::module_name_repetitions)] // the name is ok even with repetitions
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Hash)]
-pub struct ProposeId(String);
+pub type ProposeId = String;
 
-impl ProposeId {
-    /// Create a new propose id
-    #[inline]
-    #[must_use]
-    pub fn new(id: String) -> Self {
-        Self(id)
-    }
-
-    /// Get inner string
-    #[inline]
-    #[must_use]
-    pub fn into_inner(self) -> String {
-        self.0
-    }
-}
-
-impl From<ProposeId> for String {
-    #[inline]
-    fn from(value: ProposeId) -> Self {
-        value.0
-    }
-}
-
-impl Display for ProposeId {
-    #[inline]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "\"{}\"", self.0)
-    }
+/// Generate propose id with the given prefix
+#[inline]
+#[must_use]
+pub fn generate_propose_id(prefix: &str) -> ProposeId {
+    format!("{}-{}", prefix, Uuid::new_v4())
 }
 
 /// Check conflict of two keys

--- a/curp-test-utils/src/test_cmd.rs
+++ b/curp-test-utils/src/test_cmd.rs
@@ -66,7 +66,7 @@ pub struct TestCommand {
 impl Default for TestCommand {
     fn default() -> Self {
         Self {
-            id: ProposeId::new(next_id().to_string()),
+            id: next_id().to_string(),
             keys: vec![1],
             exe_dur: Duration::ZERO,
             as_dur: Duration::ZERO,
@@ -114,7 +114,7 @@ impl PbCodec for TestCommandResult {
 impl TestCommand {
     pub fn new_get(keys: Vec<u32>) -> Self {
         Self {
-            id: ProposeId::new(next_id().to_string()),
+            id: next_id().to_string(),
             keys,
             exe_dur: Duration::ZERO,
             as_dur: Duration::ZERO,
@@ -126,7 +126,7 @@ impl TestCommand {
 
     pub fn new_put(keys: Vec<u32>, value: u32) -> Self {
         Self {
-            id: ProposeId::new(next_id().to_string()),
+            id: next_id().to_string(),
             keys,
             exe_dur: Duration::ZERO,
             as_dur: Duration::ZERO,

--- a/curp/Cargo.toml
+++ b/curp/Cargo.toml
@@ -47,7 +47,6 @@ tower = { version = "0.4.13", features = ["filter"] }
 tracing = { version = "0.1.34", features = ["std", "log", "attributes"] }
 tracing-opentelemetry = "0.18.0"
 utils = { path = "../utils", version = "0.1.0", features = ["parking_lot"] }
-uuid = { version = "1.3.1", features = ["v4"] }
 
 [dev-dependencies]
 anyhow = "1.0.66"

--- a/curp/src/client.rs
+++ b/curp/src/client.rs
@@ -323,7 +323,7 @@ where
                 .get_connect(leader_id)
                 .unwrap_or_else(|| unreachable!("leader {leader_id} not found"))
                 .wait_synced(
-                    WaitSyncedRequest::new(cmd.id()),
+                    WaitSyncedRequest::new(cmd.id().clone()),
                     *self.config.wait_synced_timeout(),
                 )
                 .await

--- a/curp/src/members.rs
+++ b/curp/src/members.rs
@@ -1,8 +1,9 @@
-use itertools::Itertools;
 use std::{
     collections::{hash_map::DefaultHasher, HashMap},
     hash::Hasher,
 };
+
+use itertools::Itertools;
 
 /// Server Id
 pub type ServerId = u64;

--- a/curp/src/rpc/connect.rs
+++ b/curp/src/rpc/connect.rs
@@ -12,6 +12,7 @@ use tokio::sync::RwLock;
 use tracing::{debug, error, instrument};
 use utils::tracing::Inject;
 
+use super::{ShutdownRequest, ShutdownResponse};
 use crate::{
     error::RpcError,
     members::ServerId,
@@ -23,8 +24,6 @@ use crate::{
     },
     snapshot::Snapshot,
 };
-
-use super::{ShutdownRequest, ShutdownResponse};
 
 /// Install snapshot chunk size: 64KB
 const SNAPSHOT_CHUNK_SIZE: u64 = 64 * 1024;

--- a/curp/src/rpc/mod.rs
+++ b/curp/src/rpc/mod.rs
@@ -3,14 +3,6 @@ use std::{collections::HashMap, sync::Arc};
 use curp_external_api::cmd::{PbCodec, PbSerializeError};
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::{
-    cmd::{Command, ProposeId},
-    error::{CommandSyncError, ProposeError, WaitSyncError},
-    log_entry::LogEntry,
-    members::ServerId,
-    LogIndex,
-};
-
 use self::proto::commandpb::{cmd_result::Result as CmdResultInner, CmdResult};
 pub(crate) use self::proto::{
     commandpb::{
@@ -37,6 +29,13 @@ pub use self::proto::{
     messagepb::{
         protocol_client, protocol_server::ProtocolServer, FetchLeaderRequest, FetchLeaderResponse,
     },
+};
+use crate::{
+    cmd::{Command, ProposeId},
+    error::{CommandSyncError, ProposeError, WaitSyncError},
+    log_entry::LogEntry,
+    members::ServerId,
+    LogIndex,
 };
 
 /// Rpc connect
@@ -197,15 +196,13 @@ impl ProposeResponse {
 
 impl WaitSyncedRequest {
     /// Create a `WaitSynced` request
-    pub(crate) fn new(id: &ProposeId) -> Self {
-        Self {
-            propose_id: id.clone().into_inner(),
-        }
+    pub(crate) fn new(propose_id: ProposeId) -> Self {
+        Self { propose_id }
     }
 
-    /// Get the propose id
-    pub(crate) fn propose_id(&self) -> ProposeId {
-        ProposeId::new(self.propose_id.clone())
+    /// Get the `propose_id` reference
+    pub(crate) fn propose_id(&self) -> &ProposeId {
+        &self.propose_id
     }
 }
 
@@ -439,6 +436,6 @@ impl FetchReadStateResponse {
 impl ShutdownRequest {
     /// Create a new shutdown request
     pub(crate) fn new(id: ProposeId) -> Self {
-        Self { id: id.into() }
+        Self { id }
     }
 }

--- a/curp/src/server/cmd_worker/mod.rs
+++ b/curp/src/server/cmd_worker/mod.rs
@@ -350,9 +350,8 @@ mod tests {
     use tracing_test::traced_test;
     use utils::config::StorageConfig;
 
-    use crate::log_entry::LogEntry;
-
     use super::*;
+    use crate::log_entry::LogEntry;
 
     // This should happen in fast path in most cases
     #[traced_test]

--- a/curp/src/server/curp_node.rs
+++ b/curp/src/server/curp_node.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, fmt::Debug, io, sync::Arc, time::Duration};
 
 use clippy_utilities::NumericCast;
-use curp_external_api::cmd::{PbSerializeError, ProposeId};
+use curp_external_api::cmd::PbSerializeError;
 use engine::{SnapshotAllocator, SnapshotApi};
 use event_listener::Event;
 use futures::{pin_mut, stream::FuturesUnordered, Stream, StreamExt};
@@ -146,7 +146,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
         &self,
         request: ShutdownRequest,
     ) -> Result<ShutdownResponse, CurpError> {
-        let propose_id = ProposeId::new(request.id);
+        let propose_id = request.id;
         let ((leader_id, term), result) = self.curp.handle_shutdown(propose_id);
         let error = match result {
             Ok(()) => None,
@@ -216,7 +216,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
         let id = req.propose_id();
         debug!("{} get wait synced request for cmd({id})", self.curp.id());
 
-        let (er, asr) = CommandBoard::wait_for_er_asr(&self.cmd_board, &id).await;
+        let (er, asr) = CommandBoard::wait_for_er_asr(&self.cmd_board, id).await;
         let resp = WaitSyncedResponse::new_from_result::<C>(Some(er), asr);
 
         debug!("{} wait synced for cmd({id}) finishes", self.curp.id());

--- a/curp/src/server/gc.rs
+++ b/curp/src/server/gc.rs
@@ -96,49 +96,43 @@ mod tests {
         tokio::spawn(gc_cmd_board(Arc::clone(&board), Duration::from_millis(500)));
 
         tokio::time::sleep(Duration::from_millis(100)).await;
-        board.write().er_buffer.insert(
-            ProposeId::new("1".to_owned()),
-            Ok(TestCommandResult::default()),
-        );
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        board.write().er_buffer.insert(
-            ProposeId::new("2".to_owned()),
-            Ok(TestCommandResult::default()),
-        );
         board
             .write()
-            .asr_buffer
-            .insert(ProposeId::new("1".to_owned()), Ok(0.into()));
+            .er_buffer
+            .insert(ProposeId::from("1"), Ok(TestCommandResult::default()));
         tokio::time::sleep(Duration::from_millis(100)).await;
         board
             .write()
+            .er_buffer
+            .insert(ProposeId::from("2"), Ok(TestCommandResult::default()));
+        board
+            .write()
             .asr_buffer
-            .insert(ProposeId::new("2".to_owned()), Ok(0.into()));
+            .insert(ProposeId::from("1"), Ok(0.into()));
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        board
+            .write()
+            .asr_buffer
+            .insert(ProposeId::from("2"), Ok(0.into()));
 
         // at 600ms
         tokio::time::sleep(Duration::from_millis(400)).await;
-        board.write().er_buffer.insert(
-            ProposeId::new("3".to_owned()),
-            Ok(TestCommandResult::default()),
-        );
+        board
+            .write()
+            .er_buffer
+            .insert(ProposeId::from("3"), Ok(TestCommandResult::default()));
         board
             .write()
             .asr_buffer
-            .insert(ProposeId::new("3".to_owned()), Ok(0.into()));
+            .insert(ProposeId::from("3"), Ok(0.into()));
 
         // at 1100ms, the first two kv should be removed
         tokio::time::sleep(Duration::from_millis(500)).await;
         let board = board.write();
         assert_eq!(board.er_buffer.len(), 1);
-        assert_eq!(
-            board.er_buffer.get_index(0).unwrap().0,
-            &ProposeId::new("3".to_owned())
-        );
+        assert_eq!(board.er_buffer.get_index(0).unwrap().0, "3");
         assert_eq!(board.asr_buffer.len(), 1);
-        assert_eq!(
-            board.asr_buffer.get_index(0).unwrap().0,
-            &ProposeId::new("3".to_owned())
-        );
+        assert_eq!(board.asr_buffer.get_index(0).unwrap().0, "3");
     }
 
     #[tokio::test]

--- a/curp/src/server/raw_curp/tests.rs
+++ b/curp/src/server/raw_curp/tests.rs
@@ -619,7 +619,7 @@ fn leader_handle_shutdown_will_succeed() {
         let exe_tx = MockCEEventTxApi::<TestCommand>::default();
         RawCurp::new_test(3, exe_tx, mock_role_change())
     };
-    let id = ProposeId::new(next_id().to_string());
+    let id = next_id().to_string();
     let ((leader_id, term), result) = curp.handle_shutdown(id);
     assert_eq!(leader_id, Some(curp.id().clone()));
     assert_eq!(term, 0);
@@ -635,7 +635,7 @@ fn follower_handle_shutdown_will_reject() {
         RawCurp::new_test(3, exe_tx, mock_role_change())
     };
     curp.update_to_term_and_become_follower(&mut *curp.st.write(), 1);
-    let id = ProposeId::new(next_id().to_string());
+    let id = next_id().to_string();
     let ((leader_id, term), result) = curp.handle_shutdown(id);
     assert_eq!(leader_id, None);
     assert_eq!(term, 1);

--- a/curp/tests/server.rs
+++ b/curp/tests/server.rs
@@ -7,7 +7,6 @@ use curp::{
     client::Builder,
     error::{CommandProposeError, ProposeError},
 };
-use curp_external_api::cmd::ProposeId;
 use curp_test_utils::{
     init_logger, sleep_millis, sleep_secs,
     test_cmd::{next_id, TestCommand, TestCommandResult},
@@ -285,7 +284,7 @@ async fn shutdown_rpc_should_shutdown_the_cluster() {
     });
 
     let client = group.new_client(ClientConfig::default()).await;
-    let id = ProposeId::new(next_id().to_string());
+    let id = next_id().to_string();
     client.shutdown(id).await.unwrap();
 
     let res = client

--- a/engine/src/api/snapshot_api.rs
+++ b/engine/src/api/snapshot_api.rs
@@ -1,5 +1,4 @@
-use std::error::Error;
-use std::io;
+use std::{error::Error, io};
 
 use bytes::{Bytes, BytesMut};
 

--- a/simulation/src/curp_group.rs
+++ b/simulation/src/curp_group.rs
@@ -9,6 +9,7 @@ use curp::{
     server::Rpc,
     FetchLeaderRequest, FetchLeaderResponse, LogIndex,
 };
+pub use curp::{protocol_client::ProtocolClient, ProposeRequest, ProposeResponse};
 use curp_test_utils::{
     test_cmd::{TestCE, TestCommand, TestCommandResult},
     TestRoleChange, TestRoleChangeInner,
@@ -23,8 +24,6 @@ use utils::{
     config::{ClientConfig, CurpConfigBuilder, StorageConfig},
     shutdown,
 };
-
-pub use curp::{protocol_client::ProtocolClient, ProposeRequest, ProposeResponse};
 
 struct MemorySnapshotAllocator;
 

--- a/xline-client/Cargo.toml
+++ b/xline-client/Cargo.toml
@@ -17,7 +17,6 @@ utils = { path = "../utils", features = ["parking_lot"] }
 xlineapi = { path = "../xlineapi" }
 tonic = { version = "0.3.0", package = "madsim-tonic" }
 itertools = "0.10.3"
-uuid = { version = "1.1.2", features = ["v4"] }
 thiserror = "1.0.37"
 tower = { version = "0.4", features = ["discover"] }
 tokio = { version = "0.2.23", package = "madsim-tokio", features = ["sync"] }

--- a/xline-client/src/clients/auth.rs
+++ b/xline-client/src/clients/auth.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
-use curp::{client::Client as CurpClient, cmd::ProposeId};
+use curp::{client::Client as CurpClient, cmd::generate_propose_id};
 use pbkdf2::{
     password_hash::{rand_core::OsRng, PasswordHasher, SaltString},
     Pbkdf2,
 };
 use tonic::transport::Channel;
-use uuid::Uuid;
 use xline::server::Command;
 use xlineapi::{
     AuthDisableResponse, AuthEnableResponse, AuthRoleAddResponse, AuthRoleDeleteResponse,
@@ -694,7 +693,7 @@ impl AuthClient {
         request: Req,
         use_fast_path: bool,
     ) -> Result<Res> {
-        let propose_id = self.generate_propose_id();
+        let propose_id = generate_propose_id(&self.name);
         let request = RequestWithToken::new_with_token(request.into(), self.token.clone());
         let cmd = Command::new(vec![], request, propose_id);
 
@@ -721,10 +720,5 @@ impl AuthClient {
             .hash_password(password, salt.as_ref())
             .unwrap_or_else(|e| panic!("Failed to hash password: {e}"));
         hashed_password.to_string()
-    }
-
-    /// Generate a new `ProposeId`
-    fn generate_propose_id(&self) -> ProposeId {
-        ProposeId::new(format!("{}-{}", self.name, Uuid::new_v4()))
     }
 }

--- a/xline-client/src/clients/lock.rs
+++ b/xline-client/src/clients/lock.rs
@@ -7,10 +7,12 @@ use std::{
 };
 
 use clippy_utilities::OverflowArithmetic;
-use curp::{client::Client as CurpClient, cmd::ProposeId};
+use curp::{
+    client::Client as CurpClient,
+    cmd::{generate_propose_id, ProposeId},
+};
 use futures::{Future, FutureExt};
 use tonic::transport::Channel;
-use uuid::Uuid;
 use xline::server::{Command, CommandResponse, KeyRange, SyncResponse};
 use xlineapi::{
     Compare, CompareResult, CompareTarget, DeleteRangeRequest, DeleteRangeResponse, EventType,
@@ -244,11 +246,6 @@ impl LockClient {
         Ok(UnlockResponse { header })
     }
 
-    /// Generate a new `ProposeId`
-    fn generate_propose_id(&self) -> ProposeId {
-        ProposeId::new(format!("{}-{}", self.name, Uuid::new_v4()))
-    }
-
     /// Generate `Command` proposal from `Request`
     fn command_from_request_wrapper(propose_id: ProposeId, wrapper: RequestWithToken) -> Command {
         #[allow(clippy::wildcard_enum_match_arm)]
@@ -280,7 +277,7 @@ impl LockClient {
     {
         let request_with_token =
             RequestWithToken::new_with_token(request.into(), self.token.clone());
-        let propose_id = self.generate_propose_id();
+        let propose_id = generate_propose_id(&self.name);
 
         let cmd = Self::command_from_request_wrapper(propose_id, request_with_token);
         self.curp_client

--- a/xline/src/client/mod.rs
+++ b/xline/src/client/mod.rs
@@ -1,12 +1,11 @@
 use std::fmt::Debug;
 
-use curp::{client::Client as CurpClient, cmd::ProposeId};
+use curp::{client::Client as CurpClient, cmd::generate_propose_id};
 use etcd_client::{
     AuthClient, Client as EtcdClient, KvClient, LeaseClient, LeaseKeepAliveStream, LeaseKeeper,
     LockClient, MaintenanceClient, WatchClient,
 };
 use utils::config::ClientConfig;
-use uuid::Uuid;
 
 use crate::{
     client::{
@@ -87,11 +86,6 @@ impl Client {
         self.use_curp_client = use_curp_client;
     }
 
-    /// Generate a new `ProposeId`
-    fn generate_propose_id(&self) -> ProposeId {
-        ProposeId::new(format!("{}-{}", self.name, Uuid::new_v4()))
-    }
-
     /// Send `PutRequest` by `CurpClient` or `EtcdClient`
     ///
     /// # Errors
@@ -101,7 +95,7 @@ impl Client {
     pub async fn put(&mut self, request: PutRequest) -> Result<PutResponse, ClientError> {
         if self.use_curp_client {
             let key_ranges = vec![KeyRange::new_one_key(request.key())];
-            let propose_id = self.generate_propose_id();
+            let propose_id = generate_propose_id(&self.name);
             let request = RequestWithToken::new(rpc::PutRequest::from(request).into());
             let cmd = Command::new(key_ranges, request, propose_id);
             let (cmd_res, _sync_res) = self.curp_client.propose(cmd, true).await?;
@@ -125,7 +119,7 @@ impl Client {
     pub async fn range(&mut self, request: RangeRequest) -> Result<RangeResponse, ClientError> {
         if self.use_curp_client {
             let key_ranges = vec![KeyRange::new(request.key(), request.range_end())];
-            let propose_id = self.generate_propose_id();
+            let propose_id = generate_propose_id(&self.name);
             let request = RequestWithToken::new(rpc::RangeRequest::from(request).into());
             let cmd = Command::new(key_ranges, request, propose_id);
             let (cmd_res, _sync_res) = self.curp_client.propose(cmd, true).await?;
@@ -149,7 +143,7 @@ impl Client {
     ) -> Result<DeleteRangeResponse, ClientError> {
         if self.use_curp_client {
             let key_ranges = vec![KeyRange::new(request.key(), request.range_end())];
-            let propose_id = self.generate_propose_id();
+            let propose_id = generate_propose_id(&self.name);
             let request = RequestWithToken::new(rpc::DeleteRangeRequest::from(request).into());
             let cmd = Command::new(key_ranges, request, propose_id);
             let (cmd_res, _sync_res) = self.curp_client.propose(cmd, true).await?;

--- a/xline/src/server/auth_server.rs
+++ b/xline/src/server/auth_server.rs
@@ -1,13 +1,12 @@
 use std::sync::Arc;
 
-use curp::{client::Client, cmd::ProposeId};
+use curp::{client::Client, cmd::generate_propose_id};
 use pbkdf2::{
     password_hash::{rand_core::OsRng, PasswordHasher, SaltString},
     Pbkdf2,
 };
 use tonic::metadata::MetadataMap;
 use tracing::debug;
-use uuid::Uuid;
 use xlineapi::RequestWithToken;
 
 use super::command::{
@@ -70,11 +69,6 @@ where
         }
     }
 
-    /// Generate propose id
-    fn generate_propose_id(&self) -> ProposeId {
-        ProposeId::new(format!("{}-{}", self.name, Uuid::new_v4()))
-    }
-
     /// Propose request and get result with fast/slow path
     async fn propose<T>(
         &self,
@@ -86,7 +80,7 @@ where
     {
         let token = get_token(request.metadata());
         let wrapper = RequestWithToken::new_with_token(request.into_inner().into(), token);
-        let cmd = command_from_request_wrapper::<S>(self.generate_propose_id(), wrapper, None);
+        let cmd = command_from_request_wrapper::<S>(generate_propose_id(&self.name), wrapper, None);
 
         self.client
             .propose(cmd, use_fast_path)

--- a/xline/src/server/barriers.rs
+++ b/xline/src/server/barriers.rs
@@ -114,13 +114,13 @@ mod test {
             .map(|i| {
                 let id_barrier = Arc::clone(&id_barrier);
                 tokio::spawn(async move {
-                    id_barrier.wait(ProposeId::new(i.to_string())).await;
+                    id_barrier.wait(i.to_string()).await;
                 })
             })
             .collect::<Vec<_>>();
         sleep(Duration::from_millis(10)).await;
         for i in 0..5 {
-            id_barrier.trigger(&ProposeId::new(i.to_string()));
+            id_barrier.trigger(&i.to_string());
         }
         timeout(Duration::from_millis(100), join_all(barriers))
             .await

--- a/xline/src/server/command.rs
+++ b/xline/src/server/command.rs
@@ -697,7 +697,7 @@ impl PbCodec for Command {
         let rpc_cmd = PbCommand {
             keys: cmd.keys.into_iter().map(Into::into).collect(),
             request: Some(cmd.request.into()),
-            propose_id: cmd.id.into_inner(),
+            propose_id: cmd.id,
         };
         rpc_cmd.encode_to_vec()
     }
@@ -711,7 +711,7 @@ impl PbCodec for Command {
                 .request
                 .ok_or(PbSerializeError::EmptyField)?
                 .try_into()?,
-            id: ProposeId::new(rpc_cmd.propose_id),
+            id: rpc_cmd.propose_id,
         })
     }
 }
@@ -823,26 +823,26 @@ mod test {
         let cmd1 = Command::new(
             vec![KeyRange::new("a", "e")],
             RequestWithToken::new(RequestWrapper::PutRequest(PutRequest::default())),
-            ProposeId::new("id".to_owned()),
+            ProposeId::from("id"),
         );
         let cmd2 = Command::new(
             vec![],
             RequestWithToken::new(RequestWrapper::AuthStatusRequest(
                 AuthStatusRequest::default(),
             )),
-            ProposeId::new("id".to_owned()),
+            ProposeId::from("id"),
         );
         let cmd3 = Command::new(
             vec![KeyRange::new("c", "g")],
             RequestWithToken::new(RequestWrapper::PutRequest(PutRequest::default())),
-            ProposeId::new("id2".to_owned()),
+            ProposeId::from("id2"),
         );
         let cmd4 = Command::new(
             vec![],
             RequestWithToken::new(RequestWrapper::AuthEnableRequest(
                 AuthEnableRequest::default(),
             )),
-            ProposeId::new("id3".to_owned()),
+            ProposeId::from("id3"),
         );
         let cmd5 = Command::new(
             vec![],
@@ -850,14 +850,14 @@ mod test {
                 ttl: 1,
                 id: 1,
             })),
-            ProposeId::new("id3".to_owned()),
+            ProposeId::from("id3"),
         );
         let cmd6 = Command::new(
             vec![],
             RequestWithToken::new(RequestWrapper::LeaseRevokeRequest(LeaseRevokeRequest {
                 id: 1,
             })),
-            ProposeId::new("id3".to_owned()),
+            ProposeId::from("id3"),
         );
 
         let lease_grant_cmd = Command::new(
@@ -866,7 +866,7 @@ mod test {
                 ttl: 1,
                 id: 123,
             })),
-            ProposeId::new("id4".to_owned()),
+            ProposeId::from("id4"),
         );
         let put_with_lease_cmd = Command::new(
             vec![KeyRange::new_one_key("foo")],
@@ -876,7 +876,7 @@ mod test {
                 lease: 123,
                 ..Default::default()
             })),
-            ProposeId::new("id5".to_owned()),
+            ProposeId::from("id5"),
         );
         let txn_with_lease_id_cmd = Command::new(
             vec![KeyRange::new_one_key("key")],
@@ -892,12 +892,12 @@ mod test {
                 }],
                 failure: vec![],
             })),
-            ProposeId::new("id6".to_owned()),
+            ProposeId::from("id6"),
         );
         let lease_leases_cmd = Command::new(
             vec![],
             RequestWithToken::new(RequestWrapper::LeaseLeasesRequest(LeaseLeasesRequest {})),
-            ProposeId::new("id4".to_owned()),
+            ProposeId::from("id4"),
         );
 
         assert!(lease_grant_cmd.is_conflict(&put_with_lease_cmd)); // lease id
@@ -926,7 +926,7 @@ mod test {
                 success,
                 failure,
             })),
-            ProposeId::new(propose_id.to_owned()),
+            propose_id.to_owned(),
         )
     }
 
@@ -938,7 +938,7 @@ mod test {
                 revision: 3,
                 physical: false,
             })),
-            ProposeId::new("id11".to_owned()),
+            ProposeId::from("id11"),
         );
 
         let compaction_cmd_2 = Command::new(
@@ -947,7 +947,7 @@ mod test {
                 revision: 5,
                 physical: false,
             })),
-            ProposeId::new("id12".to_owned()),
+            ProposeId::from("id12"),
         );
 
         let txn_with_lease_id_cmd = generate_txn_command(
@@ -1021,7 +1021,7 @@ mod test {
         let cmd = Command::new(
             vec![KeyRange::new("a", "e")],
             RequestWithToken::new(RequestWrapper::PutRequest(PutRequest::default())),
-            ProposeId::new("id".to_owned()),
+            ProposeId::from("id"),
         );
         let decoded_cmd =
             <Command as PbCodec>::decode(&cmd.encode()).expect("decode should success");

--- a/xline/src/server/lease_server.rs
+++ b/xline/src/server/lease_server.rs
@@ -2,11 +2,10 @@ use std::{pin::Pin, sync::Arc, time::Duration};
 
 use async_stream::{stream, try_stream};
 use clippy_utilities::Cast;
-use curp::{client::Client, cmd::ProposeId, members::ClusterInfo};
+use curp::{client::Client, cmd::generate_propose_id, members::ClusterInfo};
 use futures::stream::Stream;
 use tokio::time;
 use tracing::{debug, warn};
-use uuid::Uuid;
 use xlineapi::RequestWithToken;
 
 use super::{
@@ -100,15 +99,6 @@ where
         }
     }
 
-    /// Generate propose id
-    fn generate_propose_id(&self) -> ProposeId {
-        ProposeId::new(format!(
-            "{}-{}",
-            self.cluster_info.self_name(),
-            Uuid::new_v4()
-        ))
-    }
-
     /// Propose request and get result with fast/slow path
     async fn propose<T>(
         &self,
@@ -121,7 +111,7 @@ where
         let token = get_token(request.metadata());
         let wrapper = RequestWithToken::new_with_token(request.into_inner().into(), token);
         let cmd = command_from_request_wrapper(
-            self.generate_propose_id(),
+            generate_propose_id(self.cluster_info.self_name()),
             wrapper,
             Some(self.lease_storage.as_ref()),
         );

--- a/xline/src/server/lock_server.rs
+++ b/xline/src/server/lock_server.rs
@@ -2,10 +2,9 @@ use std::{marker::PhantomData, sync::Arc};
 
 use async_stream::stream;
 use clippy_utilities::OverflowArithmetic;
-use curp::{client::Client, cmd::ProposeId};
+use curp::{client::Client, cmd::generate_propose_id};
 use etcd_client::EventType;
 use tracing::debug;
-use uuid::Uuid;
 use xlineapi::RequestWithToken;
 
 use super::{
@@ -65,11 +64,6 @@ where
         }
     }
 
-    /// Generate propose id
-    fn generate_propose_id(&self) -> ProposeId {
-        ProposeId::new(format!("{}-{}", self.name, Uuid::new_v4()))
-    }
-
     /// Propose request and get result with fast/slow path
     async fn propose<T>(
         &self,
@@ -81,7 +75,7 @@ where
         T: Into<RequestWrapper>,
     {
         let wrapper = RequestWithToken::new_with_token(request.into(), token);
-        let cmd = command_from_request_wrapper::<S>(self.generate_propose_id(), wrapper, None);
+        let cmd = command_from_request_wrapper::<S>(generate_propose_id(&self.name), wrapper, None);
 
         self.client
             .propose(cmd, use_fast_path)

--- a/xline/src/storage/compact/mod.rs
+++ b/xline/src/storage/compact/mod.rs
@@ -3,7 +3,7 @@ use std::{sync::Arc, time::Duration};
 use async_trait::async_trait;
 use curp::{
     client::Client,
-    cmd::ProposeId,
+    cmd::generate_propose_id,
     error::CommandProposeError::{AfterSync, Execute},
 };
 use event_listener::Event;
@@ -11,7 +11,6 @@ use periodic_compactor::PeriodicCompactor;
 use revision_compactor::RevisionCompactor;
 use tokio::{sync::mpsc::Receiver, time::sleep};
 use utils::config::AutoCompactConfig;
-use uuid::Uuid;
 
 use super::{
     index::{Index, IndexOperate},
@@ -60,7 +59,7 @@ impl Compactable for Client<Command> {
             physical: false,
         };
         let request_wrapper = RequestWithToken::new_with_token(request.into(), None);
-        let propose_id = ProposeId::new(format!("auto-compactor-{}", Uuid::new_v4()));
+        let propose_id = generate_propose_id("auto-compactor");
         let cmd = Command::new(vec![], request_wrapper, propose_id);
         if let Err(e) = self.propose(cmd, true).await {
             #[allow(clippy::wildcard_enum_match_arm)]

--- a/xline/src/storage/execute_error.rs
+++ b/xline/src/storage/execute_error.rs
@@ -320,8 +320,9 @@ impl From<ExecuteError> for tonic::Status {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use strum::IntoEnumIterator;
+
+    use super::*;
 
     #[test]
     fn serialization_is_ok() {

--- a/xlineapi/src/lib.rs
+++ b/xlineapi/src/lib.rs
@@ -198,9 +198,8 @@ pub use self::{
         RequestWithToken as PbRequestWithToken, SyncResponse as PbSyncResponse,
     },
     errorpb::{
-        execute_error::Error as PbExecuteError,
-        execute_error::ValidationError as PbValidationError, ExecuteError as PbExecuteErrorOuter,
-        Revisions as PbRevisions, UserRole as PbUserRole,
+        execute_error::{Error as PbExecuteError, ValidationError as PbValidationError},
+        ExecuteError as PbExecuteErrorOuter, Revisions as PbRevisions, UserRole as PbUserRole,
     },
     etcdserverpb::{
         auth_client::AuthClient,


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
At present, the definition of `ProposeId` is `struct ProposeId(String)`. The reason for using a tuple struct is to implement some methods for the `ProposeId`, such as `new` and `into_inner`. However, this is unnecessary since the traits derived by `ProposeId` are already implemented by `String`, and `String` also provides a `from` method that can replace the `new` method. Therefore, defining `ProposeId` as an alias for `String` can make `ProposeId` more user-friendly. Additionally, whether `ProposeId` is defined as a type alias or as a tuple struct, the amount of work required to change the `ProposeId` type is roughly the same because all the call sites for the `new` method would need to be modified.

Furthermore, many business servers currently define their own `generate_propose_id`, but their implementations are identical. Therefore, I have extracted a common `generate_propose_id` method to reduce code duplication

* what changes does this pull request make?
1. modify ProposeId as a type alias
2. extract a shared function `generate_propose_id` to reuse

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)