### PR TITLE
refactor: use `Logindex` instead of `ProposeId` in `cmd_vid`

### DIFF
--- a/curp/src/error.rs
+++ b/curp/src/error.rs
@@ -116,10 +116,10 @@ impl TryFrom<PbProposeError> for ProposeError {
     }
 }
 
-impl From<ProposeError> for PbProposeError {
+impl From<ProposeError> for PbProposeErrorOuter {
     #[inline]
     fn from(err: ProposeError) -> Self {
-        match err {
+        let e = match err {
             ProposeError::Timeout => PbProposeError::Timeout(()),
             ProposeError::NotLeader => PbProposeError::NotLeader(()),
             ProposeError::Shutdown => PbProposeError::Shutdown(()),
@@ -129,6 +129,9 @@ impl From<ProposeError> for PbProposeError {
                 wait_sync_error: Some(e.into()),
             }),
             ProposeError::EncodeError(s) => PbProposeError::EncodeError(s),
+        };
+        PbProposeErrorOuter {
+            propose_error: Some(e),
         }
     }
 }
@@ -143,10 +146,7 @@ impl From<PbSerializeError> for ProposeError {
 impl PbCodec for ProposeError {
     #[inline]
     fn encode(&self) -> Vec<u8> {
-        PbProposeErrorOuter {
-            propose_error: Some(self.clone().into()),
-        }
-        .encode_to_vec()
+        PbProposeErrorOuter::from(self.clone()).encode_to_vec()
     }
 
     #[inline]

--- a/curp/src/log_entry.rs
+++ b/curp/src/log_entry.rs
@@ -25,7 +25,7 @@ pub(crate) enum EntryData<C> {
     /// `ConfChange` entry
     ConfChange(ProposeId),
     /// `Shutdown` entry
-    Shutdown(ProposeId),
+    Shutdown,
 }
 
 impl<C> LogEntry<C>
@@ -42,11 +42,11 @@ where
     }
 
     /// Create a new `LogEntry` of `Shutdown`
-    pub(super) fn new_shutdown(index: LogIndex, term: u64, propose_id: ProposeId) -> Self {
+    pub(super) fn new_shutdown(index: LogIndex, term: u64) -> Self {
         Self {
             term,
             index,
-            entry_data: EntryData::Shutdown(propose_id),
+            entry_data: EntryData::Shutdown,
         }
     }
 
@@ -64,7 +64,13 @@ where
     pub(super) fn id(&self) -> &ProposeId {
         match self.entry_data {
             EntryData::Command(ref cmd) => cmd.id(),
-            EntryData::ConfChange(ref id) | EntryData::Shutdown(ref id) => id,
+            EntryData::ConfChange(ref id) => id,
+            EntryData::Shutdown => {
+                unreachable!(
+                    "LogEntry::id() should not be called on {:?} entry",
+                    self.entry_data
+                );
+            }
         }
     }
 }

--- a/curp/src/rpc/mod.rs
+++ b/curp/src/rpc/mod.rs
@@ -166,9 +166,7 @@ impl ProposeResponse {
         Self {
             leader_id,
             term,
-            exe_result: Some(ExeResult::Error(PbProposeErrorOuter {
-                propose_error: Some(error.into()),
-            })),
+            exe_result: Some(ExeResult::Error(error.into())),
         }
     }
 
@@ -443,13 +441,6 @@ impl FetchReadStateResponse {
     }
 }
 
-impl ShutdownRequest {
-    /// Create a new shutdown request
-    pub(crate) fn new(id: ProposeId) -> Self {
-        Self { id }
-    }
-}
-
 #[allow(dead_code)] // TODO: remove this when we implement conf change
 #[allow(clippy::as_conversions)] // ConfChangeType is so small that it won't exceed the range of i32 type.
 impl ConfChange {
@@ -486,6 +477,18 @@ impl ConfChange {
             change_type: ConfChangeType::AddLearner as i32,
             node_id,
             address: vec![address],
+        }
+    }
+}
+
+impl ShutdownResponse {
+    /// Create a new shutdown response
+    pub(crate) fn new(leader_id: Option<ServerId>, term: u64, error: Option<ProposeError>) -> Self {
+        let error = error.map(Into::into);
+        Self {
+            leader_id,
+            term,
+            error,
         }
     }
 }

--- a/curp/src/server/cmd_worker/mod.rs
+++ b/curp/src/server/cmd_worker/mod.rs
@@ -122,7 +122,7 @@ async fn worker_exe<
             er_ok
         }
         EntryData::ConfChange(_) => false, // TODO: implement conf change
-        EntryData::Shutdown(_) => true,
+        EntryData::Shutdown => true,
     }
 }
 
@@ -152,7 +152,7 @@ async fn worker_as<
             debug!("{id} cmd({}) after sync is called", entry.id());
             asr_ok
         }
-        EntryData::Shutdown(_) => {
+        EntryData::Shutdown => {
             curp.enter_shutdown();
             if let Err(e) = ce.set_last_applied(entry.index) {
                 error!("failed to set last_applied, {e}");

--- a/curp/src/server/curp_node.rs
+++ b/curp/src/server/curp_node.rs
@@ -145,19 +145,14 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
     /// Handle `Shutdown` requests
     pub(super) async fn shutdown(
         &self,
-        request: ShutdownRequest,
+        _request: ShutdownRequest,
     ) -> Result<ShutdownResponse, CurpError> {
-        let propose_id = request.id;
-        let ((leader_id, term), result) = self.curp.handle_shutdown(propose_id);
+        let ((leader_id, term), result) = self.curp.handle_shutdown();
         let error = match result {
             Ok(()) => None,
-            Err(err) => Some(bincode::serialize(&err)?),
+            Err(err) => Some(err),
         };
-        let resp = ShutdownResponse {
-            leader_id,
-            term,
-            error,
-        };
+        let resp = ShutdownResponse::new(leader_id, term, error);
         CommandBoard::wait_for_shutdown_synced(&self.cmd_board).await;
         Ok(resp)
     }

--- a/curp/src/server/raw_curp/log.rs
+++ b/curp/src/server/raw_curp/log.rs
@@ -298,13 +298,9 @@ impl<C: 'static + Command> Log<C> {
     }
 
     /// Push a shutdown entry to the end of the log, return its index
-    pub(super) fn push_shutdown(
-        &mut self,
-        term: u64,
-        propose_id: ProposeId,
-    ) -> Result<Arc<LogEntry<C>>, bincode::Error> {
+    pub(super) fn push_shutdown(&mut self, term: u64) -> Result<Arc<LogEntry<C>>, bincode::Error> {
         let index = self.last_log_index() + 1;
-        let entry = Arc::new(LogEntry::new_shutdown(index, term, propose_id));
+        let entry = Arc::new(LogEntry::new_shutdown(index, term));
         self.entries.push_back(Arc::clone(&entry))?;
         self.send_persist(Arc::clone(&entry));
         Ok(entry)

--- a/curp/src/server/raw_curp/tests.rs
+++ b/curp/src/server/raw_curp/tests.rs
@@ -1,9 +1,6 @@
 use std::time::Instant;
 
-use curp_test_utils::{
-    mock_role_change,
-    test_cmd::{next_id, TestCommand},
-};
+use curp_test_utils::{mock_role_change, test_cmd::TestCommand};
 use test_macros::abort_on_panic;
 use tokio::{sync::oneshot, time::sleep};
 use tracing_test::traced_test;
@@ -626,8 +623,7 @@ fn leader_handle_shutdown_will_succeed() {
         let exe_tx = MockCEEventTxApi::<TestCommand>::default();
         RawCurp::new_test(3, exe_tx, mock_role_change())
     };
-    let id = next_id().to_string();
-    let ((leader_id, term), result) = curp.handle_shutdown(id);
+    let ((leader_id, term), result) = curp.handle_shutdown();
     assert_eq!(leader_id, Some(curp.id().clone()));
     assert_eq!(term, 0);
     assert!(matches!(result, Ok(())));
@@ -642,8 +638,7 @@ fn follower_handle_shutdown_will_reject() {
         RawCurp::new_test(3, exe_tx, mock_role_change())
     };
     curp.update_to_term_and_become_follower(&mut *curp.st.write(), 1);
-    let id = next_id().to_string();
-    let ((leader_id, term), result) = curp.handle_shutdown(id);
+    let ((leader_id, term), result) = curp.handle_shutdown();
     assert_eq!(leader_id, None);
     assert_eq!(term, 1);
     assert!(matches!(result, Err(ProposeError::NotLeader)));

--- a/curp/tests/server.rs
+++ b/curp/tests/server.rs
@@ -9,7 +9,7 @@ use curp::{
 };
 use curp_test_utils::{
     init_logger, sleep_millis, sleep_secs,
-    test_cmd::{next_id, TestCommand, TestCommandResult},
+    test_cmd::{TestCommand, TestCommandResult},
 };
 use madsim::rand::{thread_rng, Rng};
 use test_macros::abort_on_panic;
@@ -284,8 +284,7 @@ async fn shutdown_rpc_should_shutdown_the_cluster() {
     });
 
     let client = group.new_client(ClientConfig::default()).await;
-    let id = next_id().to_string();
-    client.shutdown(id).await.unwrap();
+    client.shutdown().await.unwrap();
 
     let res = client
         .propose(TestCommand::new_put(vec![888], 1), false)


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
In the current implementation, all log entries require propose id, but some log, such as shutdown and no-op log that will be introduced in the future, do not need propose id.
* what changes does this pull request make?
 use Logindex instead of ProposeId in cmd_vid, after this refactor, now the log entry no longer has to include ProposeId
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no