### PR TITLE
fix: remove `stop` in simulation tests

### DIFF
--- a/simulation/tests/it/curp/server_election.rs
+++ b/simulation/tests/it/curp/server_election.rs
@@ -185,6 +185,4 @@ async fn conflict_should_detected_in_new_leader() {
             .values,
         vec![0]
     );
-
-    group.stop().await;
 }


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)