### PR TITLE
refactor: refactor propose id into `<client_id>#<seq_num>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,7 @@ dependencies = [
  "parking_lot",
  "prost",
  "prost-build",
+ "rand",
  "serde",
  "tempfile",
  "test-macros",
@@ -667,7 +668,6 @@ dependencies = [
  "prost",
  "serde",
  "thiserror",
- "uuid",
 ]
 
 [[package]]

--- a/curp-external-api/Cargo.toml
+++ b/curp-external-api/Cargo.toml
@@ -17,4 +17,3 @@ mockall = "0.11.3"
 prost = "0.11"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 thiserror = "1.0.31"
-uuid = { version = "1.1.2", features = ["v4"] }

--- a/curp-external-api/src/cmd.rs
+++ b/curp-external-api/src/cmd.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use engine::Snapshot;
 use prost::DecodeError;
 use serde::{de::DeserializeOwned, Serialize};
-use uuid::Uuid;
 
 use crate::LogIndex;
 
@@ -79,11 +78,21 @@ pub trait Command:
 /// Command Id wrapper, abstracting underlying implementation
 pub type ProposeId = String;
 
-/// Generate propose id with the given prefix
+/// Generate propose id with client id and seq num
 #[inline]
 #[must_use]
-pub fn generate_propose_id(prefix: &str) -> ProposeId {
-    format!("{}-{}", prefix, Uuid::new_v4())
+pub fn generate_propose_id(client_id: u64, seq_num: u64) -> ProposeId {
+    format!("{client_id}#{seq_num}")
+}
+
+/// Parse propose id to (`client_id`, `seq_num`)
+#[inline]
+#[must_use]
+pub fn parse_propose_id(id: &ProposeId) -> Option<(u64, u64)> {
+    let mut iter = id.split('#');
+    let client_id = iter.next()?.parse().ok()?;
+    let seq_num: u64 = iter.next()?.parse().ok()?;
+    Some((client_id, seq_num))
 }
 
 /// Check conflict of two keys

--- a/curp-test-utils/src/test_cmd.rs
+++ b/curp-test-utils/src/test_cmd.rs
@@ -26,10 +26,14 @@ use crate::{META_TABLE, REVISION_TABLE, TEST_TABLE};
 pub(crate) const APPLIED_INDEX_KEY: &str = "applied_index";
 pub(crate) const LAST_REVISION_KEY: &str = "last_revision";
 
+/// Test client id
+pub const TEST_CLIENT_ID: &str = "test_client_id";
+
 static NEXT_ID: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(1));
 
-pub fn next_id() -> u64 {
-    NEXT_ID.fetch_add(1, Ordering::SeqCst)
+pub fn next_id() -> String {
+    let seq_num = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    format!("{TEST_CLIENT_ID}#{seq_num}")
 }
 
 #[derive(Error, Debug, Clone, Serialize, Deserialize)]
@@ -66,7 +70,7 @@ pub struct TestCommand {
 impl Default for TestCommand {
     fn default() -> Self {
         Self {
-            id: next_id().to_string(),
+            id: next_id(),
             keys: vec![1],
             exe_dur: Duration::ZERO,
             as_dur: Duration::ZERO,
@@ -114,7 +118,7 @@ impl PbCodec for TestCommandResult {
 impl TestCommand {
     pub fn new_get(keys: Vec<u32>) -> Self {
         Self {
-            id: next_id().to_string(),
+            id: next_id(),
             keys,
             exe_dur: Duration::ZERO,
             as_dur: Duration::ZERO,
@@ -126,7 +130,7 @@ impl TestCommand {
 
     pub fn new_put(keys: Vec<u32>, value: u32) -> Self {
         Self {
-            id: next_id().to_string(),
+            id: next_id(),
             keys,
             exe_dur: Duration::ZERO,
             as_dur: Duration::ZERO,

--- a/curp/Cargo.toml
+++ b/curp/Cargo.toml
@@ -34,6 +34,7 @@ madsim = { version = "0.2.22", features = ["rpc", "macros"] }
 opentelemetry = "0.18.0"
 parking_lot = "0.12.1"
 prost = "0.11"
+rand = "0.8.5"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 thiserror = "1.0.31"
 tokio = { version = "0.2.23", package = "madsim-tokio", features = [

--- a/curp/src/client.rs
+++ b/curp/src/client.rs
@@ -3,7 +3,7 @@ use std::{
     time::Duration,
 };
 
-use curp_external_api::cmd::PbSerializeError;
+use curp_external_api::cmd::{generate_propose_id, PbSerializeError};
 use dashmap::DashMap;
 use event_listener::Event;
 use futures::{pin_mut, stream::FuturesUnordered, StreamExt};
@@ -771,6 +771,33 @@ where
     /// Get all connects
     fn all_connects(&self) -> Vec<Arc<dyn ConnectApi>> {
         self.connects.iter().map(|c| Arc::clone(&c)).collect()
+    }
+
+    /// Get the client id
+    ///
+    /// # Errors
+    ///
+    ///   `ProposeError::Timeout` if timeout
+    #[allow(clippy::unused_async)] // TODO: grant a client id from server
+    async fn get_client_id(&self) -> Result<u64, ProposeError> {
+        Ok(rand::random())
+    }
+
+    /// New a seq num and record it
+    #[allow(clippy::unused_self)] // TODO: implement request tracker
+    fn new_seq_num(&self) -> u64 {
+        0
+    }
+
+    /// Generate a propose id
+    ///
+    /// # Errors
+    ///   `ProposeError::Timeout` if timeout
+    #[inline]
+    pub async fn gen_propose_id(&self) -> Result<ProposeId, CommandProposeError<C>> {
+        let client_id = self.get_client_id().await?;
+        let seq_num = self.new_seq_num();
+        Ok(generate_propose_id(client_id, seq_num))
     }
 }
 

--- a/curp/tests/common/curp_group.rs
+++ b/curp/tests/common/curp_group.rs
@@ -57,7 +57,7 @@ pub struct CurpNode {
     pub as_rx: mpsc::UnboundedReceiver<(TestCommand, LogIndex)>,
     pub role_change_arc: Arc<TestRoleChangeInner>,
     pub handle: JoinHandle<Result<(), ServerError>>,
-    pub trigger: shutdown::Trigger,
+    pub trigger: Trigger,
 }
 
 pub struct CurpGroup {

--- a/xline-client/src/clients/kv.rs
+++ b/xline-client/src/clients/kv.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use curp::{client::Client as CurpClient, cmd::generate_propose_id};
+use curp::client::Client as CurpClient;
 use xline::server::{Command, KeyRange};
 use xlineapi::{
     CompactionResponse, DeleteRangeResponse, PutResponse, RangeResponse, RequestWithToken,
@@ -15,8 +15,6 @@ use crate::{
 /// Client for KV operations.
 #[derive(Clone, Debug)]
 pub struct KvClient {
-    /// Name of the kv client, which will be used in CURP propose id generation
-    name: String,
     /// The client running the CURP protocol, communicate with all servers.
     curp_client: Arc<CurpClient<Command>>,
     /// The auth token
@@ -26,16 +24,8 @@ pub struct KvClient {
 impl KvClient {
     /// New `KvClient`
     #[inline]
-    pub(crate) fn new(
-        name: String,
-        curp_client: Arc<CurpClient<Command>>,
-        token: Option<String>,
-    ) -> Self {
-        Self {
-            name,
-            curp_client,
-            token,
-        }
+    pub(crate) fn new(curp_client: Arc<CurpClient<Command>>, token: Option<String>) -> Self {
+        Self { curp_client, token }
     }
 
     /// Put a key-value into the store
@@ -65,7 +55,7 @@ impl KvClient {
     #[inline]
     pub async fn put(&self, request: PutRequest) -> Result<PutResponse> {
         let key_ranges = vec![KeyRange::new_one_key(request.key())];
-        let propose_id = generate_propose_id(&self.name);
+        let propose_id = self.curp_client.gen_propose_id().await?;
         let request = RequestWithToken::new_with_token(
             xlineapi::PutRequest::from(request).into(),
             self.token.clone(),
@@ -110,7 +100,7 @@ impl KvClient {
     #[inline]
     pub async fn range(&self, request: RangeRequest) -> Result<RangeResponse> {
         let key_ranges = vec![KeyRange::new(request.key(), request.range_end())];
-        let propose_id = generate_propose_id(&self.name);
+        let propose_id = self.curp_client.gen_propose_id().await?;
         let request = RequestWithToken::new_with_token(
             xlineapi::RangeRequest::from(request).into(),
             self.token.clone(),
@@ -148,7 +138,7 @@ impl KvClient {
     #[inline]
     pub async fn delete(&self, request: DeleteRangeRequest) -> Result<DeleteRangeResponse> {
         let key_ranges = vec![KeyRange::new(request.key(), request.range_end())];
-        let propose_id = generate_propose_id(&self.name);
+        let propose_id = self.curp_client.gen_propose_id().await?;
         let request = RequestWithToken::new_with_token(
             xlineapi::DeleteRangeRequest::from(request).into(),
             self.token.clone(),
@@ -203,7 +193,7 @@ impl KvClient {
             .iter()
             .map(|cmp| KeyRange::new(cmp.key.as_slice(), cmp.range_end.as_slice()))
             .collect();
-        let propose_id = generate_propose_id(&self.name);
+        let propose_id = self.curp_client.gen_propose_id().await?;
         let request = RequestWithToken::new_with_token(
             xlineapi::TxnRequest::from(request).into(),
             self.token.clone(),
@@ -256,7 +246,7 @@ impl KvClient {
     #[inline]
     pub async fn compact(&self, request: CompactionRequest) -> Result<CompactionResponse> {
         let use_fast_path = request.physical();
-        let propose_id = generate_propose_id(&self.name);
+        let propose_id = self.curp_client.gen_propose_id().await?;
         let request = RequestWithToken::new_with_token(
             xlineapi::CompactionRequest::from(request).into(),
             self.token.clone(),

--- a/xline-client/src/clients/lease.rs
+++ b/xline-client/src/clients/lease.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use curp::{client::Client as CurpClient, cmd::generate_propose_id};
+use curp::client::Client as CurpClient;
 use futures::channel::mpsc::channel;
 use tonic::{transport::Channel, Streaming};
 use xline::server::Command;
@@ -22,8 +22,6 @@ use crate::{
 /// Client for Lease operations.
 #[derive(Clone, Debug)]
 pub struct LeaseClient {
-    /// Name of the LeaseClient, which will be used in CURP propose id generation
-    name: String,
     /// The client running the CURP protocol, communicate with all servers.
     curp_client: Arc<CurpClient<Command>>,
     /// The lease RPC client, only communicate with one server at a time
@@ -38,14 +36,12 @@ impl LeaseClient {
     /// Creates a new `LeaseClient`
     #[inline]
     pub fn new(
-        name: String,
         curp_client: Arc<CurpClient<Command>>,
         channel: Channel,
         token: Option<String>,
         id_gen: Arc<LeaseIdGenerator>,
     ) -> Self {
         Self {
-            name,
             curp_client,
             lease_client: xlineapi::LeaseClient::new(AuthService::new(
                 channel,
@@ -85,7 +81,7 @@ impl LeaseClient {
     /// ```
     #[inline]
     pub async fn grant(&self, mut request: LeaseGrantRequest) -> Result<LeaseGrantResponse> {
-        let propose_id = generate_propose_id(&self.name);
+        let propose_id = self.curp_client.gen_propose_id().await?;
         if request.inner.id == 0 {
             request.inner.id = self.id_gen.next();
         }
@@ -260,7 +256,7 @@ impl LeaseClient {
     /// ```
     #[inline]
     pub async fn leases(&self) -> Result<LeaseLeasesResponse> {
-        let propose_id = generate_propose_id(&self.name);
+        let propose_id = self.curp_client.gen_propose_id().await?;
         let request = RequestWithToken::new_with_token(
             xlineapi::LeaseLeasesRequest {}.into(),
             self.token.clone(),

--- a/xline-client/src/lib.rs
+++ b/xline-client/src/lib.rs
@@ -213,7 +213,6 @@ impl Client {
             .into_iter()
             .map(|addr| addr.as_ref().to_owned())
             .collect();
-        let name = String::from("client");
         let channel = Self::build_channel(addrs.clone()).await?;
         let curp_client = Arc::new(
             CurpClient::builder()
@@ -225,12 +224,7 @@ impl Client {
 
         let token = match options.user {
             Some((username, password)) => {
-                let mut tmp_auth = AuthClient::new(
-                    name.clone(),
-                    Arc::clone(&curp_client),
-                    channel.clone(),
-                    None,
-                );
+                let mut tmp_auth = AuthClient::new(Arc::clone(&curp_client), channel.clone(), None);
                 let resp = tmp_auth
                     .authenticate(types::auth::AuthenticateRequest::new(username, password))
                     .await?;
@@ -240,22 +234,20 @@ impl Client {
             None => None,
         };
 
-        let kv = KvClient::new(name.clone(), Arc::clone(&curp_client), token.clone());
+        let kv = KvClient::new(Arc::clone(&curp_client), token.clone());
         let lease = LeaseClient::new(
-            name.clone(),
             Arc::clone(&curp_client),
             channel.clone(),
             token.clone(),
             Arc::clone(&id_gen),
         );
         let lock = LockClient::new(
-            name.clone(),
             Arc::clone(&curp_client),
             channel.clone(),
             token.clone(),
             id_gen,
         );
-        let auth = AuthClient::new(name.clone(), curp_client, channel.clone(), token.clone());
+        let auth = AuthClient::new(curp_client, channel.clone(), token.clone());
         let maintenance = MaintenanceClient::new(channel.clone(), token.clone());
         let watch = WatchClient::new(channel, token);
         let cluster = ClusterClient::new();

--- a/xline/src/client/mod.rs
+++ b/xline/src/client/mod.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use curp::{client::Client as CurpClient, cmd::generate_propose_id};
+use curp::client::Client as CurpClient;
 use etcd_client::{
     AuthClient, Client as EtcdClient, KvClient, LeaseClient, LeaseKeepAliveStream, LeaseKeeper,
     LockClient, MaintenanceClient, WatchClient,
@@ -95,7 +95,7 @@ impl Client {
     pub async fn put(&mut self, request: PutRequest) -> Result<PutResponse, ClientError> {
         if self.use_curp_client {
             let key_ranges = vec![KeyRange::new_one_key(request.key())];
-            let propose_id = generate_propose_id(&self.name);
+            let propose_id = self.curp_client.gen_propose_id().await?;
             let request = RequestWithToken::new(rpc::PutRequest::from(request).into());
             let cmd = Command::new(key_ranges, request, propose_id);
             let (cmd_res, _sync_res) = self.curp_client.propose(cmd, true).await?;
@@ -119,7 +119,7 @@ impl Client {
     pub async fn range(&mut self, request: RangeRequest) -> Result<RangeResponse, ClientError> {
         if self.use_curp_client {
             let key_ranges = vec![KeyRange::new(request.key(), request.range_end())];
-            let propose_id = generate_propose_id(&self.name);
+            let propose_id = self.curp_client.gen_propose_id().await?;
             let request = RequestWithToken::new(rpc::RangeRequest::from(request).into());
             let cmd = Command::new(key_ranges, request, propose_id);
             let (cmd_res, _sync_res) = self.curp_client.propose(cmd, true).await?;
@@ -143,7 +143,7 @@ impl Client {
     ) -> Result<DeleteRangeResponse, ClientError> {
         if self.use_curp_client {
             let key_ranges = vec![KeyRange::new(request.key(), request.range_end())];
-            let propose_id = generate_propose_id(&self.name);
+            let propose_id = self.curp_client.gen_propose_id().await?;
             let request = RequestWithToken::new(rpc::DeleteRangeRequest::from(request).into());
             let cmd = Command::new(key_ranges, request, propose_id);
             let (cmd_res, _sync_res) = self.curp_client.propose(cmd, true).await?;

--- a/xline/src/server/xline_server.rs
+++ b/xline/src/server/xline_server.rs
@@ -379,12 +379,10 @@ impl XlineServer {
                 id_barrier,
                 *self.server_timeout.range_retry_timeout(),
                 Arc::clone(&client),
-                self.cluster_info.self_name(),
             ),
             LockServer::new(
                 Arc::clone(&client),
                 Arc::clone(&id_gen),
-                self.cluster_info.self_name(),
                 self.cluster_info.self_addrs(),
             ),
             LeaseServer::new(
@@ -395,7 +393,7 @@ impl XlineServer {
                 Arc::clone(&self.cluster_info),
                 self.shutdown_trigger.subscribe(),
             ),
-            AuthServer::new(client, self.cluster_info.self_name()),
+            AuthServer::new(client),
             WatchServer::new(
                 watcher,
                 Arc::clone(&header_gen),


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    This PR refactors ProposeId into `<client_id>#<seq_num>`, The client_id will be generated by the lease manager(not implemented in this PR), and the seq_num will ensure that all IDs are unique and ordered under the same client_id.

* what changes does this pull request make?

    As above

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

    No
