### PR TITLE
chore: re-export response type in client

### DIFF
--- a/xline-client/src/types/kv.rs
+++ b/xline-client/src/types/kv.rs
@@ -1,7 +1,7 @@
 use xline::server::KeyRange;
 pub use xlineapi::{
-    CompareResult, CompareTarget, DeleteRangeResponse, PutResponse, RangeResponse, Response,
-    ResponseOp, SortOrder, SortTarget, TargetUnion, TxnResponse,
+    CompactionResponse, CompareResult, CompareTarget, DeleteRangeResponse, PutResponse,
+    RangeResponse, Response, ResponseOp, SortOrder, SortTarget, TargetUnion, TxnResponse,
 };
 
 /// Request type for `Put`

--- a/xline-client/src/types/lock.rs
+++ b/xline-client/src/types/lock.rs
@@ -1,3 +1,5 @@
+pub use xlineapi::{LockResponse, UnlockResponse};
+
 /// Default session ttl
 const DEFAULT_SESSION_TTL: i64 = 60;
 

--- a/xline-client/src/types/maintenance.rs
+++ b/xline-client/src/types/maintenance.rs
@@ -1,0 +1,1 @@
+pub use xlineapi::SnapshotResponse;

--- a/xline-client/src/types/mod.rs
+++ b/xline-client/src/types/mod.rs
@@ -6,5 +6,7 @@ pub mod kv;
 pub mod lease;
 /// Lock type definitions.
 pub mod lock;
+/// Maintenance type definitions.
+pub mod maintenance;
 /// Watch type definitions.
 pub mod watch;


### PR DESCRIPTION
We don't need to import the xlineapi crate separately when using the xline client.

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
