### PR TITLE
fix: add linearizable parameter in FetchClusterRequest

### DIFF
--- a/curp/src/server/raw_curp/mod.rs
+++ b/curp/src/server/raw_curp/mod.rs
@@ -772,8 +772,9 @@ impl<C: 'static + Command, RC: RoleChange + 'static> RawCurp<C, RC> {
     }
 
     /// Get the leader id, attached with the term
-    pub(super) fn leader(&self) -> (Option<ServerId>, u64) {
-        self.st.map_read(|st_r| (st_r.leader_id, st_r.term))
+    pub(super) fn leader(&self) -> (Option<ServerId>, u64, bool) {
+        self.st
+            .map_read(|st_r| (st_r.leader_id, st_r.term, st_r.role == Role::Leader))
     }
 
     /// Get cluster info

--- a/curp/tests/common/curp_group.rs
+++ b/curp/tests/common/curp_group.rs
@@ -233,7 +233,7 @@ impl CurpGroup {
 
             let FetchClusterResponse {
                 leader_id, term, ..
-            } = if let Ok(resp) = client.fetch_cluster(FetchClusterRequest {}).await {
+            } = if let Ok(resp) = client.fetch_cluster(FetchClusterRequest::default()).await {
                 resp.into_inner()
             } else {
                 continue;
@@ -271,7 +271,7 @@ impl CurpGroup {
 
             let FetchClusterResponse {
                 leader_id, term, ..
-            } = if let Ok(resp) = client.fetch_cluster(FetchClusterRequest {}).await {
+            } = if let Ok(resp) = client.fetch_cluster(FetchClusterRequest::default()).await {
                 resp.into_inner()
             } else {
                 continue;

--- a/curp/tests/read_state.rs
+++ b/curp/tests/read_state.rs
@@ -40,7 +40,7 @@ async fn read_state() {
         );
     }
 
-    sleep_millis(100).await;
+    sleep_millis(500).await;
 
     let res = get_client
         .fetch_read_state(&TestCommand::new_get(vec![0]))

--- a/simulation/src/curp_group.rs
+++ b/simulation/src/curp_group.rs
@@ -230,7 +230,8 @@ impl CurpGroup {
 
                     let FetchClusterResponse {
                         leader_id, term, ..
-                    } = if let Ok(resp) = client.fetch_cluster(FetchClusterRequest {}).await {
+                    } = if let Ok(resp) = client.fetch_cluster(FetchClusterRequest::default()).await
+                    {
                         resp.into_inner()
                     } else {
                         continue;
@@ -274,12 +275,13 @@ impl CurpGroup {
                         continue;
                     };
 
-                    let FetchClusterResponse { term, .. } =
-                        if let Ok(resp) = client.fetch_cluster(FetchClusterRequest {}).await {
-                            resp.into_inner()
-                        } else {
-                            continue;
-                        };
+                    let FetchClusterResponse { term, .. } = if let Ok(resp) =
+                        client.fetch_cluster(FetchClusterRequest::default()).await
+                    {
+                        resp.into_inner()
+                    } else {
+                        continue;
+                    };
 
                     if let Some(max_term) = max_term {
                         assert_eq!(max_term, term);

--- a/xline-test-utils/src/bin/validation_lock_client.rs
+++ b/xline-test-utils/src/bin/validation_lock_client.rs
@@ -45,11 +45,11 @@ async fn main() -> Result<()> {
         .lock_client();
     match args.command {
         Commands::Lock { name } => {
-            let lock_res = client.lock(LockRequest::new().with_name(name)).await?;
+            let lock_res = client.lock(LockRequest::new(name)).await?;
             println!("{}", String::from_utf8_lossy(&lock_res.key))
         }
         Commands::Unlock { key } => {
-            let _unlock_res = client.unlock(UnlockRequest::new().with_key(key)).await?;
+            let _unlock_res = client.unlock(UnlockRequest::new(key)).await?;
             println!("unlock success");
         }
     };

--- a/xline/src/server/cluster_server.rs
+++ b/xline/src/server/cluster_server.rs
@@ -141,17 +141,9 @@ impl Cluster for ClusterServer {
     ) -> Result<Response<MemberListResponse>, Status> {
         let req = request.into_inner();
         let header = self.header_gen.gen_header();
-        if req.linearizable {
-            let members = self.propose_conf_change(vec![]).await?;
-            let resp = MemberListResponse {
-                header: Some(header),
-                members,
-            };
-            return Ok(Response::new(resp));
-        }
         let members = self
             .client
-            .get_cluster_from_curp()
+            .get_cluster_from_curp(req.linearizable)
             .await
             .map_err(propose_err_to_status)?
             .members;

--- a/xline/src/server/maintenance.rs
+++ b/xline/src/server/maintenance.rs
@@ -82,7 +82,7 @@ where
     ) -> Result<tonic::Response<StatusResponse>, tonic::Status> {
         let cluster = self
             .client
-            .get_cluster_from_curp()
+            .get_cluster_from_curp(false)
             .await
             .map_err(propose_err_to_status)?;
         let header = self.header_gen.gen_header();

--- a/xline/tests/lock_test.rs
+++ b/xline/tests/lock_test.rs
@@ -21,20 +21,15 @@ async fn test_lock() -> Result<(), Box<dyn Error>> {
     let lock_handle = tokio::spawn({
         let c = lock_client.clone();
         async move {
-            let res = c.lock(LockRequest::new().with_name("test")).await.unwrap();
+            let res = c.lock(LockRequest::new("test")).await.unwrap();
             time::sleep(Duration::from_secs(3)).await;
-            let _res = c
-                .unlock(UnlockRequest::new().with_key(res.key))
-                .await
-                .unwrap();
+            let _res = c.unlock(UnlockRequest::new(res.key)).await.unwrap();
         }
     });
 
     time::sleep(Duration::from_secs(1)).await;
     let now = time::Instant::now();
-    let res = lock_client
-        .lock(LockRequest::new().with_name("test"))
-        .await?;
+    let res = lock_client.lock(LockRequest::new("test")).await?;
     let elapsed = now.elapsed();
     assert!(res.key.starts_with(b"test"));
     assert!(elapsed >= Duration::from_secs(1));
@@ -57,12 +52,12 @@ async fn test_lock_timeout() -> Result<(), Box<dyn Error>> {
         .await?
         .id;
     let _res = lock_client
-        .lock(LockRequest::new().with_name("test").with_lease(lease_id))
+        .lock(LockRequest::new("test").with_lease(lease_id))
         .await?;
 
     let res = timeout(
         Duration::from_secs(3),
-        lock_client.lock(LockRequest::new().with_name("test")),
+        lock_client.lock(LockRequest::new("test")),
     )
     .await??;
     assert!(res.key.starts_with(b"test"));


### PR DESCRIPTION
Please briefly answer these questions:

proto changes: https://github.com/xline-kv/curp-proto/pull/14

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

 Fix linearizable read in FetchClusterRequest

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
