### PR TITLE
refactor: refactor propose id

### DIFF
--- a/curp-test-utils/src/test_cmd.rs
+++ b/curp-test-utils/src/test_cmd.rs
@@ -27,13 +27,13 @@ pub(crate) const APPLIED_INDEX_KEY: &str = "applied_index";
 pub(crate) const LAST_REVISION_KEY: &str = "last_revision";
 
 /// Test client id
-pub const TEST_CLIENT_ID: &str = "test_client_id";
+pub const TEST_CLIENT_ID: u64 = 12345;
 
 static NEXT_ID: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(1));
 
-pub fn next_id() -> String {
+pub fn next_id() -> ProposeId {
     let seq_num = NEXT_ID.fetch_add(1, Ordering::Relaxed);
-    format!("{TEST_CLIENT_ID}#{seq_num}")
+    ProposeId(TEST_CLIENT_ID, seq_num)
 }
 
 #[derive(Error, Debug, Clone, Serialize, Deserialize)]
@@ -207,8 +207,8 @@ impl Command for TestCommand {
         &self.keys
     }
 
-    fn id(&self) -> &ProposeId {
-        &self.id
+    fn id(&self) -> ProposeId {
+        self.id
     }
 }
 

--- a/curp/build.rs
+++ b/curp/build.rs
@@ -6,7 +6,6 @@ fn main() {
         )
         .compile(
             &[
-                "./proto/common/src/message.proto",
                 "./proto/common/src/curp-error.proto",
                 "./proto/common/src/curp-command.proto",
             ],

--- a/curp/src/log_entry.rs
+++ b/curp/src/log_entry.rs
@@ -65,7 +65,7 @@ where
     }
 
     /// Get the id of the entry
-    pub(super) fn id(&self) -> &ProposeId {
+    pub(super) fn id(&self) -> ProposeId {
         match self.entry_data {
             EntryData::Command(ref cmd) => cmd.id(),
             EntryData::ConfChange(ref e) => e.id(),

--- a/curp/src/rpc/connect.rs
+++ b/curp/src/rpc/connect.rs
@@ -25,8 +25,8 @@ use crate::{
     members::ServerId,
     rpc::{
         proto::{
+            commandpb::protocol_client::ProtocolClient,
             inner_messagepb::inner_protocol_client::InnerProtocolClient,
-            messagepb::protocol_client::ProtocolClient,
         },
         AppendEntriesRequest, AppendEntriesResponse, FetchClusterRequest, FetchClusterResponse,
         FetchReadStateRequest, FetchReadStateResponse, InstallSnapshotRequest,

--- a/curp/src/server/cmd_worker/mod.rs
+++ b/curp/src/server/cmd_worker/mod.rs
@@ -111,10 +111,10 @@ async fn worker_exe<
                 ce.execute(cmd, entry.index).await
             };
             let er_ok = er.is_ok();
-            cb.write().insert_er(entry.id(), er);
+            cb.write().insert_er(&entry.id(), er);
             if !er_ok {
-                sp.lock().remove(entry.id());
-                let _ig = ucp.lock().remove(entry.id());
+                sp.lock().remove(&entry.id());
+                let _ig = ucp.lock().remove(&entry.id());
             }
             debug!(
                 "{id} cmd({}) is speculatively executed, exe status: {er_ok}",
@@ -146,9 +146,9 @@ async fn worker_as<
         };
             let asr = ce.after_sync(cmd.as_ref(), entry.index, prepare).await;
             let asr_ok = asr.is_ok();
-            cb.write().insert_asr(entry.id(), asr);
-            sp.lock().remove(entry.id());
-            let _ig = ucp.lock().remove(entry.id());
+            cb.write().insert_asr(&entry.id(), asr);
+            sp.lock().remove(&entry.id());
+            let _ig = ucp.lock().remove(&entry.id());
             debug!("{id} cmd({}) after sync is called", entry.id());
             asr_ok
         }
@@ -170,7 +170,7 @@ async fn worker_as<
             });
             let shutdown_self =
                 change.change_type() == ConfChangeType::Remove && change.node_id == id;
-            cb.write().insert_conf(entry.id());
+            cb.write().insert_conf(&entry.id());
             if shutdown_self {
                 curp.shutdown_trigger().self_shutdown();
             }

--- a/curp/src/server/cmd_worker/mod.rs
+++ b/curp/src/server/cmd_worker/mod.rs
@@ -111,7 +111,7 @@ async fn worker_exe<
                 ce.execute(cmd, entry.index).await
             };
             let er_ok = er.is_ok();
-            cb.write().insert_er(&entry.id(), er);
+            cb.write().insert_er(entry.id(), er);
             if !er_ok {
                 sp.lock().remove(&entry.id());
                 let _ig = ucp.lock().remove(&entry.id());
@@ -146,7 +146,7 @@ async fn worker_as<
         };
             let asr = ce.after_sync(cmd.as_ref(), entry.index, prepare).await;
             let asr_ok = asr.is_ok();
-            cb.write().insert_asr(&entry.id(), asr);
+            cb.write().insert_asr(entry.id(), asr);
             sp.lock().remove(&entry.id());
             let _ig = ucp.lock().remove(&entry.id());
             debug!("{id} cmd({}) after sync is called", entry.id());
@@ -170,7 +170,7 @@ async fn worker_as<
             });
             let shutdown_self =
                 change.change_type() == ConfChangeType::Remove && change.node_id == id;
-            cb.write().insert_conf(&entry.id());
+            cb.write().insert_conf(entry.id());
             if shutdown_self {
                 curp.shutdown_trigger().self_shutdown();
             }

--- a/curp/src/server/curp_node.rs
+++ b/curp/src/server/curp_node.rs
@@ -135,7 +135,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
         let ((leader_id, term), result) = self.curp.handle_propose(Arc::clone(&cmd));
         let resp = match result {
             Ok(true) => {
-                let er_res = CommandBoard::wait_for_er(&self.cmd_board, cmd.id()).await;
+                let er_res = CommandBoard::wait_for_er(&self.cmd_board, &cmd.id()).await;
                 ProposeResponse::new_result::<C>(leader_id, term, &er_res)
             }
             Ok(false) => ProposeResponse::new_empty(leader_id, term),
@@ -167,7 +167,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
         &self,
         req: ProposeConfChangeRequest,
     ) -> Result<ProposeConfChangeResponse, CurpError> {
-        let id = req.id.clone();
+        let id = req.id();
         let ((leader_id, term), result) = self.curp.handle_propose_conf_change(req.into());
         let error = match result {
             Ok(()) => {
@@ -240,7 +240,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
         let id = req.propose_id();
         debug!("{} get wait synced request for cmd({id})", self.curp.id());
 
-        let (er, asr) = CommandBoard::wait_for_er_asr(&self.cmd_board, id).await;
+        let (er, asr) = CommandBoard::wait_for_er_asr(&self.cmd_board, &id).await;
         let resp = WaitSyncedResponse::new_from_result::<C>(Some(er), asr);
 
         debug!("{} wait synced for cmd({id}) finishes", self.curp.id());
@@ -341,7 +341,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
         req: FetchReadStateRequest,
     ) -> Result<FetchReadStateResponse, CurpError> {
         let cmd = req.cmd()?;
-        let state = self.curp.handle_fetch_read_state(&cmd)?;
+        let state = self.curp.handle_fetch_read_state(&cmd);
         Ok(FetchReadStateResponse::new(state))
     }
 }

--- a/curp/src/server/curp_node.rs
+++ b/curp/src/server/curp_node.rs
@@ -135,7 +135,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
         let ((leader_id, term), result) = self.curp.handle_propose(Arc::clone(&cmd));
         let resp = match result {
             Ok(true) => {
-                let er_res = CommandBoard::wait_for_er(&self.cmd_board, &cmd.id()).await;
+                let er_res = CommandBoard::wait_for_er(&self.cmd_board, cmd.id()).await;
                 ProposeResponse::new_result::<C>(leader_id, term, &er_res)
             }
             Ok(false) => ProposeResponse::new_empty(leader_id, term),
@@ -171,7 +171,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
         let ((leader_id, term), result) = self.curp.handle_propose_conf_change(req.into());
         let error = match result {
             Ok(()) => {
-                CommandBoard::wait_for_conf(&self.cmd_board, &id).await;
+                CommandBoard::wait_for_conf(&self.cmd_board, id).await;
                 None
             }
             Err(err) => Some(err),
@@ -240,7 +240,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
         let id = req.propose_id();
         debug!("{} get wait synced request for cmd({id})", self.curp.id());
 
-        let (er, asr) = CommandBoard::wait_for_er_asr(&self.cmd_board, &id).await;
+        let (er, asr) = CommandBoard::wait_for_er_asr(&self.cmd_board, id).await;
         let resp = WaitSyncedResponse::new_from_result::<C>(Some(er), asr);
 
         debug!("{} wait synced for cmd({id}) finishes", self.curp.id());

--- a/curp/src/server/mod.rs
+++ b/curp/src/server/mod.rs
@@ -381,7 +381,7 @@ where
     C: Command,
 {
     /// Propose id
-    pub(crate) fn id(&self) -> &ProposeId {
+    pub(crate) fn id(&self) -> ProposeId {
         match *self {
             Self::Command(ref cmd) => cmd.id(),
             Self::ConfChange(ref conf_change) => conf_change.id(),

--- a/curp/src/server/raw_curp/log.rs
+++ b/curp/src/server/raw_curp/log.rs
@@ -356,7 +356,7 @@ impl<C: 'static + Command> Log<C> {
     }
 
     /// Get existing cmd ids
-    pub(super) fn get_cmd_ids(&self) -> HashSet<&ProposeId> {
+    pub(super) fn get_cmd_ids(&self) -> HashSet<ProposeId> {
         self.entries.iter().map(|entry| entry.id()).collect()
     }
 

--- a/curp/src/server/raw_curp/tests.rs
+++ b/curp/src/server/raw_curp/tests.rs
@@ -916,7 +916,7 @@ fn leader_handle_propose_conf_change() {
         follower_id,
         vec!["http://127.0.0.1:4567".to_owned()],
     )];
-    let conf_change_entry = ProposeConfChangeRequest::new("test_id".to_owned(), changes);
+    let conf_change_entry = ProposeConfChangeRequest::new(ProposeId(0, 0), changes);
     let ((leader, term), result) = curp.handle_propose_conf_change(conf_change_entry.into());
     assert_eq!(leader, Some(curp.id().clone()));
     assert_eq!(term, 1);
@@ -941,7 +941,7 @@ fn follower_handle_propose_conf_change() {
         follower_id,
         vec!["http://127.0.0.1:4567".to_owned()],
     )];
-    let conf_change_entry = ProposeConfChangeRequest::new("test_id".to_owned(), changes);
+    let conf_change_entry = ProposeConfChangeRequest::new(ProposeId(0, 0), changes);
     let ((leader, term), result) = curp.handle_propose_conf_change(conf_change_entry.into());
     assert_eq!(leader, None);
     assert_eq!(term, 2);

--- a/curp/src/server/spec_pool.rs
+++ b/curp/src/server/spec_pool.rs
@@ -31,8 +31,8 @@ impl<C: Command + 'static> SpeculativePool<C> {
         if self.has_conflict_with(&entry) {
             Some(entry)
         } else {
-            let id = entry.id().clone();
-            let result = self.pool.insert(id.clone(), entry);
+            let id = entry.id();
+            let result = self.pool.insert(id, entry);
             if result.is_none() {
                 debug!("insert cmd({id}) into spec pool");
             } else {

--- a/curp/tests/common/curp_group.rs
+++ b/curp/tests/common/curp_group.rs
@@ -35,20 +35,17 @@ use utils::{
     config::{ClientConfig, CurpConfigBuilder, StorageConfig},
     shutdown::{self, Trigger},
 };
-
-pub mod proto {
-    tonic::include_proto!("messagepb");
-}
 pub mod commandpb {
     tonic::include_proto!("commandpb");
 }
 pub mod errorpb {
     tonic::include_proto!("errorpb");
 }
-pub use commandpb::{ProposeRequest, ProposeResponse};
-pub use proto::protocol_client::ProtocolClient;
 
-use self::proto::{FetchClusterRequest, FetchClusterResponse};
+pub use commandpb::{
+    protocol_client::ProtocolClient, FetchClusterRequest, FetchClusterResponse, ProposeRequest,
+    ProposeResponse,
+};
 
 pub struct CurpNode {
     pub id: ServerId,

--- a/curp/tests/read_state.rs
+++ b/curp/tests/read_state.rs
@@ -18,7 +18,7 @@ async fn read_state() {
     let group = CurpGroup::new(3).await;
     let put_client = group.new_client().await;
     let put_cmd = TestCommand::new_put(vec![0], 0).set_exe_dur(Duration::from_millis(100));
-    let put_id = put_cmd.id().clone();
+    let put_id = put_cmd.id();
     tokio::spawn(async move {
         assert_eq!(
             put_client.propose(put_cmd, true).await.unwrap().0,

--- a/xline/src/server/barriers.rs
+++ b/xline/src/server/barriers.rs
@@ -114,13 +114,13 @@ mod test {
             .map(|i| {
                 let id_barrier = Arc::clone(&id_barrier);
                 tokio::spawn(async move {
-                    id_barrier.wait(i.to_string()).await;
+                    id_barrier.wait(ProposeId(i, i)).await;
                 })
             })
             .collect::<Vec<_>>();
         sleep(Duration::from_millis(10)).await;
         for i in 0..5 {
-            id_barrier.trigger(&i.to_string());
+            id_barrier.trigger(&ProposeId(i, i));
         }
         timeout(Duration::from_millis(100), join_all(barriers))
             .await

--- a/xline/src/server/barriers.rs
+++ b/xline/src/server/barriers.rs
@@ -89,8 +89,8 @@ impl IdBarrier {
     }
 
     /// Trigger the barrier of the given id.
-    pub(crate) fn trigger(&self, id: &ProposeId) {
-        if let Some(event) = self.barriers.lock().remove(id) {
+    pub(crate) fn trigger(&self, id: ProposeId) {
+        if let Some(event) = self.barriers.lock().remove(&id) {
             event.notify(usize::MAX);
         }
     }
@@ -120,7 +120,7 @@ mod test {
             .collect::<Vec<_>>();
         sleep(Duration::from_millis(10)).await;
         for i in 0..5 {
-            id_barrier.trigger(&ProposeId(i, i));
+            id_barrier.trigger(ProposeId(i, i));
         }
         timeout(Duration::from_millis(100), join_all(barriers))
             .await

--- a/xline/src/server/cluster_server.rs
+++ b/xline/src/server/cluster_server.rs
@@ -50,7 +50,7 @@ impl ClusterServer {
         Ok(self
             .client
             .propose_conf_change(ProposeConfChangeRequest {
-                id: propose_id,
+                propose_id: Some(propose_id.into()),
                 changes,
             })
             .await

--- a/xline/src/server/command.rs
+++ b/xline/src/server/command.rs
@@ -309,7 +309,7 @@ where
     ) -> Result<<Command as CurpCommand>::PR, <Command as CurpCommand>::Error> {
         let wrapper = cmd.request();
         if let Err(e) = self.auth_storage.check_permission(wrapper) {
-            self.id_barrier.trigger(&cmd.id());
+            self.id_barrier.trigger(cmd.id());
             self.index_barrier.trigger(index);
             return Err(e);
         }
@@ -346,7 +346,7 @@ where
         match res {
             Ok(res) => Ok(res),
             Err(e) => {
-                self.id_barrier.trigger(&cmd.id());
+                self.id_barrier.trigger(cmd.id());
                 self.index_barrier.trigger(index);
                 Err(e)
             }
@@ -372,7 +372,7 @@ where
             self.kv_storage.insert_index(key_revisions);
         }
         self.lease_storage.mark_lease_synced(&wrapper.request);
-        self.id_barrier.trigger(&cmd.id());
+        self.id_barrier.trigger(cmd.id());
         self.index_barrier.trigger(index);
         Ok(res)
     }

--- a/xlineapi/src/lib.rs
+++ b/xlineapi/src/lib.rs
@@ -187,7 +187,7 @@ mod errorpb {
     tonic::include_proto!("errorpb");
 }
 
-use curp_external_api::cmd::PbSerializeError;
+use curp_external_api::cmd::{PbSerializeError, ProposeId};
 use serde::{Deserialize, Serialize};
 
 pub use self::{
@@ -195,7 +195,8 @@ pub use self::{
     commandpb::{
         command_response::ResponseWrapper, request_with_token::RequestWrapper,
         Command as PbCommand, CommandResponse as PbCommandResponse, KeyRange as PbKeyRange,
-        RequestWithToken as PbRequestWithToken, SyncResponse as PbSyncResponse,
+        ProposeId as PbProposeId, RequestWithToken as PbRequestWithToken,
+        SyncResponse as PbSyncResponse,
     },
     errorpb::{
         execute_error::Error as PbExecuteError, ExecuteError as PbExecuteErrorOuter,
@@ -248,6 +249,23 @@ pub use self::{
         LockRequest, LockResponse, UnlockRequest, UnlockResponse,
     },
 };
+
+impl From<PbProposeId> for ProposeId {
+    #[inline]
+    fn from(id: PbProposeId) -> Self {
+        Self(id.client_id, id.seq_num)
+    }
+}
+
+impl From<ProposeId> for PbProposeId {
+    #[inline]
+    fn from(id: ProposeId) -> Self {
+        Self {
+            client_id: id.0,
+            seq_num: id.1,
+        }
+    }
+}
 
 impl User {
     /// Check if user has the given role


### PR DESCRIPTION
Please briefly answer these questions:

proto changes: https://github.com/xline-kv/curp-proto/pull/15 https://github.com/xline-kv/xline-proto/pull/5

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    Refactor propose id into `ProposeId(u64, u64)`

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
