### PR TITLE
fix: fix leader_crash_and_recovery test case

### DIFF
--- a/curp/src/server/raw_curp/mod.rs
+++ b/curp/src/server/raw_curp/mod.rs
@@ -640,10 +640,10 @@ impl<C: 'static + Command, RC: RoleChange + 'static> RawCurp<C, RC> {
         let mut log_w = self.log.write();
 
         let prev_last_log_index = log_w.last_log_index();
-        self.recover_from_spec_pools(&mut st_w, &mut log_w, spec_pools);
         // TODO: Generate client id in the same way as client
         let propose_id = ProposeId(rand::random(), 0);
         let _ignore = log_w.push(st_w.term, EntryData::Empty(propose_id));
+        self.recover_from_spec_pools(&mut st_w, &mut log_w, spec_pools);
         self.recover_ucp_from_log(&mut log_w);
         let last_log_index = log_w.last_log_index();
 

--- a/simulation/tests/it/curp/server_recovery.rs
+++ b/simulation/tests/it/curp/server_recovery.rs
@@ -53,12 +53,12 @@ async fn leader_crash_and_recovery() {
     let (_cmd, er) = old_leader.exe_rx.recv().await.unwrap();
     assert_eq!(er.values, Vec::<u32>::new());
     let asr = old_leader.as_rx.recv().await.unwrap();
-    assert_eq!(asr.1, 2); // log index 1 is the empty log
+    assert_eq!(asr.1, 3); // log index 1 and 2 is the empty log
 
     let (_cmd, er) = old_leader.exe_rx.recv().await.unwrap();
     assert_eq!(er.values, vec![0]);
     let asr = old_leader.as_rx.recv().await.unwrap();
-    assert_eq!(asr.1, 4); // log index 3 is the empty log
+    assert_eq!(asr.1, 4); // log index 1 and 2 is the empty log
 }
 
 #[madsim::test]


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
fix leader_crash_and_recovery test case
* what changes does this pull request make?
push empty log before recover logs from spec pool
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no