### PR TITLE
feat: publish the name of new node to cluster when node start

### DIFF
--- a/curp/src/rpc/mod.rs
+++ b/curp/src/rpc/mod.rs
@@ -11,7 +11,8 @@ pub use self::proto::{
         protocol_client,
         protocol_server::ProtocolServer,
         CmdResult, FetchClusterRequest, FetchClusterResponse, Member, ProposeConfChangeRequest,
-        ProposeConfChangeResponse, ProposeRequest, ProposeResponse,
+        ProposeConfChangeResponse, ProposeRequest, ProposeResponse, PublishRequest,
+        PublishResponse,
     },
     inner_messagepb::inner_protocol_server::InnerProtocolServer,
 };
@@ -635,5 +636,30 @@ impl From<ConfChangeError> for tonic::Status {
     fn from(_err: ConfChangeError) -> Self {
         // we'd better expose some err messages for client
         tonic::Status::invalid_argument("")
+    }
+}
+
+impl PublishRequest {
+    /// Create a new `PublishRequest`
+    #[inline]
+    #[must_use]
+    pub fn new(id: ProposeId, node_id: ServerId, name: String) -> Self {
+        Self {
+            propose_id: Some(id.into()),
+            node_id,
+            name,
+        }
+    }
+
+    /// Get id of the request
+    #[inline]
+    #[must_use]
+    pub fn id(&self) -> ProposeId {
+        self.propose_id
+            .clone()
+            .unwrap_or_else(|| {
+                unreachable!("propose id should be set in propose conf change request")
+            })
+            .into()
     }
 }

--- a/curp/src/server/cmd_worker/conflict_checked_mpmc.rs
+++ b/curp/src/server/cmd_worker/conflict_checked_mpmc.rs
@@ -347,9 +347,10 @@ impl<C: Command, CE: CommandExecutor<C>> Filter<C, CE> {
                                 Err(err) => Some(err),
                             }
                         }
-                        EntryData::ConfChange(_) | EntryData::Shutdown(_) | EntryData::Empty(_) => {
-                            None
-                        }
+                        EntryData::ConfChange(_)
+                        | EntryData::Shutdown(_)
+                        | EntryData::Empty(_)
+                        | EntryData::SetName(_, _, _) => None,
                     };
                     *exe_st = ExeState::Executing;
                     let task = Task {

--- a/curp/src/server/cmd_worker/mod.rs
+++ b/curp/src/server/cmd_worker/mod.rs
@@ -124,7 +124,10 @@ async fn worker_exe<
             );
             er_ok
         }
-        EntryData::ConfChange(_) | EntryData::Shutdown(_) | EntryData::Empty(_) => true,
+        EntryData::ConfChange(_)
+        | EntryData::Shutdown(_)
+        | EntryData::Empty(_)
+        | EntryData::SetName(_, _, _) => true,
     }
 }
 
@@ -176,6 +179,14 @@ async fn worker_as<
             if shutdown_self {
                 curp.shutdown_trigger().self_shutdown();
             }
+            true
+        }
+        EntryData::SetName(_, node_id, ref name) => {
+            if let Err(e) = ce.set_last_applied(entry.index) {
+                error!("failed to set last_applied, {e}");
+                return false;
+            }
+            curp.cluster().set_name(node_id, name.clone());
             true
         }
         EntryData::Empty(_) => true,

--- a/curp/src/server/mod.rs
+++ b/curp/src/server/mod.rs
@@ -27,7 +27,7 @@ use crate::{
         ProposeRequest, ProposeResponse, ProtocolServer, ShutdownRequest, ShutdownResponse,
         VoteRequest, VoteResponse, WaitSyncedRequest, WaitSyncedResponse,
     },
-    ConfChangeEntry,
+    ConfChangeEntry, PublishRequest, PublishResponse,
 };
 
 /// Command worker to do execution and after sync
@@ -95,6 +95,17 @@ impl<C: 'static + Command, RC: RoleChange + 'static> crate::rpc::Protocol for Rp
         request.metadata().extract_span();
         Ok(tonic::Response::new(
             self.inner.propose_conf_change(request.into_inner()).await?,
+        ))
+    }
+
+    #[instrument(skip_all, name = "curp_publish")]
+    async fn publish(
+        &self,
+        request: tonic::Request<PublishRequest>,
+    ) -> Result<tonic::Response<PublishResponse>, tonic::Status> {
+        request.metadata().extract_span();
+        Ok(tonic::Response::new(
+            self.inner.publish(request.into_inner())?,
         ))
     }
 

--- a/curp/tests/common/curp_group.rs
+++ b/curp/tests/common/curp_group.rs
@@ -357,7 +357,7 @@ impl CurpGroup {
         ProtocolClient::connect(addr.clone()).await.unwrap()
     }
 
-    pub async fn fetch_cluster_info(&self, addrs: &[String]) -> ClusterInfo {
+    pub async fn fetch_cluster_info(&self, addrs: &[String], name: &str) -> ClusterInfo {
         let leader_id = self.get_leader().await.0;
         let mut connect = self.get_connect(&leader_id).await;
         let cluster_res_base = connect
@@ -379,7 +379,7 @@ impl CurpGroup {
             members,
             cluster_version: cluster_res_base.cluster_version,
         };
-        ClusterInfo::from_cluster(cluster_res, addrs)
+        ClusterInfo::from_cluster(cluster_res, addrs, name)
     }
 }
 

--- a/curp/tests/server.rs
+++ b/curp/tests/server.rs
@@ -490,7 +490,7 @@ async fn check_new_node(is_learner: bool) {
     /*******  start new node *******/
 
     // 1. fetch cluster from other nodes
-    let cluster_info = Arc::new(group.fetch_cluster_info(&[addr]).await);
+    let cluster_info = Arc::new(group.fetch_cluster_info(&[addr], "new_node").await);
 
     // 2. start new node
     group
@@ -510,7 +510,7 @@ async fn check_new_node(is_learner: bool) {
     assert!(res
         .members
         .iter()
-        .any(|m| m.id == node_id && is_learner == m.is_learner));
+        .any(|m| m.id == node_id && m.name == "new_node" && is_learner == m.is_learner));
 
     // 4. check if the new node executes the command from old cluster
     let new_node = group.nodes.get_mut(&node_id).unwrap();
@@ -564,7 +564,7 @@ async fn shutdown_rpc_should_shutdown_the_cluster_when_client_has_wrong_cluster(
     assert_eq!(members.len(), 4);
     assert!(members.iter().any(|m| m.id == node_id));
 
-    let cluster_info = Arc::new(group.fetch_cluster_info(&addrs).await);
+    let cluster_info = Arc::new(group.fetch_cluster_info(&addrs, "new_node").await);
     group
         .run_node(listener, "new_node".to_owned(), cluster_info)
         .await;
@@ -595,7 +595,7 @@ async fn propose_conf_change_rpc_should_work_when_client_has_wrong_cluster() {
         .unwrap();
     assert_eq!(members.len(), 4);
     assert!(members.iter().any(|m| m.id == node_id));
-    let cluster_info = Arc::new(group.fetch_cluster_info(&addrs).await);
+    let cluster_info = Arc::new(group.fetch_cluster_info(&addrs, "new_node").await);
     group
         .run_node(listener, "new_node".to_owned(), cluster_info)
         .await;
@@ -632,7 +632,7 @@ async fn fetch_read_state_rpc_should_work_when_client_has_wrong_cluster() {
         .unwrap();
     assert_eq!(members.len(), 4);
     assert!(members.iter().any(|m| m.id == node_id));
-    let cluster_info = Arc::new(group.fetch_cluster_info(&addrs).await);
+    let cluster_info = Arc::new(group.fetch_cluster_info(&addrs, "new_node").await);
     group
         .run_node(listener, "new_node".to_owned(), cluster_info)
         .await;

--- a/xline/src/main.rs
+++ b/xline/src/main.rs
@@ -552,6 +552,7 @@ async fn main() -> Result<()> {
         InitialClusterState::Existing => get_cluster_info_from_remote(
             &init_cluster_info,
             server_addr_str,
+            &name,
             Duration::from_secs(3),
         )
         .await


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
 publish the name of new node to cluster when node start
* what changes does this pull request make?
When a node starts, it publishes its name to the cluster by publish RPC, 
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no