### PR TITLE
fix: remove wrong message in abort_on_panic macro

### DIFF
--- a/curp/tests/it/read_state.rs
+++ b/curp/tests/it/read_state.rs
@@ -23,6 +23,7 @@ async fn read_state() {
             TestCommandResult::default(),
         );
     });
+    sleep_millis(10).await;
     let get_client = group.new_client().await;
     let res = get_client
         .fetch_read_state(&TestCommand::new_get(vec![0]))

--- a/test-macros/src/lib.rs
+++ b/test-macros/src/lib.rs
@@ -5,12 +5,11 @@ use syn::{parse_macro_input, ItemFn, Stmt};
 #[proc_macro_attribute]
 pub fn abort_on_panic(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut input: syn::ItemFn = parse_macro_input!(item as ItemFn);
-    let test_case = &input.sig.ident.to_string();
 
     let panic_hook: Stmt = syn::parse_quote! {
         std::panic::set_hook(Box::new(|info| {
             let stacktrace = std::backtrace::Backtrace::force_capture();
-            println!("`{}` panic! \n@info:\n{}\n@stackTrace:\n{}", #test_case, info, stacktrace);
+            println!("test panic! \n@info:\n{}\n@stackTrace:\n{}", info, stacktrace);
             std::process::abort();
         }));
     };


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
remove wrong message in abort_on_panic macro
* what changes does this pull request make?
remove wrong message in abort_on_panic macro
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no