### PR TITLE
fix: do not increase cluster_version when new node apply old conf changes

### DIFF
--- a/curp/src/members.rs
+++ b/curp/src/members.rs
@@ -169,8 +169,9 @@ impl ClusterInfo {
 
     /// Insert a member
     #[inline]
-    pub fn insert(&self, member: Member) {
-        _ = self.members.insert(member.id, member);
+    #[must_use]
+    pub fn insert(&self, member: Member) -> Option<Member> {
+        self.members.insert(member.id, member)
     }
 
     /// Remove a member
@@ -337,10 +338,12 @@ impl ClusterInfo {
     }
 
     /// Promote a learner to voter
-    pub(crate) fn promote(&self, node_id: ServerId) {
+    pub(crate) fn promote(&self, node_id: ServerId) -> bool {
         if let Some(mut s) = self.members.get_mut(&node_id) {
             s.is_learner = false;
+            return true;
         }
+        false
     }
 
     /// Demote a voter to learner


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
fix xline_add_node test
* what changes does this pull request make?
do not increase cluster_version when new node apply old conf changes
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no