### PR TITLE
refactor: refactor connect from macros to function

### DIFF
--- a/curp/src/client.rs
+++ b/curp/src/client.rs
@@ -72,7 +72,7 @@ impl<C: Command> Builder<C> {
         let Some(config) = self.config else {
             return Err(ClientBuildError::invalid_arguments("timeout is required"));
         };
-        let connects = rpc::connect(all_members).await?.collect();
+        let connects = rpc::connects(all_members).await?.collect();
         let client = Client::<C> {
             local_server_id: self.local_server_id,
             state: RwLock::new(State::new(leader_id, 0)),
@@ -136,7 +136,7 @@ impl<C: Command> Builder<C> {
             state: RwLock::new(State::new(res.leader_id, res.term)),
             config,
             cluster_version: AtomicU64::new(res.cluster_version),
-            connects: rpc::connect(res.into_members_addrs()).await?.collect(),
+            connects: rpc::connects(res.into_members_addrs()).await?.collect(),
             phantom: PhantomData,
         };
         Ok(client)
@@ -448,7 +448,7 @@ where
             .map(|m| (m.id, m.addrs))
             .collect::<HashMap<ServerId, Vec<String>>>();
         self.connects.clear();
-        for (id, connect) in rpc::connect(member_addrs)
+        for (id, connect) in rpc::connects(member_addrs)
             .await
             .map_err(|e| ClientError::InternalError(format!("connect to cluster failed: {e}")))?
         {

--- a/curp/src/members.rs
+++ b/curp/src/members.rs
@@ -376,7 +376,7 @@ pub async fn get_cluster_info_from_remote(
     timeout: Duration,
 ) -> Option<ClusterInfo> {
     let peers = init_cluster_info.peers_addrs();
-    let connects = rpc::connect(peers)
+    let connects = rpc::connects(peers)
         .await
         .ok()?
         .map(|pair| pair.1)

--- a/curp/src/rpc/mod.rs
+++ b/curp/src/rpc/mod.rs
@@ -39,7 +39,7 @@ use crate::{
 
 /// Rpc connect
 pub(crate) mod connect;
-pub(crate) use connect::{connect, inner_connect};
+pub(crate) use connect::{connects, inner_connects};
 
 // Skip for generated code
 #[allow(

--- a/curp/src/server/curp_node.rs
+++ b/curp/src/server/curp_node.rs
@@ -785,7 +785,7 @@ impl<C: 'static + Command, RC: RoleChange + 'static> CurpNode<C, RC> {
             .into_iter()
             .map(|server_id| (server_id, Arc::new(Event::new())))
             .collect();
-        let connects = rpc::inner_connect(cluster_info.peers_addrs())
+        let connects = rpc::inner_connects(cluster_info.peers_addrs())
             .await
             .map_err(|e| CurpError::Internal(format!("parse peers addresses failed, err {e:?}")))?
             .collect();


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    I want to refactor the `set_cluster` function in current implementation, and I realized that I need to implement a single endpoint connection, then I refactor the connect from macros to function implementation.

* what changes does this pull request make?

    As above.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

   No
