### PR TITLE
Update xline-client/README.md to mention dependency on protobuf-compiler

### DIFF
--- a/xline-client/README.md
+++ b/xline-client/README.md
@@ -2,6 +2,9 @@
 
 Official Xline API client for Rust that supports the [CURP](https://github.com/xline-kv/Xline/tree/master/curp) protocol
 
+# Pre-requisites 
+- Install `protobuf-compiler` as mentioned in [QuickStart](https://github.com/xline-kv/Xline/blob/master/doc/quick-start/README.md#ubuntudebian)
+
 ## Features
 
 `xline-client` runs the CURP protocol on the client side for maximal performance.


### PR DESCRIPTION
It seems  that  `protobuf-compiler`  is a dependency for building `xline-client`  (Rust) 

This update in documentation adds a mention on the required dependency

A section is added in https://github.com/xline-kv/Xline/blob/master/xline-client/README.md