### PR TITLE
[Feature]: move leadership when old leader shutdown 

### DIFF
--- a/curp/src/server/raw_curp/mod.rs
+++ b/curp/src/server/raw_curp/mod.rs
@@ -834,7 +834,7 @@ impl<C: Command, RC: RoleChange> RawCurp<C, RC> {
 
     /// Handle `try_become_leader_now`
     pub(super) fn handle_try_become_leader_now(&self) -> Option<Vote> {
-        debug!("{} received timeout now", self.id());
+        debug!("{} received try become leader now", self.id());
         let mut st_w = self.st.write();
         if st_w.role == Role::Leader {
             return None;
@@ -1300,6 +1300,17 @@ impl<C: Command, RC: RoleChange> RawCurp<C, RC> {
     /// Get last log index
     pub(super) fn last_log_index(&self) -> u64 {
         self.log.read().last_log_index()
+    }
+
+    /// Pick a node that has the same log as the current node
+    pub(super) fn pick_new_leader(&self) -> Option<ServerId> {
+        let last_idx = self.log.read().last_log_index();
+        for (id, status) in self.lst.get_all_statuses() {
+            if status.match_index == last_idx && !status.is_learner {
+                return Some(id);
+            }
+        }
+        None
     }
 }
 

--- a/curp/src/server/raw_curp/tests.rs
+++ b/curp/src/server/raw_curp/tests.rs
@@ -979,11 +979,11 @@ fn leader_handle_move_leader() {
 
     let target_id = curp.cluster().get_id_by_name("S1").unwrap();
     let res = curp.handle_move_leader(target_id);
-    // need to send timeout now after handle_move_leader
+    // need to send try become leader now after handle_move_leader
     assert!(res.is_ok_and(|b| b));
 
     let res = curp.handle_move_leader(target_id);
-    // no need to send timeout now after handle_move_leader, because it's duplicated
+    // no need to send try become leader now after handle_move_leader, because it's duplicated
     assert!(res.is_ok_and(|b| !b));
 }
 


### PR DESCRIPTION
Please briefly answer these questions:
Based on #566 
* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
If we remove leader, the remaining nodes need to wait for the election timeout and elect a new leader.
* what changes does this pull request make?
move leadership when old leader shutdown 
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no