### PR TITLE
fix: longer timeout when there is no leader in cluster

### DIFF
--- a/utils/src/config.rs
+++ b/utils/src/config.rs
@@ -340,7 +340,7 @@ pub const fn default_server_wait_synced_timeout() -> Duration {
 #[must_use]
 #[inline]
 pub const fn default_initial_retry_timeout() -> Duration {
-    Duration::from_millis(50)
+    Duration::from_millis(1500)
 }
 
 /// default max retry timeout

--- a/xline/tests/it/maintenance_test.rs
+++ b/xline/tests/it/maintenance_test.rs
@@ -114,9 +114,9 @@ async fn test_status() -> Result<(), Box<dyn std::error::Error>> {
     assert!(res.db_size > 0);
     assert!(res.db_size_in_use > 0);
     assert_ne!(res.leader, 0);
-    assert_eq!(res.raft_index, 3);
+    assert!(res.raft_index >= res.raft_applied_index);
     assert_eq!(res.raft_term, 1);
-    assert_eq!(res.raft_applied_index, 3);
+    assert!(res.raft_applied_index > 0);
     assert!(!res.is_learner);
 
     Ok(())


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
unable to process requests normally without specifying leader to start the cluster
* what changes does this pull request make?
 add longer timeout when there is no leader in cluster
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no