### PR TITLE
refactor: isolate client state

### DIFF
--- a/curp/src/client/mod.rs
+++ b/curp/src/client/mod.rs
@@ -19,7 +19,6 @@ use std::{collections::HashMap, fmt::Debug, sync::Arc};
 use async_trait::async_trait;
 use curp_external_api::cmd::Command;
 use futures::{stream::FuturesUnordered, StreamExt};
-use tokio::sync::RwLock;
 use tracing::debug;
 use utils::config::ClientConfig;
 
@@ -318,7 +317,7 @@ impl ClientBuilder {
     > {
         let state = self.init_state_builder().build().await?;
         let client = Retry::new(
-            Unary::new(Arc::new(RwLock::new(state)), self.init_unary_config()),
+            Unary::new(Arc::new(state), self.init_unary_config()),
             self.init_retry_config(),
         );
         Ok(client)
@@ -341,7 +340,7 @@ impl<P: Protocol> ClientBuilderWithBypass<P> {
             .build_bypassed::<P>(self.local_server_id, self.local_server)
             .await?;
         let client = Retry::new(
-            Unary::new(Arc::new(RwLock::new(state)), self.inner.init_unary_config()),
+            Unary::new(Arc::new(state), self.inner.init_unary_config()),
             self.inner.init_retry_config(),
         );
         Ok(client)

--- a/curp/src/client/retry.rs
+++ b/curp/src/client/retry.rs
@@ -1,4 +1,4 @@
-use std::{ops::SubAssign, sync::Arc, time::Duration};
+use std::{ops::SubAssign, time::Duration};
 
 use async_trait::async_trait;
 use futures::Future;
@@ -6,10 +6,7 @@ use tracing::warn;
 
 use crate::{
     members::ServerId,
-    rpc::{
-        connect::ConnectApi, ConfChange, CurpError, FetchClusterResponse, Member, ReadState,
-        Redirect,
-    },
+    rpc::{ConfChange, CurpError, FetchClusterResponse, Member, ReadState, Redirect},
 };
 
 use super::{ClientApi, LeaderStateUpdate, ProposeResponse, RepeatableClientApi};
@@ -193,11 +190,6 @@ where
 
     /// Inherit the command type
     type Cmd = Api::Cmd;
-
-    /// Get the local connection when the client is on the server node.
-    async fn local_connect(&self) -> Option<Arc<dyn ConnectApi>> {
-        self.inner.local_connect().await
-    }
 
     /// Send propose to the whole cluster, `use_fast_path` set to `false` to fallback into ordered
     /// requests (event the requests are commutative).

--- a/curp/src/client/state.rs
+++ b/curp/src/client/state.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use tokio::sync::RwLock;
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::{
     members::ServerId,
@@ -82,8 +82,7 @@ impl State {
                 // If a server loses contact with its leader, it will update its term for election. Since other servers are all right, the election will not succeed.
                 // But if the client learns about the new term and updates its term to it, it will never get the true leader.
                 if let Some(new_leader_id) = leader_id {
-                    debug!("client term updates to {}", term);
-                    debug!("client leader id updates to {new_leader_id}");
+                    info!("client term updates to {term}\nclient leader id updates to {new_leader_id}");
                     self.term = term;
                     self.leader = Some(new_leader_id);
                 }
@@ -91,7 +90,7 @@ impl State {
             Ordering::Equal => {
                 if let Some(new_leader_id) = leader_id {
                     if self.leader.is_none() {
-                        debug!("client leader id updates to {new_leader_id}");
+                        info!("client leader id updates to {new_leader_id}");
                         self.leader = Some(new_leader_id);
                     }
                     assert_eq!(
@@ -125,7 +124,7 @@ impl State {
             return Ok(());
         }
 
-        debug!("client cluster version updated to {}", res.cluster_version);
+        info!("client cluster version updated to {}", res.cluster_version);
         self.cluster_version = res.cluster_version;
 
         let mut new_members = res.clone().into_members_addrs();

--- a/curp/src/client/state.rs
+++ b/curp/src/client/state.rs
@@ -1,0 +1,233 @@
+use std::{
+    cmp::Ordering,
+    collections::{hash_map::Entry, HashMap, HashSet},
+    sync::Arc,
+};
+
+use tokio::sync::RwLock;
+use tracing::debug;
+
+use crate::{
+    members::ServerId,
+    rpc::{
+        self,
+        connect::{BypassedConnect, ConnectApi},
+        FetchClusterResponse, Protocol,
+    },
+};
+
+/// Reference to state
+pub(super) type StateRef = Arc<RwLock<State>>;
+
+/// Client state
+pub(super) struct State {
+    /// Leader id. At the beginning, we may not know who the leader is.
+    pub(super) leader: Option<ServerId>,
+    /// Local server id
+    pub(super) local_server: Option<ServerId>,
+    /// Term, initialize to 0, calibrated by the server.
+    pub(super) term: u64,
+    /// Cluster version, initialize to 0, calibrated by the server.
+    pub(super) cluster_version: u64,
+    /// Members' connect
+    pub(super) connects: HashMap<ServerId, Arc<dyn ConnectApi>>,
+}
+
+impl std::fmt::Debug for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("State")
+            .field("leader", &self.leader)
+            .field("local_server", &self.local_server)
+            .field("term", &self.term)
+            .field("cluster_version", &self.cluster_version)
+            .field("connects", &self.connects.keys())
+            .finish()
+    }
+}
+
+impl State {
+    /// For test
+    #[cfg(test)]
+    pub(super) fn new_ref(
+        connects: HashMap<ServerId, Arc<dyn ConnectApi>>,
+        local_server: Option<ServerId>,
+        leader: Option<ServerId>,
+        term: u64,
+        cluster_version: u64,
+    ) -> StateRef {
+        Arc::new(RwLock::new(Self {
+            leader,
+            local_server,
+            term,
+            cluster_version,
+            connects,
+        }))
+    }
+
+    /// Get the local connect
+    pub(super) fn local_connect(&self) -> Option<Arc<dyn ConnectApi>> {
+        let id = self.local_server?;
+        self.connects.get(&id).map(Arc::clone)
+    }
+
+    /// Update leader
+    pub(super) fn check_and_update_leader(
+        &mut self,
+        leader_id: Option<ServerId>,
+        term: u64,
+    ) -> bool {
+        match self.term.cmp(&term) {
+            Ordering::Less => {
+                // reset term only when the resp has leader id to prevent:
+                // If a server loses contact with its leader, it will update its term for election. Since other servers are all right, the election will not succeed.
+                // But if the client learns about the new term and updates its term to it, it will never get the true leader.
+                if let Some(new_leader_id) = leader_id {
+                    debug!("client term updates to {}", term);
+                    debug!("client leader id updates to {new_leader_id}");
+                    self.term = term;
+                    self.leader = Some(new_leader_id);
+                }
+            }
+            Ordering::Equal => {
+                if let Some(new_leader_id) = leader_id {
+                    if self.leader.is_none() {
+                        debug!("client leader id updates to {new_leader_id}");
+                        self.leader = Some(new_leader_id);
+                    }
+                    assert_eq!(
+                        self.leader,
+                        Some(new_leader_id),
+                        "there should never be two leader in one term"
+                    );
+                }
+            }
+            Ordering::Greater => {
+                debug!("ignore old term({}) from server", term);
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Update client state based on [`FetchClusterResponse`]
+    pub(super) async fn check_and_update(
+        &mut self,
+        res: &FetchClusterResponse,
+    ) -> Result<(), tonic::transport::Error> {
+        if !Self::check_and_update_leader(self, res.leader_id, res.term) {
+            return Ok(());
+        }
+        if self.cluster_version == res.cluster_version {
+            debug!(
+                "ignore cluster version({}) from server",
+                res.cluster_version
+            );
+            return Ok(());
+        }
+
+        debug!("client cluster version updated to {}", res.cluster_version);
+        self.cluster_version = res.cluster_version;
+
+        let mut new_members = res.clone().into_members_addrs();
+
+        let old_ids = self.connects.keys().copied().collect::<HashSet<_>>();
+        let new_ids = new_members.keys().copied().collect::<HashSet<_>>();
+
+        let diffs = &old_ids ^ &new_ids;
+        let sames = &old_ids & &new_ids;
+
+        for diff in diffs {
+            if let Entry::Vacant(e) = self.connects.entry(diff) {
+                let addrs = new_members
+                    .remove(&diff)
+                    .unwrap_or_else(|| unreachable!("{diff} must in new member addrs"));
+                debug!("client connects to a new server({diff}), address({addrs:?})");
+                let new_conn = rpc::connect(diff, addrs).await?;
+                let _ig = e.insert(new_conn);
+            } else {
+                debug!("client removes old server({diff})");
+                let _ig = self.connects.remove(&diff);
+            }
+        }
+        for same in sames {
+            let conn = self
+                .connects
+                .get(&same)
+                .unwrap_or_else(|| unreachable!("{same} must in old connects"));
+            let addrs = new_members
+                .remove(&same)
+                .unwrap_or_else(|| unreachable!("{same} must in new member addrs"));
+            conn.update_addrs(addrs).await?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Builder for state
+#[derive(Debug, Clone)]
+pub(super) struct StateBuilder {
+    /// All members (required)
+    all_members: HashMap<ServerId, Vec<String>>,
+    /// Initial leader state (optional)
+    leader_state: Option<(ServerId, u64)>,
+    /// Initial cluster version (optional)
+    cluster_version: Option<u64>,
+}
+
+impl StateBuilder {
+    /// Create a state builder
+    pub(super) fn new(all_members: HashMap<ServerId, Vec<String>>) -> Self {
+        Self {
+            all_members,
+            leader_state: None,
+            cluster_version: None,
+        }
+    }
+
+    /// Set the leader state (optional)
+    pub(super) fn set_leader_state(&mut self, id: ServerId, term: u64) {
+        self.leader_state = Some((id, term));
+    }
+
+    /// Set the cluster version (optional)
+    pub(super) fn set_cluster_version(&mut self, cluster_version: u64) {
+        self.cluster_version = Some(cluster_version);
+    }
+
+    /// Build the state with local server
+    pub(super) async fn build_bypassed<P: Protocol>(
+        mut self,
+        local_server_id: ServerId,
+        local_server: P,
+    ) -> Result<State, tonic::transport::Error> {
+        debug!("client bypassed server({local_server_id})");
+
+        let _ig = self.all_members.remove(&local_server_id);
+        let mut connects: HashMap<_, _> = rpc::connects(self.all_members.clone()).await?.collect();
+        let __ig = connects.insert(
+            local_server_id,
+            Arc::new(BypassedConnect::new(local_server_id, local_server)),
+        );
+
+        Ok(State {
+            leader: self.leader_state.map(|state| state.0),
+            local_server: Some(local_server_id),
+            term: self.leader_state.map_or(0, |state| state.1),
+            cluster_version: self.cluster_version.unwrap_or_default(),
+            connects,
+        })
+    }
+
+    /// Build the state
+    pub(super) async fn build(self) -> Result<State, tonic::transport::Error> {
+        let connects: HashMap<_, _> = rpc::connects(self.all_members.clone()).await?.collect();
+        Ok(State {
+            leader: self.leader_state.map(|state| state.0),
+            local_server: None,
+            term: self.leader_state.map_or(0, |state| state.1),
+            cluster_version: self.cluster_version.unwrap_or_default(),
+            connects,
+        })
+    }
+}

--- a/curp/src/client/tests.rs
+++ b/curp/src/client/tests.rs
@@ -50,7 +50,7 @@ fn init_unary_client(
     term: u64,
     cluster_version: u64,
 ) -> Unary<TestCommand> {
-    let state = State::new_ref(connects, local_server, leader, term, cluster_version);
+    let state = State::new_arc(connects, local_server, leader, term, cluster_version);
     Unary::new(
         state,
         UnaryConfig::new(Duration::from_secs(0), Duration::from_secs(0)),

--- a/curp/src/rpc/connect.rs
+++ b/curp/src/rpc/connect.rs
@@ -142,7 +142,7 @@ pub(crate) async fn inner_connects(
 #[allow(clippy::module_name_repetitions)] // better for recognizing than just "Api"
 #[cfg_attr(test, automock)]
 #[async_trait]
-pub trait ConnectApi: Send + Sync + 'static {
+pub(crate) trait ConnectApi: Send + Sync + 'static {
     /// Get server id
     fn id(&self) -> ServerId;
 


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    Separate the client state from unary client to realize subsequent implementation of shared state between stream client and unary client.

* what changes does this pull request make?

    Isolate client state.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

    No.
