### PR TITLE
chore: bump rust to 1.71.0

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,7 @@ on:
     - cron: "00 00 * * 1"
 
 env:
-  CI_RUST_TOOLCHAIN: 1.70.0
+  CI_RUST_TOOLCHAIN: 1.71.0
 
 jobs:
   benchmark:

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: { }
 
 env:
-  CI_RUST_TOOLCHAIN: 1.70.0
+  CI_RUST_TOOLCHAIN: 1.71.0
   IMAGE_ID: ghcr.io/xline-kv/xline
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 env:
-  CI_RUST_TOOLCHAIN: 1.70.0
+  CI_RUST_TOOLCHAIN: 1.71.0
   IMAGE_ID: ghcr.io/xline-kv/xline
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ Check the code format.
 cargo fmt --all -- --check
 ```
 
-**Note**: The current version of the Rust toolchain used for CI is **1.70.0** .
+**Note**: The current version of the Rust toolchain used for CI is **1.71.0** .
 Please use this version to run the above command, otherwise you may get
 different results with CI.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628a8f9bd1e24b4e0db2b4bc2d000b001e7dd032d54afa60a68836aeec5aa54a"
+checksum = "3fde6067df7359f2d6335ec1a50c1f8f825801687d10da0cc4c6b08e3f6afd15"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -117,7 +117,7 @@ dependencies = [
  "anstyle",
  "bstr",
  "doc-comment",
- "predicates 3.1.0",
+ "predicates",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -962,15 +962,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "flume"
 version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,29 +1668,29 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.11.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
 dependencies = [
  "cfg-if",
  "downcast",
  "fragile",
  "lazy_static",
  "mockall_derive",
- "predicates 2.1.5",
+ "predicates",
  "predicates-tree",
 ]
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
 dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1732,12 +1723,6 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2068,20 +2053,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "predicates"
-version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
-dependencies = [
- "difflib",
- "float-cmp",
- "itertools 0.10.5",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
 
 [[package]]
 name = "predicates"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,7 @@ dependencies = [
  "fs2",
  "futures",
  "indexmap 1.9.3",
- "itertools 0.10.5",
+ "itertools",
  "madsim",
  "madsim-tokio",
  "madsim-tonic",
@@ -689,7 +689,7 @@ dependencies = [
  "bincode",
  "curp-external-api",
  "engine",
- "itertools 0.10.5",
+ "itertools",
  "madsim-tokio",
  "once_cell",
  "prost",
@@ -1356,15 +1356,6 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2152,7 +2143,7 @@ checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.11.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -2173,7 +2164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -2483,7 +2474,7 @@ dependencies = [
  "curp-test-utils",
  "engine",
  "futures",
- "itertools 0.10.5",
+ "itertools",
  "madsim",
  "madsim-tokio",
  "madsim-tonic",
@@ -3434,6 +3425,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "hyper",
  "indexmap 1.9.3",
+ "itertools",
  "libc",
  "log",
  "madsim-tokio",
@@ -3473,7 +3465,7 @@ dependencies = [
  "event-listener 2.5.3",
  "futures",
  "hyper",
- "itertools 0.10.5",
+ "itertools",
  "jsonwebtoken",
  "log",
  "madsim-tokio",
@@ -3556,7 +3548,7 @@ dependencies = [
  "async-trait",
  "curp",
  "curp-external-api",
- "itertools 0.10.5",
+ "itertools",
  "madsim-tonic",
  "madsim-tonic-build",
  "prost",

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -66,7 +66,7 @@
     clippy::indexing_slicing,
     // clippy::inline_asm_x86_att_syntax, stick to intel syntax
     clippy::inline_asm_x86_intel_syntax,
-    clippy::integer_arithmetic,
+    clippy::arithmetic_side_effects,
     // clippy::integer_division, required in the project
     clippy::let_underscore_must_use,
     clippy::lossy_float_literal,
@@ -121,7 +121,7 @@
     clippy::unused_peekable,
     clippy::unused_rounding,
 
-    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // The followings are selected restriction lints from rust 1.68.0 to 1.71.0
     // clippy::allow_attributes, still unstable
     clippy::impl_trait_in_params,
     clippy::let_underscore_untyped,
@@ -129,7 +129,14 @@
     clippy::multiple_unsafe_ops_per_block,
     clippy::semicolon_inside_block,
     // clippy::semicolon_outside_block, already used `semicolon_inside_block`
-    clippy::tests_outside_test_module
+    clippy::tests_outside_test_module,
+    // 1.71.0
+    clippy::default_constructed_unit_structs,
+    clippy::items_after_test_module,
+    clippy::manual_next_back,
+    clippy::manual_while_let_some,
+    clippy::needless_bool_assign,
+    clippy::non_minimal_cfg,
 )]
 #![allow(
     clippy::multiple_crate_versions, // caused by the dependency, can't be fixed

--- a/benchmark/src/runner.rs
+++ b/benchmark/src/runner.rs
@@ -82,6 +82,7 @@ impl Stats {
     /// Calculate the histogram from the latencies.
     #[allow(clippy::indexing_slicing)]
     #[allow(clippy::let_underscore_must_use)] // the writeln! will not fail thus always return an Ok
+    #[allow(clippy::arithmetic_side_effects)] // test only
     pub fn histogram(&self) -> String {
         let size = 10;
         let mut buckets = Vec::with_capacity(size);
@@ -254,7 +255,8 @@ impl CommandRunner {
     #[allow(
         clippy::as_conversions,
         clippy::cast_precision_loss,
-        clippy::float_arithmetic
+        clippy::float_arithmetic,
+        clippy::arithmetic_side_effects
     )]
     async fn collecter(&mut self, mut rx: Receiver<CmdResult>, barrier: Arc<Barrier>) -> Stats {
         let bar_len = match self.args.command {

--- a/benchmark/src/runner.rs
+++ b/benchmark/src/runner.rs
@@ -82,7 +82,7 @@ impl Stats {
     /// Calculate the histogram from the latencies.
     #[allow(clippy::indexing_slicing)]
     #[allow(clippy::let_underscore_must_use)] // the writeln! will not fail thus always return an Ok
-    #[allow(clippy::arithmetic_side_effects)] // test only
+    #[allow(clippy::arithmetic_side_effects)] // benchmark only
     pub fn histogram(&self) -> String {
         let size = 10;
         let mut buckets = Vec::with_capacity(size);

--- a/ci/rust-toolchain.toml
+++ b/ci/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.71.0"
 components = ["rustfmt", "clippy", "rust-src"]

--- a/curp-external-api/Cargo.toml
+++ b/curp-external-api/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["API", "Curp"]
 [dependencies]
 async-trait = "0.1.53"
 engine = { path = "../engine" }
-mockall = "0.11.3"
+mockall = "0.12.1"
 prost = "0.12.3"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 thiserror = "1.0.31"

--- a/curp-external-api/src/lib.rs
+++ b/curp-external-api/src/lib.rs
@@ -66,7 +66,7 @@
     clippy::indexing_slicing,
     // clippy::inline_asm_x86_att_syntax, stick to intel syntax
     clippy::inline_asm_x86_intel_syntax,
-    clippy::integer_arithmetic,
+    clippy::arithmetic_side_effects,
     // clippy::integer_division, required in the project
     clippy::let_underscore_must_use,
     clippy::lossy_float_literal,
@@ -121,7 +121,7 @@
     clippy::unused_peekable,
     clippy::unused_rounding,
 
-    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // The followings are selected restriction lints from rust 1.68.0 to 1.71.0
     // clippy::allow_attributes, still unstable
     clippy::impl_trait_in_params,
     clippy::let_underscore_untyped,
@@ -129,7 +129,14 @@
     clippy::multiple_unsafe_ops_per_block,
     clippy::semicolon_inside_block,
     // clippy::semicolon_outside_block, already used `semicolon_inside_block`
-    clippy::tests_outside_test_module
+    clippy::tests_outside_test_module,
+    // 1.71.0
+    clippy::default_constructed_unit_structs,
+    clippy::items_after_test_module,
+    clippy::manual_next_back,
+    clippy::manual_while_let_some,
+    clippy::needless_bool_assign,
+    clippy::non_minimal_cfg,
 )]
 
 /// Log Index

--- a/curp-external-api/src/role_change.rs
+++ b/curp-external-api/src/role_change.rs
@@ -2,7 +2,6 @@ use mockall::automock;
 
 /// Callback when the leadership changes
 #[allow(clippy::indexing_slicing)]
-#[allow(clippy::integer_arithmetic)]
 #[automock]
 pub trait RoleChange: Send + Sync + 'static {
     /// The `on_election_win` will be invoked when the current server win the election.

--- a/curp-test-utils/Cargo.toml
+++ b/curp-test-utils/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1.53"
 bincode = "1.3.3"
 curp-external-api = { path = "../curp-external-api" }
 engine = { path = "../engine" }
-itertools = "0.10.3"
+itertools = "0.11"
 once_cell = "1.17.0"
 prost = "0.12.3"
 serde = { version = "1.0.130", features = ["derive", "rc"] }

--- a/curp/Cargo.toml
+++ b/curp/Cargo.toml
@@ -26,7 +26,7 @@ flume = "0.10.14"
 fs2 = "0.4.3"
 futures = "0.3.21"
 indexmap = "1.9.2"
-itertools = "0.10.3"
+itertools = "0.11"
 madsim = { version = "0.2.22", features = ["rpc", "macros"] }
 parking_lot = "0.12.1"
 prost = "0.12.3"
@@ -51,7 +51,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 [dev-dependencies]
 anyhow = "1.0.66"
 curp-test-utils = { path = "../curp-test-utils" }
-itertools = "0.10.3"
+itertools = "0.11"
 mockall = "0.12.1"
 once_cell = "1.17.0"
 tempfile = "3"

--- a/curp/Cargo.toml
+++ b/curp/Cargo.toml
@@ -52,7 +52,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 anyhow = "1.0.66"
 curp-test-utils = { path = "../curp-test-utils" }
 itertools = "0.10.3"
-mockall = "0.11.3"
+mockall = "0.12.1"
 once_cell = "1.17.0"
 tempfile = "3"
 test-macros = { path = "../test-macros" }

--- a/curp/src/client/unary.rs
+++ b/curp/src/client/unary.rs
@@ -588,7 +588,7 @@ impl<C: Command> ClientApi for Unary<C> {
             };
             // Ignore the response of a node that doesn't know who the leader is.
             if inner.leader_id.is_some() {
-                #[allow(clippy::integer_arithmetic)]
+                #[allow(clippy::arithmetic_side_effects)]
                 match max_term.cmp(&inner.term) {
                     Ordering::Less => {
                         max_term = inner.term;

--- a/curp/src/lib.rs
+++ b/curp/src/lib.rs
@@ -66,7 +66,7 @@
     clippy::indexing_slicing,
     // clippy::inline_asm_x86_att_syntax, stick to intel syntax
     clippy::inline_asm_x86_intel_syntax,
-    clippy::integer_arithmetic,
+    clippy::arithmetic_side_effects,
     // clippy::integer_division, required in the project
     clippy::let_underscore_must_use,
     clippy::lossy_float_literal,
@@ -121,7 +121,7 @@
     clippy::unused_peekable,
     clippy::unused_rounding,
 
-    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // The followings are selected restriction lints from rust 1.68.0 to 1.71.0
     // clippy::allow_attributes, still unstable
     clippy::impl_trait_in_params,
     clippy::let_underscore_untyped,
@@ -129,7 +129,14 @@
     clippy::multiple_unsafe_ops_per_block,
     clippy::semicolon_inside_block,
     // clippy::semicolon_outside_block, already used `semicolon_inside_block`
-    clippy::tests_outside_test_module
+    clippy::tests_outside_test_module,
+    // 1.71.0
+    clippy::default_constructed_unit_structs,
+    clippy::items_after_test_module,
+    clippy::manual_next_back,
+    clippy::manual_while_let_some,
+    clippy::needless_bool_assign,
+    clippy::non_minimal_cfg,
 )]
 #![allow(
     clippy::multiple_crate_versions, // caused by the dependency, can't be fixed
@@ -137,7 +144,7 @@
 #![cfg_attr(
     test,
     allow(
-        clippy::integer_arithmetic,
+        clippy::arithmetic_side_effects,
         clippy::indexing_slicing,
         unused_results,
         clippy::unwrap_used,

--- a/curp/src/rpc/connect.rs
+++ b/curp/src/rpc/connect.rs
@@ -139,8 +139,8 @@ pub(crate) async fn inner_connects(
 }
 
 /// Connect interface between server and clients
-#[cfg_attr(test, automock)]
 #[allow(clippy::module_name_repetitions)] // better for recognizing than just "Api"
+#[cfg_attr(test, automock)]
 #[async_trait]
 pub trait ConnectApi: Send + Sync + 'static {
     /// Get server id
@@ -644,7 +644,7 @@ fn install_snapshot_stream(
             error!("snapshot seek failed, {e}");
             return;
         }
-        #[allow(clippy::integer_arithmetic)] // can't overflow
+        #[allow(clippy::arithmetic_side_effects)] // can't overflow
         while offset < snapshot.size() {
             let len: u64 =
                 std::cmp::min(snapshot.size() - offset, SNAPSHOT_CHUNK_SIZE).numeric_cast();

--- a/curp/src/server/cmd_worker/conflict_checked_mpmc.rs
+++ b/curp/src/server/cmd_worker/conflict_checked_mpmc.rs
@@ -2,7 +2,7 @@
     clippy::wildcard_enum_match_arm,
     clippy::match_wildcard_for_single_variants
 )] // wildcard actually is more clear in this module
-#![allow(clippy::integer_arithmetic)] // u64 is large enough
+#![allow(clippy::arithmetic_side_effects)] // u64 is large enough
 
 use std::{
     collections::{HashMap, HashSet},
@@ -569,7 +569,8 @@ async fn conflict_checked_mpmc_task<C: Command, CE: CommandExecutor<C>>(
     let mut shutdown_listener = shutdown_trigger.subscribe();
     let mut filter = Filter::new(filter_tx, ce);
     let mut is_shutdown_state = false;
-    #[allow(clippy::integer_arithmetic, clippy::pattern_type_mismatch)] // tokio internal triggers
+    // tokio internal triggers
+    #[allow(clippy::arithmetic_side_effects, clippy::pattern_type_mismatch)]
     loop {
         tokio::select! {
             biased; // cleanup filter first so that the buffer in filter can be kept as small as possible

--- a/curp/src/server/curp_node.rs
+++ b/curp/src/server/curp_node.rs
@@ -227,7 +227,7 @@ impl<C: Command, RC: RoleChange> CurpNode<C, RC> {
     }
 
     /// Handle `InstallSnapshot` stream
-    #[allow(clippy::integer_arithmetic)] // can't overflow
+    #[allow(clippy::arithmetic_side_effects)] // can't overflow
     pub(super) async fn install_snapshot<E: std::error::Error + 'static>(
         &self,
         req_stream: impl Stream<Item = Result<InstallSnapshotRequest, E>>,
@@ -356,7 +356,7 @@ impl<C: Command, RC: RoleChange> CurpNode<C, RC> {
 /// Spawned tasks
 impl<C: Command, RC: RoleChange> CurpNode<C, RC> {
     /// Tick periodically
-    #[allow(clippy::integer_arithmetic)]
+    #[allow(clippy::arithmetic_side_effects)]
     async fn election_task(curp: Arc<RawCurp<C, RC>>) {
         let mut shutdown_listener = curp.shutdown_listener();
         let heartbeat_interval = curp.cfg().heartbeat_interval;
@@ -399,7 +399,7 @@ impl<C: Command, RC: RoleChange> CurpNode<C, RC> {
     ) {
         let change_rx = curp.change_rx();
         let mut shutdown_listener = curp.shutdown_listener();
-        #[allow(clippy::integer_arithmetic)] // introduced by tokio select
+        #[allow(clippy::arithmetic_side_effects)] // introduced by tokio select
         loop {
             let change: ConfChange = tokio::select! {
                 _ = shutdown_listener.wait() => break,
@@ -469,7 +469,7 @@ impl<C: Command, RC: RoleChange> CurpNode<C, RC> {
         let batch_timeout = curp.cfg().batch_timeout;
         let leader_event = curp.leader_event();
 
-        #[allow(clippy::integer_arithmetic)] // tokio select internal triggered
+        #[allow(clippy::arithmetic_side_effects)] // tokio select internal triggered
         'outer: loop {
             if !curp.is_leader() {
                 tokio::select! {
@@ -758,7 +758,7 @@ impl<C: Command, RC: RoleChange> CurpNode<C, RC> {
     /// Send `append_entries` request
     /// Return `tonic::Error` if meet network issue
     /// Return (`leader_retires`, `ae_succeed`)
-    #[allow(clippy::integer_arithmetic)] // won't overflow
+    #[allow(clippy::arithmetic_side_effects)] // won't overflow
     async fn send_ae(
         connect: &(impl InnerConnectApi + ?Sized),
         curp: &RawCurp<C, RC>,

--- a/curp/src/server/raw_curp/log.rs
+++ b/curp/src/server/raw_curp/log.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)] // u64 is large enough and won't overflow
+#![allow(clippy::arithmetic_side_effects)] // u64 is large enough and won't overflow
 
 use std::{
     collections::{HashMap, HashSet, VecDeque},

--- a/curp/src/server/raw_curp/mod.rs
+++ b/curp/src/server/raw_curp/mod.rs
@@ -7,7 +7,7 @@
 //!     3. self.log
 
 #![allow(clippy::similar_names)] // st, lst, cst is similar but not confusing
-#![allow(clippy::integer_arithmetic)] // u64 is large enough and won't overflow
+#![allow(clippy::arithmetic_side_effects)] // u64 is large enough and won't overflow
 
 use std::{
     cmp::min,

--- a/curp/src/server/storage/db.rs
+++ b/curp/src/server/storage/db.rs
@@ -59,7 +59,7 @@ impl<C: Command> StorageApi for DB<C> {
                 continue;
             }
             let entry: LogEntry<C> = bincode::deserialize(&v)?;
-            #[allow(clippy::integer_arithmetic)] // won't overflow
+            #[allow(clippy::arithmetic_side_effects)] // won't overflow
             if entry.index != prev_index + 1 {
                 // break when logs are no longer consistent
                 break;

--- a/curp/src/server/storage/wal/codec.rs
+++ b/curp/src/server/storage/wal/codec.rs
@@ -87,7 +87,7 @@ impl<C> WAL<C> {
     /// Gets encoded length and padding length
     ///
     /// This is used to prevent torn write by forcing 8-bit alignment
-    #[allow(unused, clippy::integer_arithmetic)] // TODO: 8bit alignment
+    #[allow(unused, clippy::arithmetic_side_effects)] // TODO: 8bit alignment
     fn encode_frame_size(data_len: usize) -> (usize, usize) {
         let mut encoded_len = data_len;
         let pad_len = (8 - data_len % 8) % 8;
@@ -157,7 +157,7 @@ where
 
 #[allow(
     clippy::indexing_slicing, // Index slicings are checked
-    clippy::integer_arithmetic, //  Arithmetics are checked
+    clippy::arithmetic_side_effects, //  Arithmetics are checked
     clippy::unnecessary_wraps // Use the wraps to make code more consistenct
 )]
 impl<C> WALFrame<C>
@@ -256,7 +256,7 @@ impl<C> FrameEncoder for DataFrame<C>
 where
     C: Serialize,
 {
-    #[allow(clippy::integer_arithmetic)] // The integer shift is safe
+    #[allow(clippy::arithmetic_side_effects)] // The integer shift is safe
     fn encode(&self) -> Vec<u8> {
         match *self {
             DataFrame::Entry(ref entry) => {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,142 +1,149 @@
 //! Storage
 #![deny(
-// The following are allowed by default lints according to
-// https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+    // The following are allowed by default lints according to
+    // https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
 
-absolute_paths_not_starting_with_crate,
-// box_pointers, async trait must use it
-elided_lifetimes_in_paths,
-explicit_outlives_requirements,
-keyword_idents,
-macro_use_extern_crate,
-meta_variable_misuse,
-missing_abi,
-missing_copy_implementations,
-missing_debug_implementations,
-missing_docs,
-// must_not_suspend, unstable
-non_ascii_idents,
-// non_exhaustive_omitted_patterns, unstable
-noop_method_call,
-pointer_structural_match,
-rust_2021_incompatible_closure_captures,
-rust_2021_incompatible_or_patterns,
-rust_2021_prefixes_incompatible_syntax,
-rust_2021_prelude_collisions,
-single_use_lifetimes,
-trivial_casts,
-trivial_numeric_casts,
-unreachable_pub,
-unsafe_code,
-unsafe_op_in_unsafe_fn,
-unstable_features,
-// unused_crate_dependencies, the false positive case blocks us
-unused_extern_crates,
-unused_import_braces,
-unused_lifetimes,
-unused_qualifications,
-unused_results,
-variant_size_differences,
-warnings, // treat all warnings as errors
+    absolute_paths_not_starting_with_crate,
+    // box_pointers, async trait must use it
+    elided_lifetimes_in_paths,
+    explicit_outlives_requirements,
+    keyword_idents,
+    macro_use_extern_crate,
+    meta_variable_misuse,
+    missing_abi,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    // must_not_suspend, unstable
+    non_ascii_idents,
+    // non_exhaustive_omitted_patterns, unstable
+    noop_method_call,
+    pointer_structural_match,
+    rust_2021_incompatible_closure_captures,
+    rust_2021_incompatible_or_patterns,
+    rust_2021_prefixes_incompatible_syntax,
+    rust_2021_prelude_collisions,
+    single_use_lifetimes,
+    trivial_casts,
+    trivial_numeric_casts,
+    unreachable_pub,
+    unsafe_code,
+    unsafe_op_in_unsafe_fn,
+    unstable_features,
+    // unused_crate_dependencies, the false positive case blocks us
+    unused_extern_crates,
+    unused_import_braces,
+    unused_lifetimes,
+    unused_qualifications,
+    unused_results,
+    variant_size_differences,
+    warnings, // treat all warnings as errors
 
-clippy::all,
-clippy::pedantic,
-clippy::cargo,
+    clippy::all,
+    clippy::pedantic,
+    clippy::cargo,
 
-// The followings are selected restriction lints for rust 1.57
-clippy::as_conversions,
-clippy::clone_on_ref_ptr,
-clippy::create_dir,
-clippy::dbg_macro,
-clippy::decimal_literal_representation,
-// clippy::default_numeric_fallback, too verbose when dealing with numbers
-clippy::disallowed_script_idents,
-clippy::else_if_without_else,
-clippy::exhaustive_enums,
-clippy::exhaustive_structs,
-clippy::exit,
-clippy::expect_used,
-clippy::filetype_is_file,
-clippy::float_arithmetic,
-clippy::float_cmp_const,
-clippy::get_unwrap,
-clippy::if_then_some_else_none,
-// clippy::implicit_return, it's idiomatic Rust code.
-clippy::indexing_slicing,
-// clippy::inline_asm_x86_att_syntax, stick to intel syntax
-clippy::inline_asm_x86_intel_syntax,
-clippy::integer_arithmetic,
-// clippy::integer_division, required in the project
-clippy::let_underscore_must_use,
-clippy::lossy_float_literal,
-clippy::map_err_ignore,
-clippy::mem_forget,
-clippy::missing_docs_in_private_items,
-clippy::missing_enforced_import_renames,
-clippy::missing_inline_in_public_items,
-// clippy::mod_module_files, mod.rs file is used
-clippy::modulo_arithmetic,
-clippy::multiple_inherent_impl,
-clippy::panic,
-// clippy::panic_in_result_fn, not necessary as panic is banned
-clippy::pattern_type_mismatch,
-clippy::print_stderr,
-clippy::print_stdout,
-clippy::rc_buffer,
-clippy::rc_mutex,
-clippy::rest_pat_in_fully_bound_structs,
-clippy::same_name_method,
-clippy::self_named_module_files,
-// clippy::shadow_reuse, it’s a common pattern in Rust code
-// clippy::shadow_same, it’s a common pattern in Rust code
-clippy::shadow_unrelated,
-clippy::str_to_string,
-clippy::string_add,
-clippy::string_to_string,
-clippy::todo,
-clippy::unimplemented,
-clippy::unnecessary_self_imports,
-clippy::unneeded_field_pattern,
-// clippy::unreachable, allow unreachable panic, which is out of expectation
-clippy::unwrap_in_result,
-clippy::unwrap_used,
-// clippy::use_debug, debug is allow for debug log
-clippy::verbose_file_reads,
-clippy::wildcard_enum_match_arm,
+    // The followings are selected restriction lints for rust 1.57
+    clippy::as_conversions,
+    clippy::clone_on_ref_ptr,
+    clippy::create_dir,
+    clippy::dbg_macro,
+    clippy::decimal_literal_representation,
+    // clippy::default_numeric_fallback, too verbose when dealing with numbers
+    clippy::disallowed_script_idents,
+    clippy::else_if_without_else,
+    clippy::exhaustive_enums,
+    clippy::exhaustive_structs,
+    clippy::exit,
+    clippy::expect_used,
+    clippy::filetype_is_file,
+    clippy::float_arithmetic,
+    clippy::float_cmp_const,
+    clippy::get_unwrap,
+    clippy::if_then_some_else_none,
+    // clippy::implicit_return, it's idiomatic Rust code.
+    clippy::indexing_slicing,
+    // clippy::inline_asm_x86_att_syntax, stick to intel syntax
+    clippy::inline_asm_x86_intel_syntax,
+    clippy::arithmetic_side_effects,
+    // clippy::integer_division, required in the project
+    clippy::let_underscore_must_use,
+    clippy::lossy_float_literal,
+    clippy::map_err_ignore,
+    clippy::mem_forget,
+    clippy::missing_docs_in_private_items,
+    clippy::missing_enforced_import_renames,
+    clippy::missing_inline_in_public_items,
+    // clippy::mod_module_files, mod.rs file is used
+    clippy::modulo_arithmetic,
+    clippy::multiple_inherent_impl,
+    clippy::panic,
+    // clippy::panic_in_result_fn, not necessary as panic is banned
+    clippy::pattern_type_mismatch,
+    clippy::print_stderr,
+    clippy::print_stdout,
+    clippy::rc_buffer,
+    clippy::rc_mutex,
+    clippy::rest_pat_in_fully_bound_structs,
+    clippy::same_name_method,
+    clippy::self_named_module_files,
+    // clippy::shadow_reuse, it’s a common pattern in Rust code
+    // clippy::shadow_same, it’s a common pattern in Rust code
+    clippy::shadow_unrelated,
+    clippy::str_to_string,
+    clippy::string_add,
+    clippy::string_to_string,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::unnecessary_self_imports,
+    clippy::unneeded_field_pattern,
+    // clippy::unreachable, allow unreachable panic, which is out of expectation
+    clippy::unwrap_in_result,
+    clippy::unwrap_used,
+    // clippy::use_debug, debug is allow for debug log
+    clippy::verbose_file_reads,
+    clippy::wildcard_enum_match_arm,
 
-// The followings are selected lints from 1.61.0 to 1.67.1
-clippy::as_ptr_cast_mut,
-clippy::derive_partial_eq_without_eq,
-clippy::empty_drop,
-clippy::empty_structs_with_brackets,
-clippy::format_push_string,
-clippy::iter_on_empty_collections,
-clippy::iter_on_single_items,
-clippy::large_include_file,
-clippy::manual_clamp,
-clippy::suspicious_xor_used_as_pow,
-clippy::unnecessary_safety_comment,
-clippy::unnecessary_safety_doc,
-clippy::unused_peekable,
-clippy::unused_rounding,
+    // The followings are selected lints from 1.61.0 to 1.67.1
+    clippy::as_ptr_cast_mut,
+    clippy::derive_partial_eq_without_eq,
+    clippy::empty_drop,
+    clippy::empty_structs_with_brackets,
+    clippy::format_push_string,
+    clippy::iter_on_empty_collections,
+    clippy::iter_on_single_items,
+    clippy::large_include_file,
+    clippy::manual_clamp,
+    clippy::suspicious_xor_used_as_pow,
+    clippy::unnecessary_safety_comment,
+    clippy::unnecessary_safety_doc,
+    clippy::unused_peekable,
+    clippy::unused_rounding,
 
-// The followings are selected restriction lints from rust 1.68.0 to 1.70.0
-// clippy::allow_attributes, still unstable
-clippy::impl_trait_in_params,
-clippy::let_underscore_untyped,
-clippy::missing_assert_message,
-clippy::multiple_unsafe_ops_per_block,
-clippy::semicolon_inside_block,
-// clippy::semicolon_outside_block, already used `semicolon_inside_block`
-clippy::tests_outside_test_module
+    // The followings are selected restriction lints from rust 1.68.0 to 1.71.0
+    // clippy::allow_attributes, still unstable
+    clippy::impl_trait_in_params,
+    clippy::let_underscore_untyped,
+    clippy::missing_assert_message,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::semicolon_inside_block,
+    // clippy::semicolon_outside_block, already used `semicolon_inside_block`
+    clippy::tests_outside_test_module,
+    // 1.71.0
+    clippy::default_constructed_unit_structs,
+    clippy::items_after_test_module,
+    clippy::manual_next_back,
+    clippy::manual_while_let_some,
+    clippy::needless_bool_assign,
+    clippy::non_minimal_cfg,
 )]
 #![allow(
-clippy::multiple_crate_versions, // caused by the dependency, can't be fixed
+    clippy::multiple_crate_versions, // caused by the dependency, can't be fixed
 )]
 #![cfg_attr(
     test,
     allow(
-        clippy::integer_arithmetic,
+        clippy::arithmetic_side_effects,
         clippy::indexing_slicing,
         unused_results,
         clippy::unwrap_used,

--- a/simulation/Cargo.toml
+++ b/simulation/Cargo.toml
@@ -17,7 +17,7 @@ curp = { path = "../curp" }
 curp-test-utils = { path = "../curp-test-utils" }
 engine = { path = "../engine" }
 futures = "0.3.29"
-itertools = "0.10.3"
+itertools = "0.11"
 madsim = "0.2.22"
 parking_lot = "0.12.1"
 prost = "0.12.3"

--- a/utils/src/config.rs
+++ b/utils/src/config.rs
@@ -306,7 +306,7 @@ pub const fn default_batch_timeout() -> Duration {
 /// default batch timeout
 #[must_use]
 #[inline]
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 pub const fn default_batch_max_size() -> u64 {
     2 * 1024 * 1024
 }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -66,7 +66,7 @@
     clippy::indexing_slicing,
     // clippy::inline_asm_x86_att_syntax, stick to intel syntax
     clippy::inline_asm_x86_intel_syntax,
-    clippy::integer_arithmetic,
+    clippy::arithmetic_side_effects,
     // clippy::integer_division, required in the project
     clippy::let_underscore_must_use,
     clippy::lossy_float_literal,
@@ -121,7 +121,7 @@
     clippy::unused_peekable,
     clippy::unused_rounding,
 
-    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // The followings are selected restriction lints from rust 1.68.0 to 1.71.0
     // clippy::allow_attributes, still unstable
     clippy::impl_trait_in_params,
     clippy::let_underscore_untyped,
@@ -129,7 +129,14 @@
     clippy::multiple_unsafe_ops_per_block,
     clippy::semicolon_inside_block,
     // clippy::semicolon_outside_block, already used `semicolon_inside_block`
-    clippy::tests_outside_test_module
+    clippy::tests_outside_test_module,
+    // 1.71.0
+    clippy::default_constructed_unit_structs,
+    clippy::items_after_test_module,
+    clippy::manual_next_back,
+    clippy::manual_while_let_some,
+    clippy::needless_bool_assign,
+    clippy::non_minimal_cfg,
 )]
 #![allow(
     clippy::multiple_crate_versions, // caused by the dependency, can't be fixed

--- a/utils/src/parser.rs
+++ b/utils/src/parser.rs
@@ -196,7 +196,7 @@ pub fn parse_rotation(s: &str) -> Result<RotationConfig, ConfigParseError> {
 /// # Errors
 /// Return error when parsing the given string to usize failed
 #[inline]
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 pub fn parse_batch_bytes(s: &str) -> Result<u64, ConfigParseError> {
     let s = s.to_lowercase();
     if s.ends_with("kb") {

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -26,6 +26,7 @@ getrandom = { version = "0.2", default-features = false, features = ["js", "rdra
 hashbrown = { version = "0.14", default-features = false, features = ["raw"] }
 hyper = { version = "0.14", features = ["full"] }
 indexmap = { version = "1", default-features = false, features = ["std"] }
+itertools = { version = "0.11" }
 libc = { version = "0.2" }
 log = { version = "0.4", default-features = false, features = ["std"] }
 madsim-tokio = { version = "0.2", default-features = false, features = ["fs", "io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "time"] }
@@ -48,6 +49,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] }
 bytes = { version = "1" }
 either = { version = "1" }
 hashbrown = { version = "0.14", default-features = false, features = ["raw"] }
+itertools = { version = "0.11" }
 libc = { version = "0.2" }
 log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }

--- a/xline-client/src/lib.rs
+++ b/xline-client/src/lib.rs
@@ -66,7 +66,7 @@
     clippy::indexing_slicing,
     // clippy::inline_asm_x86_att_syntax, stick to intel syntax
     clippy::inline_asm_x86_intel_syntax,
-    clippy::integer_arithmetic,
+    clippy::arithmetic_side_effects,
     // clippy::integer_division, required in the project
     clippy::let_underscore_must_use,
     clippy::lossy_float_literal,
@@ -121,7 +121,7 @@
     clippy::unused_peekable,
     clippy::unused_rounding,
 
-    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // The followings are selected restriction lints from rust 1.68.0 to 1.71.0
     // clippy::allow_attributes, still unstable
     clippy::impl_trait_in_params,
     clippy::let_underscore_untyped,
@@ -129,7 +129,14 @@
     clippy::multiple_unsafe_ops_per_block,
     clippy::semicolon_inside_block,
     // clippy::semicolon_outside_block, already used `semicolon_inside_block`
-    clippy::tests_outside_test_module
+    clippy::tests_outside_test_module,
+    // 1.71.0
+    clippy::default_constructed_unit_structs,
+    clippy::items_after_test_module,
+    clippy::manual_next_back,
+    clippy::manual_while_let_some,
+    clippy::needless_bool_assign,
+    clippy::non_minimal_cfg,
 )]
 #![allow(
     clippy::multiple_crate_versions, // caused by the dependency, can't be fixed
@@ -143,7 +150,7 @@
         clippy::unwrap_used,
         clippy::as_conversions,
         clippy::shadow_unrelated,
-        clippy::integer_arithmetic
+        clippy::arithmetic_side_effects
     )
 )]
 use std::{

--- a/xline/Cargo.toml
+++ b/xline/Cargo.toml
@@ -26,7 +26,7 @@ engine = { path = "../engine" }
 event-listener = "2.5.2"
 futures = "0.3.25"
 hyper = "0.14.27"
-itertools = "0.10.3"
+itertools = "0.11"
 jsonwebtoken = "8.1.1"
 log = "0.4.17"
 merged_range = "0.1.0"

--- a/xline/Cargo.toml
+++ b/xline/Cargo.toml
@@ -68,7 +68,7 @@ tonic-build = { version = "0.4.2", package = "madsim-tonic-build" }
 
 [dev-dependencies]
 etcd-client = "0.12.1"
-mockall = "0.11.3"
+mockall = "0.12.1"
 rand = "0.8.5"
 strum = "0.25"
 strum_macros = "0.25"

--- a/xline/src/lib.rs
+++ b/xline/src/lib.rs
@@ -66,7 +66,7 @@
     clippy::indexing_slicing,
     // clippy::inline_asm_x86_att_syntax, stick to intel syntax
     clippy::inline_asm_x86_intel_syntax,
-    clippy::integer_arithmetic,
+    clippy::arithmetic_side_effects,
     // clippy::integer_division, required in the project
     clippy::let_underscore_must_use,
     clippy::lossy_float_literal,
@@ -121,7 +121,7 @@
     clippy::unused_peekable,
     clippy::unused_rounding,
 
-    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // The followings are selected restriction lints from rust 1.68.0 to 1.71.0
     // clippy::allow_attributes, still unstable
     clippy::impl_trait_in_params,
     clippy::let_underscore_untyped,
@@ -129,7 +129,14 @@
     clippy::multiple_unsafe_ops_per_block,
     clippy::semicolon_inside_block,
     // clippy::semicolon_outside_block, already used `semicolon_inside_block`
-    clippy::tests_outside_test_module
+    clippy::tests_outside_test_module,
+    // 1.71.0
+    clippy::default_constructed_unit_structs,
+    clippy::items_after_test_module,
+    clippy::manual_next_back,
+    clippy::manual_while_let_some,
+    clippy::needless_bool_assign,
+    clippy::non_minimal_cfg,
 )]
 #![allow(
     clippy::panic, // allow debug_assert, panic in production code
@@ -145,7 +152,7 @@
         clippy::expect_used,
         clippy::as_conversions,
         clippy::shadow_unrelated,
-        clippy::integer_arithmetic,
+        clippy::arithmetic_side_effects,
         clippy::let_underscore_untyped,
     )
 )]

--- a/xline/src/main.rs
+++ b/xline/src/main.rs
@@ -66,7 +66,7 @@
     clippy::indexing_slicing,
     // clippy::inline_asm_x86_att_syntax, stick to intel syntax
     clippy::inline_asm_x86_intel_syntax,
-    clippy::integer_arithmetic,
+    clippy::arithmetic_side_effects,
     // clippy::integer_division, required in the project
     clippy::let_underscore_must_use,
     clippy::lossy_float_literal,
@@ -121,7 +121,7 @@
     clippy::unused_peekable,
     clippy::unused_rounding,
 
-    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // The followings are selected restriction lints from rust 1.68.0 to 1.71.0
     // clippy::allow_attributes, still unstable
     clippy::impl_trait_in_params,
     clippy::let_underscore_untyped,
@@ -129,7 +129,14 @@
     clippy::multiple_unsafe_ops_per_block,
     clippy::semicolon_inside_block,
     // clippy::semicolon_outside_block, already used `semicolon_inside_block`
-    clippy::tests_outside_test_module
+    clippy::tests_outside_test_module,
+    // 1.71.0
+    clippy::default_constructed_unit_structs,
+    clippy::items_after_test_module,
+    clippy::manual_next_back,
+    clippy::manual_while_let_some,
+    clippy::needless_bool_assign,
+    clippy::non_minimal_cfg,
 )]
 #![allow(
     clippy::panic, // allow debug_assert, panic in production code
@@ -495,7 +502,7 @@ async fn read_key_pair(
 }
 
 #[tokio::main]
-#[allow(clippy::integer_arithmetic)] // Introduced by tokio::select!
+#[allow(clippy::arithmetic_side_effects)] // Introduced by tokio::select!
 async fn main() -> Result<()> {
     global::set_text_map_propagator(TraceContextPropagator::new());
     let config: XlineServerConfig = if env::args_os().len() == 1 {

--- a/xline/src/server/auth_server.rs
+++ b/xline/src/server/auth_server.rs
@@ -170,7 +170,7 @@ impl Auth for AuthServer {
         mut request: tonic::Request<AuthUserChangePasswordRequest>,
     ) -> Result<tonic::Response<AuthUserChangePasswordResponse>, tonic::Status> {
         debug!("Receive AuthUserChangePasswordRequest {:?}", request);
-        let mut user_change_password_req = request.get_mut();
+        let user_change_password_req = request.get_mut();
         let hashed_password = Self::hash_password(user_change_password_req.password.as_bytes());
         user_change_password_req.hashed_password = hashed_password;
         user_change_password_req.password = String::new();

--- a/xline/src/server/lease_server.rs
+++ b/xline/src/server/lease_server.rs
@@ -73,7 +73,7 @@ where
     }
 
     /// Task of revoke expired leases
-    #[allow(clippy::integer_arithmetic)] // Introduced by tokio::select!
+    #[allow(clippy::arithmetic_side_effects)] // Introduced by tokio::select!
     async fn revoke_expired_leases_task(lease_server: Arc<LeaseServer<S>>) {
         let mut listener = lease_server.shutdown_listener.clone();
         loop {
@@ -139,7 +139,7 @@ where
     }
 
     /// Handle keep alive at leader
-    #[allow(clippy::integer_arithmetic)] // Introduced by tokio::select!
+    #[allow(clippy::arithmetic_side_effects)] // Introduced by tokio::select!
     async fn leader_keep_alive(
         &self,
         mut request_stream: tonic::Streaming<LeaseKeepAliveRequest>,
@@ -186,7 +186,7 @@ where
     }
 
     /// Handle keep alive at follower
-    #[allow(clippy::integer_arithmetic)] // Introduced by tokio::select!
+    #[allow(clippy::arithmetic_side_effects)] // Introduced by tokio::select!
     async fn follower_keep_alive(
         &self,
         mut request_stream: tonic::Streaming<LeaseKeepAliveRequest>,
@@ -270,7 +270,7 @@ where
         if let Some(sync_res) = sync_res {
             let revision = sync_res.revision();
             debug!("Get revision {:?} for LeaseGrantResponse", revision);
-            if let Some(mut header) = res.header.as_mut() {
+            if let Some(header) = res.header.as_mut() {
                 header.revision = revision;
             }
         }
@@ -291,7 +291,7 @@ where
         if let Some(sync_res) = sync_res {
             let revision = sync_res.revision();
             debug!("Get revision {:?} for LeaseRevokeResponse", revision);
-            if let Some(mut header) = res.header.as_mut() {
+            if let Some(header) = res.header.as_mut() {
                 header.revision = revision;
             }
         }
@@ -398,7 +398,7 @@ where
         if let Some(sync_res) = sync_res {
             let revision = sync_res.revision();
             debug!("Get revision {:?} for LeaseLeasesResponse", revision);
-            if let Some(mut header) = res.header.as_mut() {
+            if let Some(header) = res.header.as_mut() {
                 header.revision = revision;
             }
         }

--- a/xline/src/server/maintenance.rs
+++ b/xline/src/server/maintenance.rs
@@ -118,7 +118,7 @@ where
         if let Some(sync_res) = sync_res {
             let revision = sync_res.revision();
             debug!("Get revision {:?} for AlarmResponse", revision);
-            if let Some(mut header) = res.header.as_mut() {
+            if let Some(header) = res.header.as_mut() {
                 header.revision = revision;
             }
         }

--- a/xline/src/server/watch_server.rs
+++ b/xline/src/server/watch_server.rs
@@ -65,7 +65,7 @@ where
     }
 
     /// bg task for handle watch connection
-    #[allow(clippy::integer_arithmetic)] // Introduced by tokio::select!
+    #[allow(clippy::arithmetic_side_effects)] // Introduced by tokio::select!
     async fn task<ST, W>(
         next_id_gen: Arc<WatchIdGenerator>,
         kv_watcher: Arc<W>,

--- a/xline/src/server/xline_server.rs
+++ b/xline/src/server/xline_server.rs
@@ -107,6 +107,7 @@ impl XlineServer {
 
     /// Construct a `LeaseCollection`
     #[inline]
+    #[allow(clippy::arithmetic_side_effects)] // never overflow
     fn construct_lease_collection(
         heartbeat_interval: Duration,
         candidate_timeout_ticks: u8,

--- a/xline/src/storage/auth_store/store.rs
+++ b/xline/src/storage/auth_store/store.rs
@@ -79,7 +79,7 @@ where
     S: StorageApi,
 {
     /// New `AuthStore`
-    #[allow(clippy::integer_arithmetic)] // Introduced by tokio::select!
+    #[allow(clippy::arithmetic_side_effects)] // Introduced by tokio::select!
     pub(crate) fn new(
         lease_collection: Arc<LeaseCollection>,
         key_pair: Option<(EncodingKey, DecodingKey)>,

--- a/xline/src/storage/compact/mod.rs
+++ b/xline/src/storage/compact/mod.rs
@@ -97,7 +97,7 @@ pub(crate) async fn auto_compactor<C: Compactable>(
 }
 
 /// background compact executor
-#[allow(clippy::integer_arithmetic)] // introduced bt tokio::select! macro
+#[allow(clippy::arithmetic_side_effects)] // introduced bt tokio::select! macro
 pub(crate) async fn compact_bg_task<DB>(
     kv_store: Arc<KvStore<DB>>,
     index: Arc<Index>,

--- a/xline/src/storage/compact/periodic_compactor.rs
+++ b/xline/src/storage/compact/periodic_compactor.rs
@@ -36,14 +36,14 @@ impl RevisionWindow {
     }
 
     /// Store the revision into the inner ring buffer
-    #[allow(clippy::integer_arithmetic, clippy::indexing_slicing)]
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
     fn sample(&mut self, revision: i64) {
         self.cursor = (self.cursor + 1) % self.retention; // it's ok to do so since cursor will never overflow
         self.ring_buf[self.cursor] = revision;
     }
 
     /// Retrieve the expired revision that is sampled period ago
-    #[allow(clippy::indexing_slicing, clippy::integer_arithmetic)]
+    #[allow(clippy::indexing_slicing, clippy::arithmetic_side_effects)]
     fn expired_revision(&self) -> Option<i64> {
         let target = self.ring_buf[(self.cursor + 1) % self.retention];
         if target == 0 {
@@ -157,7 +157,7 @@ fn sample_config(period: Duration) -> (Duration, usize) {
 
 #[async_trait::async_trait]
 impl<C: Compactable> Compactor<C> for PeriodicCompactor<C> {
-    #[allow(clippy::integer_arithmetic)]
+    #[allow(clippy::arithmetic_side_effects)]
     async fn run(&self) {
         let mut last_revision: Option<i64> = None;
         let (sample_frequency, sample_total) = sample_config(self.period);

--- a/xline/src/storage/compact/revision_compactor.rs
+++ b/xline/src/storage/compact/revision_compactor.rs
@@ -102,7 +102,7 @@ impl<C: Compactable> Compactor<C> for RevisionCompactor<C> {
         self.is_leader.store(true, Relaxed);
     }
 
-    #[allow(clippy::integer_arithmetic)]
+    #[allow(clippy::arithmetic_side_effects)]
     async fn run(&self) {
         let mut last_revision = None;
         let mut ticker = tokio::time::interval(CHECK_INTERVAL);

--- a/xline/src/storage/kvwatcher.rs
+++ b/xline/src/storage/kvwatcher.rs
@@ -276,7 +276,7 @@ impl WatcherMap {
 }
 
 /// Operations of KV watcher
-#[allow(clippy::integer_arithmetic, clippy::indexing_slicing)] // Introduced by mockall::automock
+#[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // Introduced by mockall::automock
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub(crate) trait KvWatcherOps {
@@ -412,7 +412,7 @@ where
     }
 
     /// Background task to handle KV updates
-    #[allow(clippy::integer_arithmetic)] // Introduced by tokio::select!
+    #[allow(clippy::arithmetic_side_effects)] // Introduced by tokio::select!
     async fn kv_updates_task(
         kv_watcher: Arc<KvWatcher<S>>,
         mut kv_update_rx: mpsc::Receiver<(i64, Vec<Event>)>,
@@ -427,7 +427,7 @@ where
     }
 
     /// Background task to sync victims
-    #[allow(clippy::integer_arithmetic)] // Introduced by tokio::select!
+    #[allow(clippy::arithmetic_side_effects)] // Introduced by tokio::select!
     async fn sync_victims_task(
         kv_watcher: Arc<KvWatcher<S>>,
         sync_victims_interval: Duration,

--- a/xline/src/storage/lease_store/lease.rs
+++ b/xline/src/storage/lease_store/lease.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashSet,
+    ops::Add,
     time::{Duration, Instant},
 };
 
@@ -70,7 +71,7 @@ impl Lease {
 
     /// Refresh expiry and return new expiry
     pub(crate) fn refresh(&mut self, extend: Duration) -> Instant {
-        let new_expiry = Instant::now() + extend + self.remaining_ttl();
+        let new_expiry = Instant::now().add(extend).add(self.remaining_ttl());
         self.expiry = Some(new_expiry);
         new_expiry
     }

--- a/xlineapi/Cargo.toml
+++ b/xlineapi/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["RPC", "Interfaces"]
 async-trait = "0.1.53"
 curp = { path = "../curp" }
 curp-external-api = { path = "../curp-external-api" }
-itertools = "0.10.3"
+itertools = "0.11"
 prost = "0.12.3"
 serde = { version = "1.0.137", features = ["derive"] }
 thiserror = "1.0.37"

--- a/xlineapi/src/execute_error.rs
+++ b/xlineapi/src/execute_error.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)] // introduced by `strum_macros::EnumIter`
+#![allow(clippy::arithmetic_side_effects)] // introduced by `strum_macros::EnumIter`
 
 use crate::{PbExecuteError, PbExecuteErrorOuter, PbRevisions, PbUserRole};
 use curp::cmd::{PbCodec, PbSerializeError};

--- a/xlineapi/src/lib.rs
+++ b/xlineapi/src/lib.rs
@@ -66,7 +66,7 @@
     clippy::indexing_slicing,
     // clippy::inline_asm_x86_att_syntax, stick to intel syntax
     clippy::inline_asm_x86_intel_syntax,
-    clippy::integer_arithmetic,
+    clippy::arithmetic_side_effects,
     // clippy::integer_division, required in the project
     clippy::let_underscore_must_use,
     clippy::lossy_float_literal,
@@ -121,7 +121,7 @@
     clippy::unused_peekable,
     clippy::unused_rounding,
 
-    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // The followings are selected restriction lints from rust 1.68.0 to 1.71.0
     // clippy::allow_attributes, still unstable
     clippy::impl_trait_in_params,
     clippy::let_underscore_untyped,
@@ -129,7 +129,14 @@
     clippy::multiple_unsafe_ops_per_block,
     clippy::semicolon_inside_block,
     // clippy::semicolon_outside_block, already used `semicolon_inside_block`
-    clippy::tests_outside_test_module
+    clippy::tests_outside_test_module,
+    // 1.71.0
+    clippy::default_constructed_unit_structs,
+    clippy::items_after_test_module,
+    clippy::manual_next_back,
+    clippy::manual_while_let_some,
+    clippy::needless_bool_assign,
+    clippy::non_minimal_cfg,
 )]
 // Skip for generated code
 #![allow(
@@ -154,7 +161,7 @@
         clippy::unwrap_used,
         clippy::as_conversions,
         clippy::shadow_unrelated,
-        clippy::integer_arithmetic
+        clippy::arithmetic_side_effects
     )
 )]
 

--- a/xlinectl/src/command/lease/keep_alive.rs
+++ b/xlinectl/src/command/lease/keep_alive.rs
@@ -34,7 +34,7 @@ pub(super) async fn execute(client: &mut Client, matches: &ArgMatches) -> Result
 
     let (mut keeper, mut stream) = client.lease_client().keep_alive(req).await?;
 
-    #[allow(clippy::integer_arithmetic)] // introduced by tokio::select
+    #[allow(clippy::arithmetic_side_effects)] // introduced by tokio::select
     if once {
         keeper.keep_alive()?;
         if let Some(resp) = stream.message().await? {

--- a/xlinectl/src/main.rs
+++ b/xlinectl/src/main.rs
@@ -66,7 +66,7 @@
     clippy::indexing_slicing,
     // clippy::inline_asm_x86_att_syntax, stick to intel syntax
     clippy::inline_asm_x86_intel_syntax,
-    clippy::integer_arithmetic,
+    clippy::arithmetic_side_effects,
     // clippy::integer_division, required in the project
     clippy::let_underscore_must_use,
     clippy::lossy_float_literal,
@@ -121,7 +121,7 @@
     clippy::unused_peekable,
     clippy::unused_rounding,
 
-    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // The followings are selected restriction lints from rust 1.68.0 to 1.71.0
     // clippy::allow_attributes, still unstable
     clippy::impl_trait_in_params,
     clippy::let_underscore_untyped,
@@ -129,7 +129,14 @@
     clippy::multiple_unsafe_ops_per_block,
     clippy::semicolon_inside_block,
     // clippy::semicolon_outside_block, already used `semicolon_inside_block`
-    clippy::tests_outside_test_module
+    clippy::tests_outside_test_module,
+    // 1.71.0
+    clippy::default_constructed_unit_structs,
+    clippy::items_after_test_module,
+    clippy::manual_next_back,
+    clippy::manual_while_let_some,
+    clippy::needless_bool_assign,
+    clippy::non_minimal_cfg,
 )]
 #![allow(
     clippy::multiple_crate_versions, // caused by the dependency, can't be fixed
@@ -145,7 +152,7 @@
         clippy::unwrap_used,
         clippy::as_conversions,
         clippy::shadow_unrelated,
-        clippy::integer_arithmetic
+        clippy::arithmetic_side_effects
     )
 )]
 


### PR DESCRIPTION

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    Refer to https://github.com/rust-lang/rust/issues/112430.
    When switching branches or writing mockall tests, we may encounter bugs in rustc's incremental compilation. The specific reason is unknown, but updating rustc and mockall versions can resolve it.

* what changes does this pull request make?

   Bump rust to 1.71.0

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

   Exposing APIs to users will not, but for developers, they need to update their own rustc.