### PR TITLE
fix: return error if put kv with nonexistent lease id

### DIFF
--- a/crates/xline/src/storage/kv_store.rs
+++ b/crates/xline/src/storage/kv_store.rs
@@ -598,6 +598,9 @@ where
             header: Some(self.header_gen.gen_header()),
             ..Default::default()
         };
+        if req.lease != 0 && self.lease_collection.look_up(req.lease).is_none() {
+            return Err(ExecuteError::LeaseNotFound(req.lease));
+        };
         if req.prev_kv || req.ignore_lease || req.ignore_value {
             let prev_kv = self.inner.get_range(&req.key, &[], 0)?.pop();
             if prev_kv.is_none() && (req.ignore_lease || req.ignore_value) {

--- a/crates/xline/tests/it/kv_test.rs
+++ b/crates/xline/tests/it/kv_test.rs
@@ -30,6 +30,10 @@ async fn test_kv_put() -> Result<(), Box<dyn Error>> {
             req: PutRequest::new("foo", "").with_ignore_value(true),
             want_err: false,
         },
+        TestCase {
+            req: PutRequest::new("foo", "").with_lease(12345),
+            want_err: true,
+        },
     ];
 
     let mut cluster = Cluster::new(3).await;


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
return error if put kv with nonexistent lease id
* what changes does this pull request make?
return error if put kv with nonexistent lease id
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no