### PR TITLE
refactor: modify --client-use-backoff commandline arg

### DIFF
--- a/crates/curp/src/client/mod.rs
+++ b/crates/curp/src/client/mod.rs
@@ -304,15 +304,15 @@ impl ClientBuilder {
 
     /// Init retry config
     fn init_retry_config(&self) -> RetryConfig {
-        if *self.config.use_backoff() {
-            RetryConfig::new_exponential(
+        if *self.config.fixed_backoff() {
+            RetryConfig::new_fixed(
                 *self.config.initial_retry_timeout(),
-                *self.config.max_retry_timeout(),
                 *self.config.retry_count(),
             )
         } else {
-            RetryConfig::new_fixed(
+            RetryConfig::new_exponential(
                 *self.config.initial_retry_timeout(),
+                *self.config.max_retry_timeout(),
                 *self.config.retry_count(),
             )
         }

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -374,8 +374,8 @@ pub const fn default_retry_count() -> usize {
 /// default use backoff
 #[must_use]
 #[inline]
-pub const fn default_use_backoff() -> bool {
-    true
+pub const fn default_fixed_backoff() -> bool {
+    false
 }
 
 /// default rpc timeout
@@ -516,8 +516,8 @@ pub struct ClientConfig {
 
     /// Whether to use exponential backoff in retries
     #[getset(get = "pub")]
-    #[serde(default = "default_use_backoff")]
-    use_backoff: bool,
+    #[serde(default = "default_fixed_backoff")]
+    fixed_backoff: bool,
 }
 
 impl ClientConfig {
@@ -534,7 +534,7 @@ impl ClientConfig {
         initial_retry_timeout: Duration,
         max_retry_timeout: Duration,
         retry_count: usize,
-        use_backoff: bool,
+        fixed_backoff: bool,
     ) -> Self {
         assert!(
             initial_retry_timeout <= max_retry_timeout,
@@ -546,7 +546,7 @@ impl ClientConfig {
             initial_retry_timeout,
             max_retry_timeout,
             retry_count,
-            use_backoff,
+            fixed_backoff,
         }
     }
 }
@@ -560,7 +560,7 @@ impl Default for ClientConfig {
             initial_retry_timeout: default_initial_retry_timeout(),
             max_retry_timeout: default_max_retry_timeout(),
             retry_count: default_retry_count(),
-            use_backoff: default_use_backoff(),
+            fixed_backoff: default_fixed_backoff(),
         }
     }
 }
@@ -1173,7 +1173,6 @@ mod tests {
             [cluster.client_config]
             initial_retry_timeout = '5s'
             max_retry_timeout = '50s'
-            use_backoff = false
 
             [storage]
             engine = { type = 'memory'}
@@ -1230,7 +1229,7 @@ mod tests {
             Duration::from_secs(5),
             Duration::from_secs(50),
             default_retry_count(),
-            false,
+            default_fixed_backoff(),
         );
 
         let server_timeout = ServerTimeout::new(

--- a/crates/xline/src/main.rs
+++ b/crates/xline/src/main.rs
@@ -147,8 +147,10 @@ use anyhow::Result;
 use opentelemetry::global;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tracing::{debug, info};
-use xline::server::XlineServer;
-use xline::utils::{init_metrics, init_subscriber, parse_config};
+use xline::{
+    server::XlineServer,
+    utils::{init_metrics, init_subscriber, parse_config},
+};
 
 #[tokio::main]
 #[allow(clippy::arithmetic_side_effects)] // Introduced by tokio::select!

--- a/crates/xline/src/metrics.rs
+++ b/crates/xline/src/metrics.rs
@@ -103,10 +103,12 @@ impl Metrics {
 #[allow(unsafe_code)]
 #[cfg(target_os = "macos")]
 fn fd_used_count() -> anyhow::Result<u64> {
-    use anyhow::anyhow;
+    use std::{
+        os::raw::{c_int, c_void},
+        ptr::null_mut,
+    };
 
-    use std::os::raw::{c_int, c_void};
-    use std::ptr::null_mut;
+    use anyhow::anyhow;
 
     /// Copying the related definitions from the headers
     #[repr(C)]

--- a/crates/xline/src/utils/args.rs
+++ b/crates/xline/src/utils/args.rs
@@ -14,10 +14,10 @@ use utils::{
         default_metrics_push_endpoint, default_metrics_push_protocol, default_propose_timeout,
         default_quota, default_range_retry_timeout, default_retry_count, default_rotation,
         default_rpc_timeout, default_server_wait_synced_timeout, default_sync_victims_interval,
-        default_use_backoff, default_watch_progress_notify_interval, AuthConfig, AutoCompactConfig,
-        ClientConfig, ClusterConfig, CompactConfig, CurpConfigBuilder, EngineConfig,
-        InitialClusterState, LevelConfig, LogConfig, MetricsConfig, MetricsPushProtocol,
-        RotationConfig, ServerTimeout, StorageConfig, TlsConfig, TraceConfig, XlineServerConfig,
+        default_watch_progress_notify_interval, AuthConfig, AutoCompactConfig, ClientConfig,
+        ClusterConfig, CompactConfig, CurpConfigBuilder, EngineConfig, InitialClusterState,
+        LevelConfig, LogConfig, MetricsConfig, MetricsPushProtocol, RotationConfig, ServerTimeout,
+        StorageConfig, TlsConfig, TraceConfig, XlineServerConfig,
     },
     parse_batch_bytes, parse_duration, parse_log_level, parse_members, parse_metrics_push_protocol,
     parse_rotation, parse_state, ConfigFileError,
@@ -129,9 +129,9 @@ pub struct ServerArgs {
     /// Curp client max retry timeout [default: 10_000ms]
     #[clap(long, value_parser = parse_duration)]
     client_max_retry_timeout: Option<Duration>,
-    /// Curp client use backoff [default: true]
+    /// Curp client use fixed backoff
     #[clap(long)]
-    client_use_backoff: Option<bool>,
+    client_fixed_backoff: bool,
     /// How often should the gc task run [default: 20s]
     #[clap(long, value_parser = parse_duration)]
     gc_interval: Option<Duration>,
@@ -158,7 +158,7 @@ pub struct ServerArgs {
     /// Curp command workers count
     #[clap(long, default_value_t = default_cmd_workers())]
     cmd_workers: u8,
-    /// The max number of historical versions processed in a single compact operation  [default: 1000]
+    /// The max number of historical versions processed in a single compact operation
     #[clap(long, default_value_t = default_compact_batch_size())]
     compact_batch_size: usize,
     /// Interval between two compaction operations [default: 10ms]
@@ -242,7 +242,7 @@ impl From<ServerArgs> for XlineServerConfig {
             args.client_max_retry_timeout
                 .unwrap_or_else(default_max_retry_timeout),
             args.retry_count.unwrap_or_else(default_retry_count),
-            args.client_use_backoff.unwrap_or_else(default_use_backoff),
+            args.client_fixed_backoff,
         );
         let server_timeout = ServerTimeout::new(
             args.range_retry_timeout

--- a/crates/xline/src/utils/trace.rs
+++ b/crates/xline/src/utils/trace.rs
@@ -2,9 +2,7 @@ use anyhow::Result;
 use opentelemetry_contrib::trace::exporter::jaeger_json::JaegerJsonExporter;
 use opentelemetry_sdk::runtime::Tokio;
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::fmt::format;
-use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{layer::SubscriberExt, Layer};
+use tracing_subscriber::{fmt::format, layer::SubscriberExt, util::SubscriberInitExt, Layer};
 use utils::config::{file_appender, LogConfig, TraceConfig};
 
 /// init tracing subscriber


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
refactor the `client-use-backoff` cmd line arg.

* what changes does this pull request make?
1. rename the `client-use-backoff` as `client-fixed-backoff` 
2. modify the type of `client-fixed-backoff` from Option<bool> to bool
3. modify the default value of `client-fixed-backoff`


* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
