### PR TITLE
docs: Fixed README redirection hyperlinks

### DIFF
--- a/crates/xline-client/README.md
+++ b/crates/xline-client/README.md
@@ -1,6 +1,6 @@
 # xline-client
 
-Official Xline API client for Rust that supports the [CURP](https://github.com/xline-kv/Xline/tree/master/curp) protocol
+Official Xline API client for Rust that supports the [CURP](https://github.com/xline-kv/Xline/tree/master/crates/curp) protocol
 
 # Pre-requisites
 - Install `protobuf-compiler` as mentioned in [QuickStart](https://github.com/xline-kv/Xline/blob/master/doc/quick-start/README.md#install-dependencies)
@@ -113,7 +113,7 @@ To create a xline client:
 
 ## Examples
 
-You can find them in [examples](https://github.com/xline-kv/Xline/tree/master/xline-client/examples)
+You can find them in [examples](https://github.com/xline-kv/Xline/tree/master/crates/xline-client/examples)
 
 ## Xline Compatibility
 


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
The `README.md` file in `crates/xline-client` contains two incorrect hyperlinks, likely due to changes in the code structure.
* what changes does this pull request make?
Only modified the `README.md`
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
