### PR TITLE
refactor: improve append entries

### DIFF
--- a/crates/curp/src/server/raw_curp/log.rs
+++ b/crates/curp/src/server/raw_curp/log.rs
@@ -284,7 +284,7 @@ impl<C: Command> Log<C> {
         // append log entries, will erase inconsistencies
         // Find the index of the first entry that needs to be truncated
         let mut pi = self.li_to_pi(prev_log_index + 1);
-        for entry in entries.iter() {
+        for entry in &entries {
             if self
                 .entries
                 .get(pi)
@@ -306,7 +306,7 @@ impl<C: Command> Log<C> {
         for entry in entries
             .into_iter()
             .skip(pi - self.li_to_pi(prev_log_index + 1))
-            .map(|x| Arc::new(x))
+            .map(Arc::new)
         {
             if matches!(entry.entry_data, EntryData::ConfChange(_)) {
                 conf_changes.push(Arc::clone(&entry));


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Optimize the behavior of log append entries. Ref to #515
* what changes does this pull request make?
The behavior of log append entries was redudant and this pr has made optimization according to following steps:
1. Find the index of the first entry that needs to be truncated.
2. Record entries that need to be fallback in the truncated entries.
3. truncate entries
4. Push the remaining entries and record the conf change entries
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
No.