### PR TITLE
fix: add keep alive logic for xlinectl lock command

### DIFF
--- a/crates/xline-client/src/lib.rs
+++ b/crates/xline-client/src/lib.rs
@@ -269,12 +269,7 @@ impl Client {
             token.clone(),
             Arc::clone(&id_gen),
         );
-        let lock = LockClient::new(
-            Arc::clone(&curp_client),
-            channel.clone(),
-            token.clone(),
-            id_gen,
-        );
+        let lock = LockClient::new(Arc::clone(&curp_client), channel.clone(), token.clone());
         let auth = AuthClient::new(curp_client, channel.clone(), token.clone());
         let maintenance = MaintenanceClient::new(channel.clone(), token.clone());
         let cluster = ClusterClient::new(channel.clone(), token.clone());

--- a/crates/xline-client/src/types/lock.rs
+++ b/crates/xline-client/src/types/lock.rs
@@ -1,7 +1,7 @@
 pub use xlineapi::{LockResponse, UnlockResponse};
 
 /// Default session ttl
-const DEFAULT_SESSION_TTL: i64 = 60;
+pub const DEFAULT_SESSION_TTL: i64 = 60;
 
 /// Request for `Lock`
 #[derive(Debug, PartialEq)]

--- a/crates/xline-client/tests/it/lock.rs
+++ b/crates/xline-client/tests/it/lock.rs
@@ -2,21 +2,36 @@ use std::time::Duration;
 
 use test_macros::abort_on_panic;
 use xline_client::{
+    clients::LeaseClient,
     error::Result,
-    types::lock::{LockRequest, UnlockRequest},
+    types::{
+        lease::LeaseGrantRequest,
+        lock::{LockRequest, UnlockRequest, DEFAULT_SESSION_TTL},
+    },
 };
 
 use super::common::get_cluster_client;
 
+async fn gen_lease_id(client: LeaseClient, ttl: i64) -> i64 {
+    client
+        .grant(LeaseGrantRequest::new(ttl))
+        .await
+        .expect("grant lease should be success")
+        .id
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn lock_unlock_should_success_in_normal_path() -> Result<()> {
     let (_cluster, client) = get_cluster_client().await.unwrap();
-    let client = client.lock_client();
+    let lock_client = client.lock_client();
+    let lease_id = gen_lease_id(client.lease_client(), DEFAULT_SESSION_TTL).await;
 
-    let resp = client.lock(LockRequest::new("lock-test")).await?;
+    let resp = lock_client
+        .lock(LockRequest::new("lock-test").with_lease(lease_id))
+        .await?;
     assert!(resp.key.starts_with(b"lock-test/"));
 
-    client.unlock(UnlockRequest::new(resp.key)).await?;
+    lock_client.unlock(UnlockRequest::new(resp.key)).await?;
     Ok(())
 }
 
@@ -24,31 +39,44 @@ async fn lock_unlock_should_success_in_normal_path() -> Result<()> {
 #[abort_on_panic]
 async fn lock_contention_should_occur_when_acquire_by_two() -> Result<()> {
     let (_cluster, client) = get_cluster_client().await.unwrap();
-    let client = client.lock_client();
+    let lock_client = client.lock_client();
+    let lease_id_1 = gen_lease_id(client.lease_client(), DEFAULT_SESSION_TTL).await;
+    let lease_id_2 = gen_lease_id(client.lease_client(), DEFAULT_SESSION_TTL).await;
+
     let client_c = client.clone();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
-    let resp = client.lock(LockRequest::new("lock-test")).await.unwrap();
+    let resp = lock_client
+        .lock(LockRequest::new("lock-test").with_lease(lease_id_1))
+        .await
+        .unwrap();
 
     let handle = tokio::spawn(async move {
         let res = tokio::time::timeout(
             Duration::from_secs(2),
-            client_c.lock(LockRequest::new("lock-test")),
+            client_c
+                .lock_client()
+                .lock(LockRequest::new("lock-test").with_lease(lease_id_2)),
         )
         .await;
         assert!(res.is_err());
         let _ignore = tx.send(());
-
+        let lease_id_3 = gen_lease_id(client_c.lease_client(), DEFAULT_SESSION_TTL).await;
         let res = tokio::time::timeout(
             Duration::from_millis(200),
-            client_c.lock(LockRequest::new("lock-test")),
+            client_c
+                .lock_client()
+                .lock(LockRequest::new("lock-test").with_lease(lease_id_3)),
         )
         .await;
         assert!(res.is_ok_and(|r| r.is_ok_and(|resp| resp.key.starts_with(b"lock-test/"))));
     });
 
     rx.recv().await.unwrap();
-    let _resp = client.unlock(UnlockRequest::new(resp.key)).await.unwrap();
+    let _resp = lock_client
+        .unlock(UnlockRequest::new(resp.key))
+        .await
+        .unwrap();
 
     handle.await.unwrap();
 
@@ -59,16 +87,18 @@ async fn lock_contention_should_occur_when_acquire_by_two() -> Result<()> {
 #[abort_on_panic]
 async fn lock_should_timeout_when_ttl_is_set() -> Result<()> {
     let (_cluster, client) = get_cluster_client().await.unwrap();
-    let client = client.lock_client();
+    let lock_client = client.lock_client();
+    let lease_id_1 = gen_lease_id(client.lease_client(), 1).await;
 
-    let _resp = client
-        .lock(LockRequest::new("lock-test").with_ttl(1))
+    let _resp = lock_client
+        .lock(LockRequest::new("lock-test").with_lease(lease_id_1))
         .await
         .unwrap();
 
+    let lease_id_2 = gen_lease_id(client.lease_client(), DEFAULT_SESSION_TTL).await;
     let resp = tokio::time::timeout(
         Duration::from_secs(2),
-        client.lock(LockRequest::new("lock-test")),
+        lock_client.lock(LockRequest::new("lock-test").with_lease(lease_id_2)),
     )
     .await
     .expect("timeout when trying to lock")?;
@@ -82,26 +112,32 @@ async fn lock_should_timeout_when_ttl_is_set() -> Result<()> {
 #[abort_on_panic]
 async fn lock_should_unlock_after_cancelled() -> Result<()> {
     let (_cluster, client) = get_cluster_client().await.unwrap();
-    let client = client.lock_client();
-    let client_c = client.clone();
+    let lock_client = client.lock_client();
+    let client_c = lock_client.clone();
+    let lease_id_1 = gen_lease_id(client.lease_client(), DEFAULT_SESSION_TTL).await;
+    let lease_id_2 = gen_lease_id(client.lease_client(), DEFAULT_SESSION_TTL).await;
+    let lease_id_3 = gen_lease_id(client.lease_client(), DEFAULT_SESSION_TTL).await;
     // first acquire the lock
-    let resp = client.lock(LockRequest::new("lock-test")).await.unwrap();
+    let resp = lock_client
+        .lock(LockRequest::new("lock-test").with_lease(lease_id_1))
+        .await
+        .unwrap();
 
     // acquire the lock again and then cancel it
     let res = tokio::time::timeout(
         Duration::from_secs(1),
-        client_c.lock(LockRequest::new("lock-test")),
+        client_c.lock(LockRequest::new("lock-test").with_lease(lease_id_2)),
     )
     .await;
     assert!(res.is_err());
 
     // unlock the first one
-    client.unlock(UnlockRequest::new(resp.key)).await?;
+    lock_client.unlock(UnlockRequest::new(resp.key)).await?;
 
     // try lock again, it should success
     let resp = tokio::time::timeout(
         Duration::from_secs(1),
-        client.lock(LockRequest::new("lock-test")),
+        lock_client.lock(LockRequest::new("lock-test").with_lease(lease_id_3)),
     )
     .await
     .expect("timeout when trying to lock")?;

--- a/crates/xline/tests/it/lock_test.rs
+++ b/crates/xline/tests/it/lock_test.rs
@@ -5,7 +5,7 @@ use tokio::time::{self, timeout};
 use xline_test_utils::{
     types::{
         lease::LeaseGrantRequest,
-        lock::{LockRequest, UnlockRequest},
+        lock::{LockRequest, UnlockRequest, DEFAULT_SESSION_TTL},
     },
     Cluster,
 };
@@ -17,11 +17,19 @@ async fn test_lock() -> Result<(), Box<dyn Error>> {
     cluster.start().await;
     let client = cluster.client().await;
     let lock_client = client.lock_client();
+    let lease_id_1 = client
+        .lease_client()
+        .grant(LeaseGrantRequest::new(DEFAULT_SESSION_TTL))
+        .await?
+        .id;
 
     let lock_handle = tokio::spawn({
         let c = lock_client.clone();
         async move {
-            let res = c.lock(LockRequest::new("test")).await.unwrap();
+            let res = c
+                .lock(LockRequest::new("test").with_lease(lease_id_1))
+                .await
+                .unwrap();
             time::sleep(Duration::from_secs(3)).await;
             let _res = c.unlock(UnlockRequest::new(res.key)).await.unwrap();
         }
@@ -29,7 +37,14 @@ async fn test_lock() -> Result<(), Box<dyn Error>> {
 
     time::sleep(Duration::from_secs(1)).await;
     let now = time::Instant::now();
-    let res = lock_client.lock(LockRequest::new("test")).await?;
+    let lease_id_2 = client
+        .lease_client()
+        .grant(LeaseGrantRequest::new(DEFAULT_SESSION_TTL))
+        .await?
+        .id;
+    let res = lock_client
+        .lock(LockRequest::new("test").with_lease(lease_id_2))
+        .await?;
     let elapsed = now.elapsed();
     assert!(res.key.starts_with(b"test"));
     assert!(elapsed >= Duration::from_secs(1));
@@ -46,18 +61,23 @@ async fn test_lock_timeout() -> Result<(), Box<dyn Error>> {
     let client = cluster.client().await;
     let lock_client = client.lock_client();
 
-    let lease_id = client
+    let lease_id_1 = client
         .lease_client()
         .grant(LeaseGrantRequest::new(1))
         .await?
         .id;
     let _res = lock_client
-        .lock(LockRequest::new("test").with_lease(lease_id))
+        .lock(LockRequest::new("test").with_lease(lease_id_1))
         .await?;
+    let lease_id_2 = client
+        .lease_client()
+        .grant(LeaseGrantRequest::new(DEFAULT_SESSION_TTL))
+        .await?
+        .id;
 
     let res = timeout(
         Duration::from_secs(3),
-        lock_client.lock(LockRequest::new("test")),
+        lock_client.lock(LockRequest::new("test").with_lease(lease_id_2)),
     )
     .await??;
     assert!(res.key.starts_with(b"test"));

--- a/crates/xlinectl/src/command/lease/mod.rs
+++ b/crates/xlinectl/src/command/lease/mod.rs
@@ -6,7 +6,7 @@ use crate::handle_matches;
 /// `grant` command
 mod grant;
 /// `keep_alive` command
-mod keep_alive;
+pub(crate) mod keep_alive;
 /// `list` command
 mod list;
 /// `revoke` command


### PR DESCRIPTION
Closes: #664

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
fix issue #664 

* what changes does this pull request make?
1. remove the lease client from LockClient
2. add keep alive logic for xlinectl lock cmd

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
