### PR TITLE
Refactor/better debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3911,6 +3911,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
+ "utils",
  "workspace-hack",
 ]
 

--- a/crates/curp/src/server/storage/wal/pipeline.rs
+++ b/crates/curp/src/server/storage/wal/pipeline.rs
@@ -162,9 +162,8 @@ impl std::fmt::Debug for FilePipeline {
 
 #[cfg(test)]
 mod tests {
-    use crate::server::storage::wal::util::get_file_paths_with_ext;
-
     use super::*;
+    use crate::server::storage::wal::util::get_file_paths_with_ext;
 
     #[tokio::test]
     async fn file_pipeline_is_ok() {

--- a/crates/curp/src/server/storage/wal/segment.rs
+++ b/crates/curp/src/server/storage/wal/segment.rs
@@ -12,14 +12,13 @@ use tokio::{
 use tokio_stream::StreamExt;
 use tokio_util::codec::Framed;
 
-use crate::log_entry::LogEntry;
-
 use super::{
     codec::{DataFrame, WAL},
     error::{CorruptType, WALError},
     util::{get_checksum, parse_u64, validate_data, LockedFile},
     WAL_FILE_EXT, WAL_MAGIC, WAL_VERSION,
 };
+use crate::log_entry::LogEntry;
 
 /// The size of wal file header in bytes
 const WAL_HEADER_SIZE: usize = 56;
@@ -415,9 +414,8 @@ mod tests {
 
     use curp_test_utils::test_cmd::TestCommand;
 
-    use crate::log_entry::EntryData;
-
     use super::*;
+    use crate::log_entry::EntryData;
 
     #[tokio::test]
     async fn segment_state_transition_is_correct() {

--- a/crates/curp/src/tracker.rs
+++ b/crates/curp/src/tracker.rs
@@ -1,7 +1,9 @@
 #![allow(unused)] // TODO remove when used
 
-use std::collections::VecDeque;
-use std::ops::{AddAssign, Sub};
+use std::{
+    collections::VecDeque,
+    ops::{AddAssign, Sub},
+};
 
 use clippy_utilities::NumericCast;
 

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -201,6 +201,26 @@ pub mod tracing;
 use ::tracing::debug;
 pub use parser::*;
 
+/// display all elements for the given vector
+#[macro_export]
+macro_rules! write_vec {
+    ($f:expr, $name:expr, $vector:expr) => {
+        write!($f, "{}: [ ", { $name })?;
+        let last_idx = if $vector.is_empty() {
+            0
+        } else {
+            $vector.len() - 1
+        };
+        for (idx, element) in $vector.iter().enumerate() {
+            write!($f, "{}", element)?;
+            if idx != last_idx {
+                write!($f, ",")?;
+            }
+        }
+        write!($f, "]")?;
+    };
+}
+
 /// Get current timestamp in seconds
 #[must_use]
 #[inline]

--- a/crates/xline/src/server/auth_server.rs
+++ b/crates/xline/src/server/auth_server.rs
@@ -142,8 +142,8 @@ where
         &self,
         mut request: tonic::Request<AuthUserAddRequest>,
     ) -> Result<tonic::Response<AuthUserAddResponse>, tonic::Status> {
-        debug!("Receive AuthUserAddRequest {:?}", request);
         let user_add_req = request.get_mut();
+        debug!("Receive AuthUserAddRequest {}", user_add_req);
         user_add_req.validation()?;
         let hashed_password = Self::hash_password(user_add_req.password.as_bytes());
         user_add_req.hashed_password = hashed_password;
@@ -244,7 +244,10 @@ where
         &self,
         request: tonic::Request<AuthRoleGrantPermissionRequest>,
     ) -> Result<tonic::Response<AuthRoleGrantPermissionResponse>, tonic::Status> {
-        debug!("Receive AuthRoleGrantPermissionRequest {:?}", request);
+        debug!(
+            "Receive AuthRoleGrantPermissionRequest {}",
+            request.get_ref()
+        );
         request.get_ref().validation()?;
         self.handle_req(request, false).await
     }
@@ -253,7 +256,10 @@ where
         &self,
         request: tonic::Request<AuthRoleRevokePermissionRequest>,
     ) -> Result<tonic::Response<AuthRoleRevokePermissionResponse>, tonic::Status> {
-        debug!("Receive AuthRoleRevokePermissionRequest {:?}", request);
+        debug!(
+            "Receive AuthRoleRevokePermissionRequest {}",
+            request.get_ref()
+        );
         self.handle_req(request, false).await
     }
 }

--- a/crates/xline/src/server/kv_server.rs
+++ b/crates/xline/src/server/kv_server.rs
@@ -205,7 +205,7 @@ where
     ) -> Result<tonic::Response<RangeResponse>, tonic::Status> {
         let range_req = request.get_ref();
         range_req.validation()?;
-        debug!("Receive grpc request: {:?}", range_req);
+        debug!("Receive grpc request: {}", range_req);
         range_req.check_revision(
             self.kv_storage.compacted_revision(),
             self.kv_storage.revision(),
@@ -244,7 +244,7 @@ where
     ) -> Result<tonic::Response<PutResponse>, tonic::Status> {
         let put_req: &PutRequest = request.get_ref();
         put_req.validation()?;
-        debug!("Receive grpc request: {:?}", put_req);
+        debug!("Receive grpc request: {}", put_req);
         let auth_info = self.auth_storage.try_get_auth_info_from_request(&request)?;
         let is_fast_path = true;
         let (cmd_res, sync_res) = self
@@ -253,7 +253,7 @@ where
         let mut res = Self::parse_response_op(cmd_res.into_inner().into());
         if let Some(sync_res) = sync_res {
             let revision = sync_res.revision();
-            debug!("Get revision {:?} for PutRequest", revision);
+            debug!("Get revision {} for PutRequest", revision);
             Self::update_header_revision(&mut res, revision);
         }
         if let Response::ResponsePut(response) = res {
@@ -273,7 +273,7 @@ where
     ) -> Result<tonic::Response<DeleteRangeResponse>, tonic::Status> {
         let delete_range_req = request.get_ref();
         delete_range_req.validation()?;
-        debug!("Receive grpc request: {:?}", delete_range_req);
+        debug!("Receive grpc request: {}", delete_range_req);
         let auth_info = self.auth_storage.try_get_auth_info_from_request(&request)?;
         let is_fast_path = true;
         let (cmd_res, sync_res) = self
@@ -282,7 +282,7 @@ where
         let mut res = Self::parse_response_op(cmd_res.into_inner().into());
         if let Some(sync_res) = sync_res {
             let revision = sync_res.revision();
-            debug!("Get revision {:?} for DeleteRangeRequest", revision);
+            debug!("Get revision {} for DeleteRangeRequest", revision);
             Self::update_header_revision(&mut res, revision);
         }
         if let Response::ResponseDeleteRange(response) = res {
@@ -303,7 +303,7 @@ where
     ) -> Result<tonic::Response<TxnResponse>, tonic::Status> {
         let txn_req = request.get_ref();
         txn_req.validation()?;
-        debug!("Receive grpc request: {:?}", txn_req);
+        debug!("Receive grpc request: {}", txn_req);
         txn_req.check_revision(
             self.kv_storage.compacted_revision(),
             self.kv_storage.revision(),
@@ -326,7 +326,7 @@ where
             let mut res = Self::parse_response_op(cmd_res.into_inner().into());
             if let Some(sync_res) = sync_res {
                 let revision = sync_res.revision();
-                debug!("Get revision {:?} for TxnRequest", revision);
+                debug!("Get revision {} for TxnRequest", revision);
                 Self::update_header_revision(&mut res, revision);
             }
             res

--- a/crates/xline/src/server/mod.rs
+++ b/crates/xline/src/server/mod.rs
@@ -21,6 +21,5 @@ mod watch_server;
 /// Xline server
 mod xline_server;
 
-pub(crate) use self::auth_server::get_token;
-pub(crate) use self::maintenance::MAINTENANCE_SNAPSHOT_CHUNK_SIZE;
 pub use self::xline_server::XlineServer;
+pub(crate) use self::{auth_server::get_token, maintenance::MAINTENANCE_SNAPSHOT_CHUNK_SIZE};

--- a/crates/xline/src/storage/kvwatcher.rs
+++ b/crates/xline/src/storage/kvwatcher.rs
@@ -20,6 +20,7 @@ use tracing::debug;
 use utils::{
     parking_lot_lock::RwLockMap,
     task_manager::{tasks::TaskName, Listener, TaskManager},
+    write_vec,
 };
 use xlineapi::command::KeyRange;
 
@@ -550,6 +551,19 @@ pub(crate) struct WatchEvent {
     revision: i64,
     /// Compacted WatchEvent
     compacted: bool,
+}
+
+impl std::fmt::Display for WatchEvent {
+    #[allow(clippy::arithmetic_side_effects)]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "WatchEvent {{ id: {}, revision: {}, compacted: {}, ",
+            self.id, self.revision, self.compacted,
+        )?;
+        write_vec!(f, "events", self.events);
+        write!(f, " }}")
+    }
 }
 
 impl WatchEvent {

--- a/crates/xline/src/storage/kvwatcher.rs
+++ b/crates/xline/src/storage/kvwatcher.rs
@@ -541,7 +541,6 @@ where
 }
 
 /// Watch Event
-#[derive(Debug)]
 pub(crate) struct WatchEvent {
     /// Watch ID
     id: WatchId,
@@ -553,8 +552,7 @@ pub(crate) struct WatchEvent {
     compacted: bool,
 }
 
-impl std::fmt::Display for WatchEvent {
-    #[allow(clippy::arithmetic_side_effects)]
+impl std::fmt::Debug for WatchEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,

--- a/crates/xline/src/storage/mod.rs
+++ b/crates/xline/src/storage/mod.rs
@@ -19,8 +19,7 @@ pub(crate) mod revision;
 /// Persistent storage abstraction
 pub(crate) mod storage_api;
 
+pub use self::revision::Revision;
 pub(crate) use self::{
     alarm_store::AlarmStore, auth_store::AuthStore, kv_store::KvStore, lease_store::LeaseStore,
 };
-
-pub use self::revision::Revision;

--- a/crates/xlineapi/Cargo.toml
+++ b/crates/xlineapi/Cargo.toml
@@ -19,6 +19,7 @@ prost = "0.12.3"
 serde = { version = "1.0.137", features = ["derive"] }
 thiserror = "1.0.37"
 tonic = { version = "0.4.1", package = "madsim-tonic" }
+utils = { path = "../utils", features = ["parking_lot"] }
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [build-dependencies]

--- a/crates/xlineapi/src/lib.rs
+++ b/crates/xlineapi/src/lib.rs
@@ -723,6 +723,9 @@ impl Display for AlarmMember {
     }
 }
 
+/// Since the tokio-rs/prost will automatically derive Debug trait for all the structures it generates, we have to
+/// override the Display trait for these requests and responses.
+/// FYI: https://github.com/tokio-rs/prost/issues/334
 impl Display for PutRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -758,22 +761,34 @@ impl Display for RangeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "RangeRequest {{ key: {:?}, range_end: {:?}, limit: {:?}, revision: {:?}, sort_order: {:?}, sort_target: {:?}, serializable: {:?}, keys_only: {:?}, count_only: {:?}, min_mod_revision: {:?}, max_mod_revision: {:?}, min_create_revision: {:?}, max_create_revision: {:?}, key_only: {:?}, count_only: {:?}, min_mod_revision: {:?}, max_mod_revision: {:?}, min_create_revision: {:?}, max_create_revision: {:?} }}",
+            "RangeRequest {{ key: {:?}, range_end: {:?}, limit: {:?}, revision: {:?}, sort_order: {:?}, ",
             String::from_utf8_lossy(&self.key),
             String::from_utf8_lossy(&self.range_end),
             self.limit,
             self.revision,
             self.sort_order,
+        )?;
+        write!(
+            f,
+            "sort_target: {:?}, serializable: {:?}, keys_only: {:?}, count_only: {:?}, min_mod_revision: {:?}, ",
             self.sort_target,
             self.serializable,
             self.keys_only,
             self.count_only,
-            self.min_mod_revision,
+            self.min_mod_revision
+        )?;
+        write!(
+            f,
+            "max_mod_revision: {:?}, min_create_revision: {:?}, max_create_revision: {:?}, key_only: {:?}, count_only: {:?}, ",
             self.max_mod_revision,
             self.min_create_revision,
             self.max_create_revision,
             self.keys_only,
             self.count_only,
+        )?;
+        write!(
+            f,
+            "min_mod_revision: {:?}, max_mod_revision: {:?}, min_create_revision: {:?}, max_create_revision: {:?} }}",
             self.min_mod_revision,
             self.max_mod_revision,
             self.min_create_revision,


### PR DESCRIPTION
Please briefly answer these questions:
Currently, some gRPC requests and responses consist of bytes and are not human-readable. I implemented the Display trait for these requests and responses so they can be output in a more developer-friendly format. The reason for implementing Display instead of Debug is that Prost automatically derives Debug for all requests and responses. This pr can reduce the log content size which mentioned in issue #516 .

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Implement Display trait for some requests and responses

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no