### PR TITLE
feat: support redirecting the logs to the terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3360,6 +3360,7 @@ dependencies = [
  "pbkdf2",
  "petgraph",
  "rand",
+ "regex",
  "serde",
  "test-macros",
  "thiserror",

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -29,6 +29,7 @@ parking_lot = { version = "0.12.3", optional = true }
 pbkdf2 = { version = "0.12.2", features = ["simple"] }
 petgraph = "0.6.4"
 rand = "0.8.5"
+regex = "1.10.4"
 serde = { version = "1.0.203", features = ["derive"] }
 thiserror = "1.0.61"
 tokio = { version = "0.2.25", package = "madsim-tokio", features = [

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -801,9 +801,9 @@ impl LogConfig {
     /// Generate a new `LogConfig` object
     #[must_use]
     #[inline]
-    pub fn new(path: PathBuf, rotation: RotationConfig, level: LevelConfig) -> Self {
+    pub fn new(path: Option<PathBuf>, rotation: RotationConfig, level: LevelConfig) -> Self {
         Self {
-            path: Some(path),
+            path,
             rotation,
             level,
         }
@@ -857,7 +857,7 @@ pub mod rotation_format {
 #[must_use]
 #[inline]
 pub const fn default_rotation() -> RotationConfig {
-    RotationConfig::Daily
+    RotationConfig::Never
 }
 
 /// Generates a `RollingFileAppender` from the given `RotationConfig` and `name`
@@ -1326,7 +1326,7 @@ mod tests {
         assert_eq!(
             config.log,
             LogConfig::new(
-                PathBuf::from("/var/log/xline"),
+                Some(PathBuf::from("/var/log/xline")),
                 RotationConfig::Daily,
                 LevelConfig::INFO
             )
@@ -1452,8 +1452,8 @@ mod tests {
         assert_eq!(
             config.log,
             LogConfig::new(
-                PathBuf::from("/var/log/xline"),
-                RotationConfig::Daily,
+                Some(PathBuf::from("/var/log/xline")),
+                RotationConfig::Never,
                 LevelConfig::INFO
             )
         );

--- a/crates/xline/src/utils/args.rs
+++ b/crates/xline/src/utils/args.rs
@@ -20,8 +20,8 @@ use utils::{
         MetricsPushProtocol, RotationConfig, ServerTimeout, StorageConfig, TlsConfig, TraceConfig,
         XlineServerConfig,
     },
-    parse_batch_bytes, parse_duration, parse_log_level, parse_members, parse_metrics_push_protocol,
-    parse_rotation, parse_state, ConfigFileError,
+    parse_batch_bytes, parse_duration, parse_log_file, parse_log_level, parse_members,
+    parse_metrics_push_protocol, parse_rotation, parse_state, ConfigFileError,
 };
 
 /// Xline server config path env name
@@ -92,8 +92,8 @@ pub struct ServerArgs {
     #[clap(long, value_parser = parse_metrics_push_protocol, default_value_t = default_metrics_push_protocol())]
     metrics_push_protocol: MetricsPushProtocol,
     /// Log file path
-    #[clap(long, default_value = "/var/log/xline")]
-    log_file: PathBuf,
+    #[clap(long, value_parser = parse_log_file, default_value = None)]
+    log_file: Option<PathBuf>,
     /// Log rotate strategy, eg: never, hourly, daily
     #[clap(long, value_parser = parse_rotation, default_value_t = default_rotation())]
     log_rotate: RotationConfig,

--- a/crates/xline/src/utils/trace.rs
+++ b/crates/xline/src/utils/trace.rs
@@ -1,9 +1,22 @@
-use anyhow::Result;
+use anyhow::{Ok, Result};
 use opentelemetry_contrib::trace::exporter::jaeger_json::JaegerJsonExporter;
 use opentelemetry_sdk::runtime::Tokio;
+use tracing::warn;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{fmt::format, layer::SubscriberExt, util::SubscriberInitExt, Layer};
-use utils::config::{file_appender, LogConfig, TraceConfig};
+use utils::config::{file_appender, LogConfig, RotationConfig, TraceConfig};
+
+/// Return a Box trait from the config
+fn generate_writer(name: &str, log_config: &LogConfig) -> Box<dyn std::io::Write + Send> {
+    if let Some(ref file_path) = *log_config.path() {
+        Box::new(file_appender(*log_config.rotation(), file_path, name))
+    } else {
+        if matches!(*log_config.rotation(), RotationConfig::Never) {
+            warn!("The log is output to the terminal, so the rotation parameter is ignored.");
+        }
+        Box::new(std::io::stdout())
+    }
+}
 
 /// init tracing subscriber
 /// # Errors
@@ -14,19 +27,6 @@ pub fn init_subscriber(
     log_config: &LogConfig,
     trace_config: &TraceConfig,
 ) -> Result<Option<WorkerGuard>> {
-    let mut guard = None;
-    let log_file_layer = log_config.path().as_ref().map(|log_path| {
-        let file_appender = file_appender(*log_config.rotation(), log_path, name);
-        // `WorkerGuard` should be assigned in the `main` function or whatever the entrypoint of the program is.
-        let (non_blocking, guard_inner) = tracing_appender::non_blocking(file_appender);
-        guard = Some(guard_inner);
-        tracing_subscriber::fmt::layer()
-            .event_format(format().compact())
-            .with_writer(non_blocking)
-            .with_ansi(false)
-            .with_filter(*log_config.level())
-    });
-
     let jaeger_level = *trace_config.jaeger_level();
     let jaeger_online_layer = trace_config
         .jaeger_online()
@@ -55,15 +55,20 @@ pub fn init_subscriber(
             .install_batch(),
         )
     });
-
     let jaeger_fmt_layer = tracing_subscriber::fmt::layer()
         .with_filter(tracing_subscriber::EnvFilter::from_default_env());
-
+    let writer = generate_writer(name, log_config);
+    let (non_blocking, guard) = tracing_appender::non_blocking(writer);
+    let log_layer = tracing_subscriber::fmt::layer()
+        .event_format(format().compact())
+        .with_writer(non_blocking)
+        .with_ansi(false)
+        .with_filter(*log_config.level());
     tracing_subscriber::registry()
-        .with(log_file_layer)
         .with(jaeger_fmt_layer)
         .with(jaeger_online_layer)
         .with(jaeger_offline_layer)
+        .with(log_layer)
         .try_init()?;
-    Ok(guard)
+    Ok(Some(guard))
 }

--- a/scripts/quick_start.sh
+++ b/scripts/quick_start.sh
@@ -11,11 +11,7 @@ source $DIR/log.sh
 stop_all() {
     log::info stopping
     for name in "node1" "node2" "node3" "client"; do
-        docker_id=$(docker ps -qf "name=${name}")
-        if [ -n "$docker_id" ]; then
-            docker exec $docker_id rm -rf $LOG_PATH/$name
-            docker stop $docker_id -t 1
-        fi
+        common::stop_container ${name}
     done
     docker network rm xline_net >/dev/null 2>&1
     docker stop "prometheus" > /dev/null 2>&1
@@ -29,21 +25,10 @@ run_cluster() {
     common::run_xline 1 ${MEMBERS} new
     common::run_xline 2 ${MEMBERS} new
     common::run_xline 3 ${MEMBERS} new
+    common::run_etcd_client
     wait
     log::info cluster started
 }
-
-# run container of xline/etcd use specified image
-# args:
-#   $1: size of cluster
-run_container() {
-    size=${1}
-    for ((i = 1; i <= ${size}; i++)); do
-        common::run_container ${i}
-    done
-    common::run_etcd_client
-}
-
 
 # run prometheus
 run_prometheus() {
@@ -56,7 +41,6 @@ if [ -z "$1" ]; then
     stop_all
     docker network create --subnet=172.20.0.0/24 xline_net >/dev/null 2>&1
     log::warn "A Docker network named 'xline_net' is created for communication among various xline nodes. You can use the command 'docker network rm xline_net' to remove it after use."
-    run_container 3
     run_cluster
     run_prometheus "172.20.0.6"
     echo "Prometheus starts on http://172.20.0.6:9090/graph and http://127.0.0.1:9090/graph (if you are using Docker Desktop)."

--- a/scripts/validation_test.sh
+++ b/scripts/validation_test.sh
@@ -6,7 +6,7 @@ source $DIR/log.sh
 QUICK_START="${DIR}/quick_start.sh"
 ETCDCTL="docker exec -i client etcdctl --endpoints=http://172.20.0.3:2379,http://172.20.0.4:2379"
 LOCK_CLIENT="docker exec -i client /mnt/validation_lock_client --endpoints=http://172.20.0.3:2379,http://172.20.0.4:2379,http://172.20.0.5:2379"
-export LOG_PATH=/mnt/logs
+export LOG_PATH=/var/log/xline
 export LOG_LEVEL=debug
 
 bash ${QUICK_START}
@@ -30,7 +30,6 @@ function run_new_member() {
     if [ -n "$docker_id" ]; then
         docker stop $docker_id
     fi
-    common::run_container 4
     common::run_xline 4 ${NEWMEMBERS} existing
 }
 


### PR DESCRIPTION
- what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
-> Fixes #670 
-> Currently, Xline does not support redirecting the logs to the terminal. It  outputs to a specified log file through `--log-file` in command line. If the user does not specify this parameter, the file path `/var/log/xline` is created by default.

- what changes does this pull request make?
-> Checks whether the user specifies  `--log-file`. If not, output the logs to the terminal and ignore `--log-rotate` if provided.

- are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
-> No