### PR TITLE
fix: quick-start readme corrected pem file path

### DIFF
--- a/doc/quick-start/README.md
+++ b/doc/quick-start/README.md
@@ -88,7 +88,7 @@ docker build . -t ghcr.io/xline-kv/xline -f doc/quick-start/Dockerfile
 ### Start Xline servers
 
 ```bash
-cp ./xline-test-utils/{private,public}.pem ./scripts
+cp ./fixtures/{private,public}.pem ./scripts
 
 ./scripts/quick_start.sh
 ```


### PR DESCRIPTION
This PR resolved this issue https://github.com/xline-kv/Xline/issues/693
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Documentation change for quick-start

* what changes does this pull request make?
Correct the quick-start DOC path to copy private and public pem file to scripts
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
NO