### PR TITLE
feat: Added validation for --client-listen-urls and --peer-listen-urls

### DIFF
--- a/crates/xline/src/utils/args.rs
+++ b/crates/xline/src/utils/args.rs
@@ -38,13 +38,13 @@ pub struct ServerArgs {
     #[clap(long)]
     name: String,
     /// Node peer listen urls
-    #[clap(long, num_args = 1.., value_delimiter = ',')]
+    #[clap(long, required = true, num_args = 1.., value_delimiter = ',')]
     peer_listen_urls: Vec<String>,
     /// Node peer advertise urls
     #[clap(long, num_args = 1.., value_delimiter = ',')]
     peer_advertise_urls: Vec<String>,
     /// Node client listen urls
-    #[clap(long, num_args = 1.., value_delimiter = ',')]
+    #[clap(long, required = true, num_args = 1.., value_delimiter = ',')]
     client_listen_urls: Vec<String>,
     /// Node client advertise urls
     #[clap(long, num_args = 1.., value_delimiter = ',')]


### PR DESCRIPTION
This PR resolved this issue: https://github.com/xline-kv/Xline/issues/691
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
 During the startup process of Xline, certain essential command-line parameters such as --member and --storage-engine are checked. and there is a lack of validation for `--client-listen-urls `and `--peer-listen-urls`
 Here's how it looks -
![fix_cli](https://github.com/xline-kv/Xline/assets/97114586/4e8cb483-2b2e-4932-ab73-a1d6dcb5e068)
![fix--help](https://github.com/xline-kv/Xline/assets/97114586/740ffe53-70ed-46b9-8da6-27562447e0ea)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
