### PR TITLE
fix: prevent batch_index overflow in raw_curp

### DIFF
--- a/crates/curp/src/server/curp_node.rs
+++ b/crates/curp/src/server/curp_node.rs
@@ -28,8 +28,10 @@ use utils::{
 use super::{
     cmd_board::{CmdBoardRef, CommandBoard},
     cmd_worker::{conflict_checked_mpmc, start_cmd_workers},
-    conflict::spec_pool_new::{SpObject, SpeculativePool},
-    conflict::uncommitted_pool::{UcpObject, UncommittedPool},
+    conflict::{
+        spec_pool_new::{SpObject, SpeculativePool},
+        uncommitted_pool::{UcpObject, UncommittedPool},
+    },
     gc::gc_cmd_board,
     lease_manager::LeaseManager,
     raw_curp::{AppendEntries, RawCurp, Vote},

--- a/crates/curp/src/server/mod.rs
+++ b/crates/curp/src/server/mod.rs
@@ -10,8 +10,10 @@ use utils::ClientTlsConfig;
 use utils::{config::CurpConfig, task_manager::TaskManager, tracing::Extract};
 
 use self::curp_node::CurpNode;
-pub use self::raw_curp::RawCurp;
-pub use self::{conflict::spec_pool_new::SpObject, conflict::uncommitted_pool::UcpObject};
+pub use self::{
+    conflict::{spec_pool_new::SpObject, uncommitted_pool::UcpObject},
+    raw_curp::RawCurp,
+};
 use crate::{
     cmd::{Command, CommandExecutor},
     members::{ClusterInfo, ServerId},

--- a/crates/curp/src/server/raw_curp/mod.rs
+++ b/crates/curp/src/server/raw_curp/mod.rs
@@ -218,7 +218,9 @@ impl<C: Command, RC: RoleChange> RawCurpBuilder<C, RC> {
             log_w.last_as = last_applied;
             log_w.last_exe = last_applied;
             log_w.commit_index = last_applied;
-            log_w.restore_entries(args.entries);
+            log_w
+                .restore_entries(args.entries)
+                .map_err(|e| RawCurpBuilderError::ValidationError(e.to_string()))?;
         }
 
         Ok(raw_curp)

--- a/crates/curp/src/server/raw_curp/mod.rs
+++ b/crates/curp/src/server/raw_curp/mod.rs
@@ -47,9 +47,11 @@ use self::{
     state::{CandidateState, LeaderState, State},
 };
 use super::{
-    cmd_worker::CEEventTxApi, conflict::spec_pool_new::SpeculativePool,
-    conflict::uncommitted_pool::UncommittedPool, lease_manager::LeaseManagerRef,
-    storage::StorageApi, DB,
+    cmd_worker::CEEventTxApi,
+    conflict::{spec_pool_new::SpeculativePool, uncommitted_pool::UncommittedPool},
+    lease_manager::LeaseManagerRef,
+    storage::StorageApi,
+    DB,
 };
 use crate::{
     cmd::Command,

--- a/crates/curp/src/server/storage/wal/segment.rs
+++ b/crates/curp/src/server/storage/wal/segment.rs
@@ -17,8 +17,6 @@ use tokio::{
 };
 use tokio_stream::StreamExt;
 
-use crate::log_entry::LogEntry;
-
 use super::{
     codec::{DataFrame, DataFrameOwned, WAL},
     error::{CorruptType, WALError},
@@ -26,6 +24,7 @@ use super::{
     util::{get_checksum, parse_u64, validate_data, LockedFile},
     WAL_FILE_EXT, WAL_MAGIC, WAL_VERSION,
 };
+use crate::log_entry::LogEntry;
 
 /// The size of wal file header in bytes
 const WAL_HEADER_SIZE: usize = 56;
@@ -307,9 +306,8 @@ mod tests {
 
     use curp_test_utils::test_cmd::TestCommand;
 
-    use crate::log_entry::EntryData;
-
     use super::*;
+    use crate::log_entry::EntryData;
 
     #[test]
     fn gen_parse_header_is_correct() {


### PR DESCRIPTION
* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
-> Fixes #368 

* what changes does this pull request make?
-> Use a scrolling array to replace the previous prefix array to prevent `batch_index ` overflow, which will be truncated when compact. Besides, the scrolling array reduces the operation time complexity of obtaining batch log to O(1).

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
-> No