### PR TITLE
chore: ignore hyper dependency update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
   labels:
     - "dependencies"
   open-pull-requests-limit: 10
+  ignore:
+  # We're using `AddrStream` which removed since 1.0.0, so we need to ignore this update for compatibility
+  - dependency-name: hyper
+    versions:
+    - 0.14.2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,7 @@ updates:
   - dependency-name: hyper
     versions:
     - 0.14.2
+  # The latest version of `clap` requires to upgrade the rustc from 1.71.0 to 1.74.0 or newer.
+  - dependency-name: clap
+    versions:
+    - 4.4.18


### PR DESCRIPTION
Please briefly answer these questions:
Prevent automatic upgrade of hyper from 0.14.28 to 1.0.0, as tonic depends on deprecated data structures, such as `AddrStream` and `AddrIncoming`.
FYI: https://github.com/hyperium/hyper/issues/2850

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
