### PR TITLE
ci: ignore RUSTSEC-2024-0332 in audit

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -49,7 +49,8 @@ jobs:
         run: ci/scripts/check-trailing-spaces.sh
 
       - name: Audit
-        run: cargo audit
+        # remove `--ignore` when https://github.com/hyperium/tonic/pull/1670 is merged
+        run: cargo audit --ignore RUSTSEC-2024-0332
 
       - name: Format
         run: cargo fmt --all -- --check


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
fix cargo-audit failed issue in ci. The root cause can be viewed in [CONTINUATION Flood](https://rustsec.org/advisories/RUSTSEC-2024-0332.html). The `tonic` depends on this `h2` crate. And this `--ignore` option will be removed after [pr 1670](https://github.com/hyperium/tonic/pull/1670) merge.

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
