### PR TITLE
fix:change rpc timeout to prevent the warn of ae failed

### DIFF
--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -407,7 +407,7 @@ pub const fn default_fixed_backoff() -> bool {
 #[must_use]
 #[inline]
 pub const fn default_rpc_timeout() -> Duration {
-    Duration::from_millis(50)
+    Duration::from_millis(150)
 }
 
 /// default candidate timeout ticks


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
-> Fixes #649 
* what changes does this pull request make?
-> Change default `rpc_timeout` to 150ms to prevent the warn of ae failed in tests, which was caused by the scheduling of simulation.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
No