### PR TITLE
refactor: remove DB generic

### DIFF
--- a/crates/xline/src/server/auth_server.rs
+++ b/crates/xline/src/server/auth_server.rs
@@ -22,18 +22,15 @@ use crate::{
         AuthUserRevokeRoleRequest, AuthUserRevokeRoleResponse, AuthenticateRequest,
         AuthenticateResponse, RequestWrapper, ResponseWrapper,
     },
-    storage::{storage_api::StorageApi, AuthStore},
+    storage::AuthStore,
 };
 
 /// Auth Server
-pub(crate) struct AuthServer<S>
-where
-    S: StorageApi,
-{
+pub(crate) struct AuthServer {
     /// Consensus client
     client: Arc<CurpClient>,
     /// Auth Store
-    auth_store: Arc<AuthStore<S>>,
+    auth_store: Arc<AuthStore>,
 }
 
 /// Get token from metadata
@@ -44,12 +41,9 @@ pub(crate) fn get_token(metadata: &MetadataMap) -> Option<String> {
         .and_then(|v| v.to_str().map(String::from).ok())
 }
 
-impl<S> AuthServer<S>
-where
-    S: StorageApi,
-{
+impl AuthServer {
     /// New `AuthServer`
-    pub(crate) fn new(client: Arc<CurpClient>, auth_store: Arc<AuthStore<S>>) -> Self {
+    pub(crate) fn new(client: Arc<CurpClient>, auth_store: Arc<AuthStore>) -> Self {
         Self { client, auth_store }
     }
 
@@ -89,10 +83,7 @@ where
 }
 
 #[tonic::async_trait]
-impl<S> Auth for AuthServer<S>
-where
-    S: StorageApi,
-{
+impl Auth for AuthServer {
     async fn auth_enable(
         &self,
         request: tonic::Request<AuthEnableRequest>,

--- a/crates/xline/src/server/auth_wrapper.rs
+++ b/crates/xline/src/server/auth_wrapper.rs
@@ -13,25 +13,19 @@ use tracing::debug;
 use xlineapi::command::Command;
 
 use super::xline_server::CurpServer;
-use crate::storage::{storage_api::StorageApi, AuthStore};
+use crate::storage::AuthStore;
 
 /// Auth wrapper
-pub(crate) struct AuthWrapper<S>
-where
-    S: StorageApi,
-{
+pub(crate) struct AuthWrapper {
     /// Curp server
-    curp_server: CurpServer<S>,
+    curp_server: CurpServer,
     /// Auth store
-    auth_store: Arc<AuthStore<S>>,
+    auth_store: Arc<AuthStore>,
 }
 
-impl<S> AuthWrapper<S>
-where
-    S: StorageApi,
-{
+impl AuthWrapper {
     /// Create a new auth wrapper
-    pub(crate) fn new(curp_server: CurpServer<S>, auth_store: Arc<AuthStore<S>>) -> Self {
+    pub(crate) fn new(curp_server: CurpServer, auth_store: Arc<AuthStore>) -> Self {
         Self {
             curp_server,
             auth_store,
@@ -40,10 +34,7 @@ where
 }
 
 #[tonic::async_trait]
-impl<S> Protocol for AuthWrapper<S>
-where
-    S: StorageApi,
-{
+impl Protocol for AuthWrapper {
     async fn propose(
         &self,
         mut request: tonic::Request<ProposeRequest>,

--- a/crates/xline/src/server/kv_server.rs
+++ b/crates/xline/src/server/kv_server.rs
@@ -28,18 +28,15 @@ use crate::{
         PutRequest, PutResponse, RangeRequest, RangeResponse, RequestWrapper, Response, ResponseOp,
         TxnRequest, TxnResponse,
     },
-    storage::{storage_api::StorageApi, AuthStore, KvStore},
+    storage::{AuthStore, KvStore},
 };
 
 /// KV Server
-pub(crate) struct KvServer<S>
-where
-    S: StorageApi,
-{
+pub(crate) struct KvServer {
     /// KV storage
-    kv_storage: Arc<KvStore<S>>,
+    kv_storage: Arc<KvStore>,
     /// Auth storage
-    auth_storage: Arc<AuthStore<S>>,
+    auth_storage: Arc<AuthStore>,
     /// Barrier for applied index
     index_barrier: Arc<IndexBarrier>,
     /// Barrier for propose id
@@ -56,15 +53,12 @@ where
     next_compact_id: AtomicU64,
 }
 
-impl<S> KvServer<S>
-where
-    S: StorageApi,
-{
+impl KvServer {
     /// New `KvServer`
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        kv_storage: Arc<KvStore<S>>,
-        auth_storage: Arc<AuthStore<S>>,
+        kv_storage: Arc<KvStore>,
+        auth_storage: Arc<AuthStore>,
         index_barrier: Arc<IndexBarrier>,
         id_barrier: Arc<IdBarrier>,
         range_retry_timeout: Duration,
@@ -193,10 +187,7 @@ where
 }
 
 #[tonic::async_trait]
-impl<S> Kv for KvServer<S>
-where
-    S: StorageApi,
-{
+impl Kv for KvServer {
     /// Range gets the keys in the range from the key-value store.
     #[instrument(skip_all)]
     async fn range(

--- a/crates/xline/src/server/lease_server.rs
+++ b/crates/xline/src/server/lease_server.rs
@@ -28,21 +28,18 @@ use crate::{
         LeaseKeepAliveResponse, LeaseLeasesRequest, LeaseLeasesResponse, LeaseRevokeRequest,
         LeaseRevokeResponse, LeaseTimeToLiveRequest, LeaseTimeToLiveResponse, RequestWrapper,
     },
-    storage::{storage_api::StorageApi, AuthStore, LeaseStore},
+    storage::{AuthStore, LeaseStore},
 };
 
 /// Default Lease Request Time
 const DEFAULT_LEASE_REQUEST_TIME: Duration = Duration::from_millis(500);
 
 /// Lease Server
-pub(crate) struct LeaseServer<S>
-where
-    S: StorageApi,
-{
+pub(crate) struct LeaseServer {
     /// Lease storage
-    lease_storage: Arc<LeaseStore<S>>,
+    lease_storage: Arc<LeaseStore>,
     /// Auth storage
-    auth_storage: Arc<AuthStore<S>>,
+    auth_storage: Arc<AuthStore>,
     /// Consensus client
     client: Arc<CurpClient>,
     /// Id generator
@@ -55,14 +52,11 @@ where
     task_manager: Arc<TaskManager>,
 }
 
-impl<S> LeaseServer<S>
-where
-    S: StorageApi,
-{
+impl LeaseServer {
     /// New `LeaseServer`
     pub(crate) fn new(
-        lease_storage: Arc<LeaseStore<S>>,
-        auth_storage: Arc<AuthStore<S>>,
+        lease_storage: Arc<LeaseStore>,
+        auth_storage: Arc<AuthStore>,
         client: Arc<CurpClient>,
         id_gen: Arc<IdGenerator>,
         cluster_info: Arc<ClusterInfo>,
@@ -87,7 +81,7 @@ where
     /// Task of revoke expired leases
     #[allow(clippy::arithmetic_side_effects, clippy::ignored_unit_patterns)] // Introduced by tokio::select!
     async fn revoke_expired_leases_task(
-        lease_server: Arc<LeaseServer<S>>,
+        lease_server: Arc<LeaseServer>,
         shutdown_listener: Listener,
     ) {
         loop {
@@ -258,10 +252,7 @@ fn build_endpoints(
 }
 
 #[tonic::async_trait]
-impl<S> Lease for LeaseServer<S>
-where
-    S: StorageApi,
-{
+impl Lease for LeaseServer {
     /// LeaseGrant creates a lease which expires if the server does not receive a keepAlive
     /// within a given time to live period. All keys attached to the lease will be expired and
     /// deleted if the lease expires. Each expired key generates a delete event in the event history.

--- a/crates/xline/src/server/lock_server.rs
+++ b/crates/xline/src/server/lock_server.rs
@@ -24,35 +24,29 @@ use crate::{
         ResponseHeader, SortOrder, SortTarget, TargetUnion, TxnRequest, TxnResponse, UnlockRequest,
         UnlockResponse, WatchClient, WatchCreateRequest, WatchRequest,
     },
-    storage::{storage_api::StorageApi, AuthStore},
+    storage::AuthStore,
 };
 
 /// Default session ttl
 const DEFAULT_SESSION_TTL: i64 = 60;
 
 /// Lock Server
-pub(super) struct LockServer<S>
-where
-    S: StorageApi,
-{
+pub(super) struct LockServer {
     /// Consensus client
     client: Arc<CurpClient>,
     /// Auth store
-    auth_store: Arc<AuthStore<S>>,
+    auth_store: Arc<AuthStore>,
     /// Id Generator
     id_gen: Arc<IdGenerator>,
     /// Server addresses
     addrs: Vec<Endpoint>,
 }
 
-impl<S> LockServer<S>
-where
-    S: StorageApi,
-{
+impl LockServer {
     /// New `LockServer`
     pub(super) fn new(
         client: Arc<CurpClient>,
-        auth_store: Arc<AuthStore<S>>,
+        auth_store: Arc<AuthStore>,
         id_gen: Arc<IdGenerator>,
         addrs: &[String],
         client_tls_config: Option<&ClientTlsConfig>,
@@ -211,10 +205,7 @@ where
 }
 
 #[tonic::async_trait]
-impl<S> Lock for LockServer<S>
-where
-    S: StorageApi,
-{
+impl Lock for LockServer {
     /// Lock acquires a distributed shared lock on a given named lock.
     /// On success, it will return a unique key that exists so long as the
     /// lock is held by the caller. This key can be used in conjunction with

--- a/crates/xline/src/state.rs
+++ b/crates/xline/src/state.rs
@@ -4,19 +4,18 @@ use curp::role_change::RoleChange;
 
 use crate::storage::{
     compact::{Compactable, Compactor},
-    storage_api::StorageApi,
     LeaseStore,
 };
 
 /// State of current node
-pub(crate) struct State<DB: StorageApi, C: Compactable> {
+pub(crate) struct State<C: Compactable> {
     /// lease storage
-    lease_storage: Arc<LeaseStore<DB>>,
+    lease_storage: Arc<LeaseStore>,
     /// auto compactor
     auto_compactor: Option<Arc<dyn Compactor<C>>>,
 }
 
-impl<DB: StorageApi, C: Compactable> Clone for State<DB, C> {
+impl<C: Compactable> Clone for State<C> {
     fn clone(&self) -> Self {
         Self {
             lease_storage: Arc::clone(&self.lease_storage),
@@ -25,7 +24,7 @@ impl<DB: StorageApi, C: Compactable> Clone for State<DB, C> {
     }
 }
 
-impl<DB: StorageApi, C: Compactable> RoleChange for State<DB, C> {
+impl<C: Compactable> RoleChange for State<C> {
     fn on_election_win(&self) {
         self.lease_storage.promote(Duration::from_secs(1)); // TODO: extend should be election timeout
         if let Some(auto_compactor) = self.auto_compactor.as_ref() {
@@ -41,10 +40,10 @@ impl<DB: StorageApi, C: Compactable> RoleChange for State<DB, C> {
     }
 }
 
-impl<DB: StorageApi, C: Compactable> State<DB, C> {
+impl<C: Compactable> State<C> {
     /// Create a new State
     pub(super) fn new(
-        lease_storage: Arc<LeaseStore<DB>>,
+        lease_storage: Arc<LeaseStore>,
         auto_compactor: Option<Arc<dyn Compactor<C>>>,
     ) -> Self {
         Self {

--- a/crates/xline/src/storage/alarm_store.rs
+++ b/crates/xline/src/storage/alarm_store.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::multiple_inherent_impl)]
+
 use std::{
     collections::HashMap,
     sync::{
@@ -16,15 +18,12 @@ use xlineapi::{
     AlarmAction, AlarmMember, AlarmResponse, AlarmType, RequestWrapper, ResponseWrapper,
 };
 
-use super::{db::WriteOp, storage_api::StorageApi};
+use super::db::{WriteOp, DB};
 use crate::header_gen::HeaderGenerator;
 
 /// Alarm store
 #[derive(Debug)]
-pub(crate) struct AlarmStore<DB>
-where
-    DB: StorageApi,
-{
+pub(crate) struct AlarmStore {
     /// Header generator
     header_gen: Arc<HeaderGenerator>,
     /// Persistent storage
@@ -35,10 +34,7 @@ where
     current_alarm: AtomicI32,
 }
 
-impl<DB> AlarmStore<DB>
-where
-    DB: StorageApi,
-{
+impl AlarmStore {
     /// execute a alarm request
     pub(crate) fn execute(&self, request: &RequestWrapper) -> CommandResponse {
         #[allow(clippy::wildcard_enum_match_arm)]
@@ -98,10 +94,7 @@ where
     }
 }
 
-impl<DB> AlarmStore<DB>
-where
-    DB: StorageApi,
-{
+impl AlarmStore {
     /// Create a new alarm store
     pub(crate) fn new(header_gen: Arc<HeaderGenerator>, db: Arc<DB>) -> Self {
         Self {

--- a/crates/xline/src/storage/auth_store/backend.rs
+++ b/crates/xline/src/storage/auth_store/backend.rs
@@ -6,7 +6,7 @@ use xlineapi::execute_error::ExecuteError;
 
 use crate::{
     rpc::{Role, User},
-    storage::storage_api::StorageApi,
+    storage::db::DB,
 };
 
 /// Key of `AuthEnable`
@@ -19,18 +19,12 @@ pub(crate) const ROOT_USER: &str = "root";
 pub(crate) const ROOT_ROLE: &str = "root";
 
 /// Auth store inner
-pub(crate) struct AuthStoreBackend<DB>
-where
-    DB: StorageApi,
-{
+pub(crate) struct AuthStoreBackend {
     /// DB to store key value
     db: Arc<DB>,
 }
 
-impl<DB> fmt::Debug for AuthStoreBackend<DB>
-where
-    DB: StorageApi,
-{
+impl fmt::Debug for AuthStoreBackend {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AuthStoreBackend")
             .field("db", &self.db)
@@ -38,10 +32,7 @@ where
     }
 }
 
-impl<DB> AuthStoreBackend<DB>
-where
-    DB: StorageApi,
-{
+impl AuthStoreBackend {
     /// New `AuthStoreBackend`
     pub(crate) fn new(db: Arc<DB>) -> Self {
         Self { db }

--- a/crates/xline/src/storage/compact/mod.rs
+++ b/crates/xline/src/storage/compact/mod.rs
@@ -14,7 +14,6 @@ use xlineapi::{command::Command, execute_error::ExecuteError, RequestWrapper};
 
 use super::{
     index::{Index, IndexOperate},
-    storage_api::StorageApi,
     KvStore,
 };
 use crate::{revision_number::RevisionNumberGenerator, rpc::CompactionRequest};
@@ -96,17 +95,15 @@ pub(crate) async fn auto_compactor<C: Compactable>(
 }
 
 /// background compact executor
-#[allow(clippy::arithmetic_side_effects, clippy::ignored_unit_patterns)] // introduced bt tokio::select! macro
-pub(crate) async fn compact_bg_task<DB>(
-    kv_store: Arc<KvStore<DB>>,
+#[allow(clippy::arithmetic_side_effects, clippy::ignored_unit_patterns)] // introduced by tokio::select! macro
+pub(crate) async fn compact_bg_task(
+    kv_store: Arc<KvStore>,
     index: Arc<Index>,
     batch_limit: usize,
     interval: Duration,
     mut compact_task_rx: Receiver<(i64, Option<Arc<Event>>)>,
     shutdown_listener: Listener,
-) where
-    DB: StorageApi,
-{
+) {
     loop {
         let (revision, listener) = tokio::select! {
             recv = compact_task_rx.recv() => {

--- a/crates/xline/src/storage/kv_store.rs
+++ b/crates/xline/src/storage/kv_store.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::multiple_inherent_impl)]
+
 use std::{
     cmp::Ordering,
     collections::{HashMap, VecDeque},
@@ -18,11 +20,10 @@ use xlineapi::{
 };
 
 use super::{
-    db::SCHEDULED_COMPACT_REVISION,
+    db::{DB, SCHEDULED_COMPACT_REVISION},
     index::{Index, IndexOperate},
     lease_store::LeaseCollection,
     revision::{KeyRevision, Revision},
-    storage_api::StorageApi,
 };
 use crate::{
     header_gen::HeaderGenerator,
@@ -39,12 +40,9 @@ use crate::{
 
 /// KV store
 #[derive(Debug)]
-pub(crate) struct KvStore<DB>
-where
-    DB: StorageApi,
-{
+pub(crate) struct KvStore {
     /// Kv storage inner
-    inner: Arc<KvStoreInner<DB>>,
+    inner: Arc<KvStoreInner>,
     /// Revision
     revision: Arc<RevisionNumberGenerator>,
     /// Header generator
@@ -59,10 +57,7 @@ where
 
 /// KV store inner, shared by `KvStore` and `KvWatcher`
 #[derive(Debug)]
-pub(crate) struct KvStoreInner<DB>
-where
-    DB: StorageApi,
-{
+pub(crate) struct KvStoreInner {
     /// Key Index
     index: Arc<Index>,
     /// DB to store key value
@@ -71,10 +66,7 @@ where
     compacted_rev: AtomicI64,
 }
 
-impl<DB> KvStoreInner<DB>
-where
-    DB: StorageApi,
-{
+impl KvStoreInner {
     /// Create new `KvStoreInner`
     pub(crate) fn new(index: Arc<Index>, db: Arc<DB>) -> Self {
         Self {
@@ -182,10 +174,7 @@ where
     }
 }
 
-impl<DB> KvStore<DB>
-where
-    DB: StorageApi,
-{
+impl KvStore {
     /// execute a kv request
     pub(crate) fn execute(
         &self,
@@ -276,13 +265,10 @@ where
     }
 }
 
-impl<DB> KvStore<DB>
-where
-    DB: StorageApi,
-{
+impl KvStore {
     /// New `KvStore`
     pub(crate) fn new(
-        inner: Arc<KvStoreInner<DB>>,
+        inner: Arc<KvStoreInner>,
         header_gen: Arc<HeaderGenerator>,
         kv_update_tx: mpsc::Sender<(i64, Vec<Event>)>,
         compact_task_tx: mpsc::Sender<(i64, Option<Arc<event_listener::Event>>)>,
@@ -537,10 +523,7 @@ where
 }
 
 /// handle and sync kv requests
-impl<DB> KvStore<DB>
-where
-    DB: StorageApi,
-{
+impl KvStore {
     /// Handle kv requests
     fn handle_kv_requests(
         &self,
@@ -945,7 +928,7 @@ mod test {
 
     const CHANNEL_SIZE: usize = 1024;
 
-    struct StoreWrapper(Option<Arc<KvStore<DB>>>, Arc<TaskManager>);
+    struct StoreWrapper(Option<Arc<KvStore>>, Arc<TaskManager>);
 
     impl Drop for StoreWrapper {
         fn drop(&mut self) {
@@ -959,7 +942,7 @@ mod test {
     }
 
     impl std::ops::Deref for StoreWrapper {
-        type Target = Arc<KvStore<DB>>;
+        type Target = Arc<KvStore>;
 
         fn deref(&self) -> &Self::Target {
             self.0.as_ref().unwrap()
@@ -1035,7 +1018,7 @@ mod test {
     }
 
     async fn exe_as_and_flush(
-        store: &Arc<KvStore<DB>>,
+        store: &Arc<KvStore>,
         request: &RequestWrapper,
         revision: i64,
     ) -> Result<(), ExecuteError> {
@@ -1045,7 +1028,7 @@ mod test {
         Ok(())
     }
 
-    fn index_compact(store: &Arc<KvStore<DB>>, at_rev: i64) -> Vec<Vec<u8>> {
+    fn index_compact(store: &Arc<KvStore>, at_rev: i64) -> Vec<Vec<u8>> {
         store
             .inner
             .index

--- a/crates/xline/src/storage/kvwatcher.rs
+++ b/crates/xline/src/storage/kvwatcher.rs
@@ -22,7 +22,7 @@ use utils::{
 };
 use xlineapi::command::KeyRange;
 
-use super::{kv_store::KvStoreInner, storage_api::StorageApi};
+use super::kv_store::KvStoreInner;
 use crate::rpc::{Event, KeyValue};
 
 /// Watch ID
@@ -170,12 +170,9 @@ impl Watcher {
 
 /// KV watcher
 #[derive(Debug)]
-pub(crate) struct KvWatcher<S>
-where
-    S: StorageApi,
-{
+pub(crate) struct KvWatcher {
     /// KV storage Inner
-    kv_store_inner: Arc<KvStoreInner<S>>,
+    kv_store_inner: Arc<KvStoreInner>,
     /// Watch indexes
     watcher_map: Arc<RwLock<WatcherMap>>,
 }
@@ -305,10 +302,7 @@ pub(crate) trait KvWatcherOps {
 }
 
 #[async_trait::async_trait]
-impl<S> KvWatcherOps for KvWatcher<S>
-where
-    S: StorageApi,
-{
+impl KvWatcherOps for KvWatcher {
     fn watch(
         &self,
         id: WatchId,
@@ -385,13 +379,10 @@ where
     }
 }
 
-impl<S> KvWatcher<S>
-where
-    S: StorageApi,
-{
+impl KvWatcher {
     /// Create a new `Arc<KvWatcher>`
     pub(crate) fn new_arc(
-        kv_store_inner: Arc<KvStoreInner<S>>,
+        kv_store_inner: Arc<KvStoreInner>,
         kv_update_rx: mpsc::Receiver<(i64, Vec<Event>)>,
         sync_victims_interval: Duration,
         task_manager: &TaskManager,
@@ -413,7 +404,7 @@ where
     /// Background task to handle KV updates
     #[allow(clippy::arithmetic_side_effects, clippy::ignored_unit_patterns)] // Introduced by tokio::select!
     async fn kv_updates_task(
-        kv_watcher: Arc<KvWatcher<S>>,
+        kv_watcher: Arc<KvWatcher>,
         mut kv_update_rx: mpsc::Receiver<(i64, Vec<Event>)>,
         shutdown_listener: Listener,
     ) {
@@ -437,7 +428,7 @@ where
     /// Background task to sync victims
     #[allow(clippy::arithmetic_side_effects, clippy::ignored_unit_patterns)] // Introduced by tokio::select!
     async fn sync_victims_task(
-        kv_watcher: Arc<KvWatcher<S>>,
+        kv_watcher: Arc<KvWatcher>,
         sync_victims_interval: Duration,
         shutdown_listener: Listener,
     ) {
@@ -617,9 +608,7 @@ mod test {
         },
     };
 
-    fn init_empty_store(
-        task_manager: &TaskManager,
-    ) -> (Arc<KvStore<DB>>, Arc<DB>, Arc<KvWatcher<DB>>) {
+    fn init_empty_store(task_manager: &TaskManager) -> (Arc<KvStore>, Arc<DB>, Arc<KvWatcher>) {
         let (compact_tx, _compact_rx) = mpsc::channel(COMPACT_CHANNEL_SIZE);
         let db = DB::open(&EngineConfig::Memory).unwrap();
         let header_gen = Arc::new(HeaderGenerator::new(0, 0));
@@ -773,7 +762,7 @@ mod test {
     }
 
     async fn put(
-        store: &KvStore<DB>,
+        store: &KvStore,
         db: &DB,
         key: impl Into<Vec<u8>>,
         value: impl Into<Vec<u8>>,

--- a/crates/xline/src/storage/lease_store/mod.rs
+++ b/crates/xline/src/storage/lease_store/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::multiple_inherent_impl)]
+
 /// Lease
 mod lease;
 /// Lease related structs collection
@@ -25,7 +27,10 @@ use xlineapi::{
 };
 
 pub(crate) use self::{lease::Lease, lease_collection::LeaseCollection};
-use super::{db::WriteOp, index::Index, storage_api::StorageApi};
+use super::{
+    db::{WriteOp, DB},
+    index::Index,
+};
 use crate::{
     header_gen::HeaderGenerator,
     rpc::{
@@ -41,10 +46,7 @@ const MAX_LEASE_TTL: i64 = 9_000_000_000;
 
 /// Lease store
 #[derive(Debug)]
-pub(crate) struct LeaseStore<DB>
-where
-    DB: StorageApi,
-{
+pub(crate) struct LeaseStore {
     /// lease collection
     lease_collection: Arc<LeaseCollection>,
     /// Db to store lease
@@ -63,10 +65,7 @@ where
     sync_event: event_listener::Event,
 }
 
-impl<DB> LeaseStore<DB>
-where
-    DB: StorageApi,
-{
+impl LeaseStore {
     /// New `LeaseStore`
     pub(crate) fn new(
         lease_collection: Arc<LeaseCollection>,
@@ -195,10 +194,7 @@ where
     }
 }
 
-impl<DB> LeaseStore<DB>
-where
-    DB: StorageApi,
-{
+impl LeaseStore {
     /// Handle lease requests
     fn handle_lease_requests(
         &self,
@@ -347,7 +343,7 @@ where
         }
 
         for (key, sub_revision) in del_keys.iter().zip(0..) {
-            let (mut del_ops, mut del_event) = KvStore::<DB>::delete_keys(
+            let (mut del_ops, mut del_event) = KvStore::delete_keys(
                 &self.index,
                 &self.lease_collection,
                 key,
@@ -504,7 +500,7 @@ mod test {
         Ok(())
     }
 
-    fn init_store(db: Arc<DB>) -> LeaseStore<DB> {
+    fn init_store(db: Arc<DB>) -> LeaseStore {
         let lease_collection = Arc::new(LeaseCollection::new(0));
         let (kv_update_tx, _) = mpsc::channel(1);
         let header_gen = Arc::new(HeaderGenerator::new(0, 0));
@@ -513,7 +509,7 @@ mod test {
     }
 
     async fn exe_and_sync_req(
-        ls: &LeaseStore<DB>,
+        ls: &LeaseStore,
         req: &RequestWrapper,
         revision: i64,
     ) -> Result<ResponseWrapper, ExecuteError> {

--- a/crates/xline/src/storage/mod.rs
+++ b/crates/xline/src/storage/mod.rs
@@ -16,8 +16,6 @@ pub(crate) mod kvwatcher;
 pub(crate) mod lease_store;
 /// Revision module
 pub(crate) mod revision;
-/// Persistent storage abstraction
-pub(crate) mod storage_api;
 
 pub use self::revision::Revision;
 pub(crate) use self::{

--- a/crates/xline/src/storage/revision.rs
+++ b/crates/xline/src/storage/revision.rs
@@ -2,7 +2,7 @@ use prost::bytes::{Buf, BufMut};
 
 /// Revision of a key
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct KeyRevision {
+pub(crate) struct KeyRevision {
     /// Last creation revision
     pub(super) create_revision: i64,
     /// Number of modification since last creation

--- a/crates/xline/src/storage/storage_api.rs
+++ b/crates/xline/src/storage/storage_api.rs
@@ -7,7 +7,7 @@ use super::{db::WriteOp, revision::KeyRevision};
 
 /// The Stable Storage Api
 #[async_trait::async_trait]
-pub trait StorageApi: Send + Sync + 'static + std::fmt::Debug {
+pub(crate) trait StorageApi: Send + Sync + 'static + std::fmt::Debug {
     /// Get values by keys from storage
     ///
     /// # Errors


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

  The DB generic is redundant as no other type will ever implement `StorageApi` in Xline. This change aims to enhance readability of the codebase.

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
