### PR TITLE
chore: downgrade github artifact to v3 from v4 for publish docker image.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
   # 5 by default
   # see https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
   open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: 'actions/upload-artifact'
+  #ignore all updates greater than or equal to version 4
+    versions: '>= 4'
+  - dependency-name: 'actions/download-artifact'
+    versions: '>= 4'
 - package-ecosystem: "cargo"
   directory: "/"
   schedule:

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -100,7 +100,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload Digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: digests
           path: /tmp/digests/*

--- a/.github/workflows/merge_image.yml
+++ b/.github/workflows/merge_image.yml
@@ -16,7 +16,7 @@ jobs:
     name: Merge Docker Image
     steps:
       - name: Download Digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: digests
           path: /tmp/digests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload Digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: startsWith(matrix.job.platform, 'linux/')
         with:
           name: digests


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

artifact v4 do not support upload artifact with the same name, https://github.com/actions/upload-artifact?tab=readme-ov-file#not-uploading-to-the-same-artifact , so this PR is working for downgrade v4 to v3, until we get rid of using github jobs to build multi-architecture container images.

so release workflow is also broken, https://github.com/xline-kv/Xline/blob/dca44495673ab0cf4c67ecb59110bbddcde22c74/.github/workflows/release.yml#L144

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
