### PR TITLE
ci: update workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,4 @@ updates:
     interval: "weekly"
   labels:
     - "dependencies"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 3

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,6 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Auto unassign stale assignments
-      uses: JasonEtco/slash-assign-action@v1
+      uses: JasonEtco/slash-assign-action@v0.0.3
       with:
         required_label: 'good-first-issue'


### PR DESCRIPTION
Please briefly answer these questions:
Currently, our depend-bot update is a little bit frequent, therefore I reduce the `open-pull-requests-limit` from 10 to 3 per week.

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
1. reduce the `open-pull-requests-limit` from 10 to 3 per week.
2. update the correct release slash-assign-action

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
