### PR TITLE
chore: bump etcd-client to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,8 +910,9 @@ dependencies = [
 
 [[package]]
 name = "etcd-client"
-version = "0.12.5"
-source = "git+https://github.com/Phoenix500526/etcd-client?branch=update-tonic#3b4f3ef00d69082a0393ebcb4b654fc9d945bece"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b915bb9b1e143ab7062e0067ed663e3dfeffc69ce0ceb9e93b35fecfc158d28"
 dependencies = [
  "http",
  "prost",
@@ -2952,9 +2953,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2980,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,3 @@ madsim = { git = "https://github.com/Phoenix500526/madsim.git", branch = "update
 madsim-tonic = { git = "https://github.com/Phoenix500526/madsim.git", branch = "update-tonic" }
 madsim-tonic-build = { git = "https://github.com/Phoenix500526/madsim.git", branch = "update-tonic" }
 madsim-tokio = { git = "https://github.com/Phoenix500526/madsim.git", branch = "update-tonic" }
-# TODO: switch to the original etcd-client crate when new version is released(https://github.com/etcdv3/etcd-client/pull/75)
-etcd-client = { git = "https://github.com/Phoenix500526/etcd-client", branch = "update-tonic" }

--- a/crates/benchmark/Cargo.toml
+++ b/crates/benchmark/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/xline-kv/Xline/tree/master/benchmark"
 anyhow = "1.0.83"
 clap = { version = "4", features = ["derive"] }
 clippy-utilities = "0.2.0"
-etcd-client = { version = "0.12.5", features = ["tls"] }
+etcd-client = { version = "0.13.0", features = ["tls"] }
 indicatif = "0.17.8"
 rand = "0.8.5"
 thiserror = "1.0.61"

--- a/crates/xline/Cargo.toml
+++ b/crates/xline/Cargo.toml
@@ -79,7 +79,7 @@ xlineapi = { path = "../xlineapi" }
 tonic-build = { version = "0.4.3", package = "madsim-tonic-build" }
 
 [dev-dependencies]
-etcd-client = { version = "0.12.5", features = ["tls"] }
+etcd-client = { version = "0.13.0", features = ["tls"] }
 mockall = "0.12.1"
 rand = "0.8.5"
 strum = "0.26"


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
bump etcd-client to 0.13.0

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
