### PR TITLE
feat: add exec command args for xlinectl lock command

### DIFF
--- a/crates/xlinectl/README.md
+++ b/crates/xlinectl/README.md
@@ -652,14 +652,25 @@ Acquire a lock, which will return a unique key that exists so long as the lock i
 #### Usage
 
 ```bash
-lock <lockname>
+lock <lockname> [command arg1 arg2 ...]
 ```
 
 #### Examples
 
 ```bash
-# Hold a lock named foo until `SIGINT` is received
+# Hold a lock named `foo` until `SIGINT` is received
 ./xlinectl lock foo
+foo/key
+
+# Hold a lock named `mylock` until `SIGINT` is received and print lock acquired
+./xlinectl lock mylock echo lock acquired
+mylock/key
+lock acquired
+
+# Hold a lock named `mylock` until `SIGINT` is received and put key `foo` with value `bar`
+./xlinectl lock mylock ./xlinectl put foo bar
+mylock/key
+OK
 ```
 ## Authentication commands
 

--- a/crates/xlinectl/src/command/lock.rs
+++ b/crates/xlinectl/src/command/lock.rs
@@ -1,11 +1,11 @@
 use clap::{arg, ArgMatches, Command};
+use std::process::Command as StdCommand;
 use tokio::signal;
 use xline_client::{
     error::Result,
     types::lock::{LockRequest, UnlockRequest},
     Client,
 };
-use std::process::Command as StdCommand;
 
 use crate::utils::printer::Printer;
 
@@ -35,8 +35,10 @@ pub(crate) async fn execute(client: &mut Client, matches: &ArgMatches) -> Result
 
     if let Some(exec_command) = exec_command {
         let exec_command_vec: Vec<&String> = exec_command.collect();
-        if exec_command_vec.len() > 0 {
-            let (command, args) = exec_command_vec.split_first().unwrap();
+        if !exec_command_vec.is_empty() {
+            let (command, args) = exec_command_vec
+                .split_first()
+                .expect("Expected at least one exec command");
             let output = StdCommand::new(command)
                 .args(args)
                 .output()

--- a/crates/xlinectl/src/command/lock.rs
+++ b/crates/xlinectl/src/command/lock.rs
@@ -66,10 +66,13 @@ mod tests {
 
     #[test]
     fn command_parse_should_be_valid() {
-        let test_cases = vec![TestCase::new(
-            vec!["lock", "my_lock"],
-            Some(LockRequest::new("my_lock")),
-        )];
+        let test_cases = vec![
+            TestCase::new(vec!["lock", "my_lock"], Some(LockRequest::new("my_lock"))),
+            TestCase::new(
+                vec!["lock", "my_lock", "echo", "lock", "acquired"],
+                Some(LockRequest::new("my_lock")),
+            ),
+        ];
 
         for case in test_cases {
             case.run_test();


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
https://github.com/xline-kv/Xline/issues/823

* what changes does this pull request make?
Added exec command support to xlinectl lock command. Updated the README with new examples for lock.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
No

Additional comments:
I'm not sure how to test the exec command args. I thought of two solutions:
1. Extend LockRequest or Test Case Representation: Add a way to represent the exec commands that should be executed after the lock is acquired. This could be a new field in the LockRequest struct or a separate structure linked to the test case.
2. Modify the Test Case: Adjust the test case in macros.rs to include the exec commands as part of the expected outcome.