### PR TITLE
refactor: remove keys from command

### DIFF
--- a/crates/curp-external-api/src/cmd.rs
+++ b/crates/curp-external-api/src/cmd.rs
@@ -44,7 +44,7 @@ pub trait Command: pri::Serializable + ConflictCheck + PbCodec {
     type ASR: pri::Serializable + PbCodec;
 
     /// Get keys of the command
-    fn keys(&self) -> &[Self::K];
+    fn keys(&self) -> Vec<Self::K>;
 
     /// Returns `true` if the command is read-only
     fn is_read_only(&self) -> bool;

--- a/crates/curp-test-utils/src/test_cmd.rs
+++ b/crates/curp-test-utils/src/test_cmd.rs
@@ -188,8 +188,8 @@ impl Command for TestCommand {
 
     type ASR = LogIndexResult;
 
-    fn keys(&self) -> &[Self::K] {
-        &self.keys
+    fn keys(&self) -> Vec<Self::K> {
+        self.keys.clone()
     }
 
     fn is_read_only(&self) -> bool {

--- a/crates/xline-client/src/clients/auth.rs
+++ b/crates/xline-client/src/clients/auth.rs
@@ -721,7 +721,7 @@ impl AuthClient {
         use_fast_path: bool,
     ) -> Result<Res> {
         let request = request.into();
-        let cmd = Command::new(request.keys(), request);
+        let cmd = Command::new(request);
 
         let res_wrapper = if use_fast_path {
             let (cmd_res, _sync_error) = self

--- a/crates/xline-client/src/clients/kv.rs
+++ b/crates/xline-client/src/clients/kv.rs
@@ -84,7 +84,7 @@ impl KvClient {
     #[inline]
     pub async fn put(&self, request: PutRequest) -> Result<PutResponse> {
         let request = RequestWrapper::from(xlineapi::PutRequest::from(request));
-        let cmd = Command::new(request.keys(), request);
+        let cmd = Command::new(request);
         let (cmd_res, _sync_res) = self
             .curp_client
             .propose(&cmd, self.token.as_ref(), true)
@@ -128,7 +128,7 @@ impl KvClient {
     #[inline]
     pub async fn range(&self, request: RangeRequest) -> Result<RangeResponse> {
         let request = RequestWrapper::from(xlineapi::RangeRequest::from(request));
-        let cmd = Command::new(request.keys(), request);
+        let cmd = Command::new(request);
         let (cmd_res, _sync_res) = self
             .curp_client
             .propose(&cmd, self.token.as_ref(), true)
@@ -165,7 +165,7 @@ impl KvClient {
     #[inline]
     pub async fn delete(&self, request: DeleteRangeRequest) -> Result<DeleteRangeResponse> {
         let request = RequestWrapper::from(xlineapi::DeleteRangeRequest::from(request));
-        let cmd = Command::new(request.keys(), request);
+        let cmd = Command::new(request);
         let (cmd_res, _sync_res) = self
             .curp_client
             .propose(&cmd, self.token.as_ref(), true)
@@ -213,7 +213,7 @@ impl KvClient {
     #[inline]
     pub async fn txn(&self, request: TxnRequest) -> Result<TxnResponse> {
         let request = RequestWrapper::from(xlineapi::TxnRequest::from(request));
-        let cmd = Command::new(request.keys(), request);
+        let cmd = Command::new(request);
         let (cmd_res, Some(sync_res)) = self
             .curp_client
             .propose(&cmd, self.token.as_ref(), false)
@@ -273,7 +273,7 @@ impl KvClient {
                 .map_err(Into::into);
         }
         let request = RequestWrapper::from(xlineapi::CompactionRequest::from(request));
-        let cmd = Command::new(request.keys(), request);
+        let cmd = Command::new(request);
         let (cmd_res, _sync_res) = self
             .curp_client
             .propose(&cmd, self.token.as_ref(), true)

--- a/crates/xline-client/src/clients/lease.rs
+++ b/crates/xline-client/src/clients/lease.rs
@@ -100,7 +100,7 @@ impl LeaseClient {
             request.inner.id = self.id_gen.next();
         }
         let request = RequestWrapper::from(xlineapi::LeaseGrantRequest::from(request));
-        let cmd = Command::new(request.keys(), request);
+        let cmd = Command::new(request);
         let (cmd_res, _sync_res) = self
             .curp_client
             .propose(&cmd, self.token.as_ref(), true)
@@ -275,7 +275,7 @@ impl LeaseClient {
     #[inline]
     pub async fn leases(&self) -> Result<LeaseLeasesResponse> {
         let request = RequestWrapper::from(xlineapi::LeaseLeasesRequest {});
-        let cmd = Command::new(request.keys(), request);
+        let cmd = Command::new(request);
         let (cmd_res, _sync_res) = self
             .curp_client
             .propose(&cmd, self.token.as_ref(), true)

--- a/crates/xline-client/src/clients/lock.rs
+++ b/crates/xline-client/src/clients/lock.rs
@@ -255,7 +255,7 @@ impl LockClient {
         T: Into<RequestWrapper>,
     {
         let request = request.into();
-        let cmd = Command::new(request.keys(), request);
+        let cmd = Command::new(request);
         self.curp_client
             .propose(&cmd, self.token.as_ref(), use_fast_path)
             .await?

--- a/crates/xline/src/conflict/tests.rs
+++ b/crates/xline/src/conflict/tests.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 use curp::{rpc::ProposeId, server::conflict::CommandEntry};
 use curp_external_api::conflict::{ConflictPoolOp, SpeculativePoolOp, UncommittedPoolOp};
 use xlineapi::{
-    command::{Command, KeyRange},
-    AuthEnableRequest, AuthRoleAddRequest, DeleteRangeRequest, LeaseGrantRequest,
+    command::Command, AuthEnableRequest, AuthRoleAddRequest, DeleteRangeRequest, LeaseGrantRequest,
     LeaseRevokeRequest, PutRequest, RequestWrapper,
 };
 
@@ -203,60 +202,46 @@ struct EntryGenerator {
 
 impl EntryGenerator {
     fn gen_put(&mut self, key: &str) -> CommandEntry<Command> {
-        self.gen_entry(
-            vec![KeyRange::new_one_key(key)],
-            RequestWrapper::PutRequest(PutRequest {
-                key: key.as_bytes().to_vec(),
-                ..Default::default()
-            }),
-        )
+        self.gen_entry(RequestWrapper::PutRequest(PutRequest {
+            key: key.as_bytes().to_vec(),
+            ..Default::default()
+        }))
     }
 
     fn gen_delete_range(&mut self, key: &str, range_end: &str) -> CommandEntry<Command> {
-        self.gen_entry(
-            vec![KeyRange::new(key, range_end)],
-            RequestWrapper::DeleteRangeRequest(DeleteRangeRequest {
-                key: key.as_bytes().to_vec(),
-                range_end: range_end.as_bytes().to_vec(),
-                ..Default::default()
-            }),
-        )
+        self.gen_entry(RequestWrapper::DeleteRangeRequest(DeleteRangeRequest {
+            key: key.as_bytes().to_vec(),
+            range_end: range_end.as_bytes().to_vec(),
+            ..Default::default()
+        }))
     }
 
     fn gen_lease_grant(&mut self, id: i64) -> CommandEntry<Command> {
-        self.gen_entry(
-            vec![],
-            RequestWrapper::LeaseGrantRequest(LeaseGrantRequest {
-                id,
-                ..Default::default()
-            }),
-        )
+        self.gen_entry(RequestWrapper::LeaseGrantRequest(LeaseGrantRequest {
+            id,
+            ..Default::default()
+        }))
     }
 
     fn gen_lease_revoke(&mut self, id: i64) -> CommandEntry<Command> {
-        self.gen_entry(
-            vec![],
-            RequestWrapper::LeaseRevokeRequest(LeaseRevokeRequest { id }),
-        )
+        self.gen_entry(RequestWrapper::LeaseRevokeRequest(LeaseRevokeRequest {
+            id,
+        }))
     }
 
     fn gen_auth_enable(&mut self) -> CommandEntry<Command> {
-        self.gen_entry(
-            vec![],
-            RequestWrapper::AuthEnableRequest(AuthEnableRequest {}),
-        )
+        self.gen_entry(RequestWrapper::AuthEnableRequest(AuthEnableRequest {}))
     }
 
     fn gen_role_add(&mut self) -> CommandEntry<Command> {
-        self.gen_entry(
-            vec![],
-            RequestWrapper::AuthRoleAddRequest(AuthRoleAddRequest::default()),
-        )
+        self.gen_entry(RequestWrapper::AuthRoleAddRequest(
+            AuthRoleAddRequest::default(),
+        ))
     }
 
-    fn gen_entry(&mut self, keys: Vec<KeyRange>, req: RequestWrapper) -> CommandEntry<Command> {
+    fn gen_entry(&mut self, req: RequestWrapper) -> CommandEntry<Command> {
         self.id += 1;
-        let cmd = Command::new(keys, req);
+        let cmd = Command::new(req);
         CommandEntry::new(ProposeId(0, self.id), Arc::new(cmd))
     }
 }

--- a/crates/xline/src/server/auth_server.rs
+++ b/crates/xline/src/server/auth_server.rs
@@ -64,7 +64,7 @@ where
     {
         let auth_info = self.auth_store.try_get_auth_info_from_request(&request)?;
         let request = request.into_inner().into();
-        let cmd = Command::new_with_auth_info(request.keys(), request, auth_info);
+        let cmd = Command::new_with_auth_info(request, auth_info);
         let res = self.client.propose(&cmd, None, use_fast_path).await??;
         Ok(res)
     }

--- a/crates/xline/src/server/command.rs
+++ b/crates/xline/src/server/command.rs
@@ -219,7 +219,7 @@ impl Alarmer {
     /// Propose alarm request to other nodes
     async fn alarm(&self, action: AlarmAction, alarm: AlarmType) -> Result<(), tonic::Status> {
         let request = RequestWrapper::from(AlarmRequest::new(action, self.id, alarm));
-        let cmd = Command::new(request.keys(), request);
+        let cmd = Command::new(request);
         let _ig = self.client.propose(&cmd, None, true).await?;
         Ok(())
     }

--- a/crates/xline/src/server/kv_server.rs
+++ b/crates/xline/src/server/kv_server.rs
@@ -113,7 +113,7 @@ where
         T: Into<RequestWrapper>,
     {
         let request = request.into();
-        let cmd = Command::new_with_auth_info(request.keys(), request, auth_info);
+        let cmd = Command::new_with_auth_info(request, auth_info);
         let res = self.client.propose(&cmd, None, use_fast_path).await??;
         Ok(res)
     }
@@ -214,7 +214,7 @@ where
         let range_required_revision = range_req.revision;
         let is_serializable = range_req.serializable;
         let request = RequestWrapper::from(request.into_inner());
-        let cmd = Command::new_with_auth_info(request.keys(), request, auth_info);
+        let cmd = Command::new_with_auth_info(request, auth_info);
         if !is_serializable {
             self.wait_read_state(&cmd).await?;
             // Double check whether the range request is compacted or not since the compaction request
@@ -313,7 +313,7 @@ where
             debug!("TxnRequest is read only");
             let is_serializable = txn_req.is_serializable();
             let request = RequestWrapper::from(request.into_inner());
-            let cmd = Command::new_with_auth_info(request.keys(), request, auth_info);
+            let cmd = Command::new_with_auth_info(request, auth_info);
             if !is_serializable {
                 self.wait_read_state(&cmd).await?;
             }
@@ -354,7 +354,7 @@ where
         let auth_info = self.auth_storage.try_get_auth_info_from_request(&request)?;
         let physical = req.physical;
         let request = RequestWrapper::from(request.into_inner());
-        let cmd = Command::new_with_auth_info(request.keys(), request, auth_info);
+        let cmd = Command::new_with_auth_info(request, auth_info);
         let compact_id = self.next_compact_id.fetch_add(1, Ordering::Relaxed);
         let compact_physical_fut = if physical {
             let event = Arc::new(Event::new());

--- a/crates/xline/src/server/lease_server.rs
+++ b/crates/xline/src/server/lease_server.rs
@@ -16,7 +16,7 @@ use utils::{
     task_manager::{tasks::TaskName, Listener, TaskManager},
 };
 use xlineapi::{
-    command::{Command, CommandResponse, CurpClient, KeyRange, SyncResponse},
+    command::{Command, CommandResponse, CurpClient, SyncResponse},
     execute_error::ExecuteError,
 };
 
@@ -132,18 +132,8 @@ where
     {
         let auth_info = self.auth_storage.try_get_auth_info_from_request(&request)?;
         let request = request.into_inner().into();
-        let keys = {
-            if let RequestWrapper::LeaseRevokeRequest(ref req) = request {
-                self.lease_storage
-                    .get_keys(req.id)
-                    .into_iter()
-                    .map(|k| KeyRange::new(k, ""))
-                    .collect()
-            } else {
-                vec![]
-            }
-        };
-        let cmd = Command::new_with_auth_info(keys, request, auth_info);
+        // FIXME: get the keys in the conflict pools
+        let cmd = Command::new_with_auth_info(request, auth_info);
         let res = self.client.propose(&cmd, None, use_fast_path).await??;
         Ok(res)
     }

--- a/crates/xline/src/server/lock_server.rs
+++ b/crates/xline/src/server/lock_server.rs
@@ -83,7 +83,7 @@ where
         T: Into<RequestWrapper>,
     {
         let request = request.into();
-        let cmd = Command::new_with_auth_info(request.keys(), request, auth_info);
+        let cmd = Command::new_with_auth_info(request, auth_info);
         let res = self.client.propose(&cmd, None, use_fast_path).await??;
         Ok(res)
     }

--- a/crates/xline/src/server/maintenance.rs
+++ b/crates/xline/src/server/maintenance.rs
@@ -97,7 +97,7 @@ where
     {
         let auth_info = self.auth_store.try_get_auth_info_from_request(&request)?;
         let request = request.into_inner().into();
-        let cmd = Command::new_with_auth_info(request.keys(), request, auth_info);
+        let cmd = Command::new_with_auth_info(request, auth_info);
         let res = self.client.propose(&cmd, None, use_fast_path).await??;
         Ok(res)
     }

--- a/crates/xline/src/storage/compact/mod.rs
+++ b/crates/xline/src/storage/compact/mod.rs
@@ -58,7 +58,7 @@ impl Compactable
             revision,
             physical: false,
         });
-        let cmd = Command::new(request.keys(), request);
+        let cmd = Command::new(request);
         let err = match self.propose(&cmd, None, true).await? {
             Ok(_) => return Ok(revision),
             Err(err) => err,

--- a/crates/xline/src/storage/lease_store/mod.rs
+++ b/crates/xline/src/storage/lease_store/mod.rs
@@ -124,6 +124,8 @@ where
     }
 
     /// Get keys attached to a lease
+    /// FIXME: use this in conflict pools
+    #[allow(unused)]
     pub(crate) fn get_keys(&self, lease_id: i64) -> Vec<Vec<u8>> {
         self.lease_collection
             .look_up(lease_id)

--- a/crates/xlineapi/src/command.rs
+++ b/crates/xlineapi/src/command.rs
@@ -213,8 +213,6 @@ impl From<KeyRange> for PbKeyRange {
 pub struct Command {
     /// Request data
     request: RequestWrapper,
-    /// Keys of request
-    keys: Vec<KeyRange>,
     /// Compact Id
     compact_id: u64,
     /// Auth info
@@ -357,10 +355,9 @@ impl Command {
     /// New `Command`
     #[must_use]
     #[inline]
-    pub fn new(keys: Vec<KeyRange>, request: RequestWrapper) -> Self {
+    pub fn new(request: RequestWrapper) -> Self {
         Self {
             request,
-            keys,
             compact_id: 0,
             auth_info: None,
         }
@@ -369,14 +366,9 @@ impl Command {
     /// New `Command` with auth info
     #[must_use]
     #[inline]
-    pub fn new_with_auth_info(
-        keys: Vec<KeyRange>,
-        request: RequestWrapper,
-        auth_info: Option<AuthInfo>,
-    ) -> Self {
+    pub fn new_with_auth_info(request: RequestWrapper, auth_info: Option<AuthInfo>) -> Self {
         Self {
             request,
-            keys,
             compact_id: 0,
             auth_info,
         }
@@ -537,8 +529,8 @@ impl CurpCommand for Command {
     type ASR = SyncResponse;
 
     #[inline]
-    fn keys(&self) -> &[Self::K] {
-        self.keys.as_slice()
+    fn keys(&self) -> Vec<Self::K> {
+        self.request().keys()
     }
 
     #[inline]
@@ -551,7 +543,6 @@ impl PbCodec for Command {
     #[inline]
     fn encode(&self) -> Vec<u8> {
         let rpc_cmd = PbCommand {
-            keys: self.keys.iter().cloned().map(Into::into).collect(),
             compact_id: self.compact_id,
             auth_info: self.auth_info.clone(),
             request_wrapper: Some(self.request.clone()),
@@ -563,7 +554,6 @@ impl PbCodec for Command {
     fn decode(buf: &[u8]) -> Result<Self, PbSerializeError> {
         let rpc_cmd = PbCommand::decode(buf)?;
         Ok(Self {
-            keys: rpc_cmd.keys.into_iter().map(Into::into).collect(),
             compact_id: rpc_cmd.compact_id,
             auth_info: rpc_cmd.auth_info,
             request: rpc_cmd
@@ -578,8 +568,8 @@ mod test {
     use super::*;
     use crate::{
         AuthEnableRequest, AuthStatusRequest, CommandKeys, CompactionRequest, Compare,
-        LeaseGrantRequest, LeaseLeasesRequest, LeaseRevokeRequest, PutRequest, PutResponse,
-        RangeRequest, RequestOp, TxnRequest,
+        DeleteRangeRequest, LeaseGrantRequest, LeaseLeasesRequest, LeaseRevokeRequest, PutRequest,
+        PutResponse, RangeRequest, RequestOp, TxnRequest,
     };
 
     #[test]
@@ -616,63 +606,54 @@ mod test {
 
     #[test]
     fn test_command_conflict() {
-        let cmd1 = Command::new(
-            vec![KeyRange::new("a", "e")],
-            RequestWrapper::PutRequest(PutRequest::default()),
-        );
-        let cmd2 = Command::new(
-            vec![],
-            RequestWrapper::AuthStatusRequest(AuthStatusRequest::default()),
-        );
-        let cmd3 = Command::new(
-            vec![KeyRange::new("c", "g")],
-            RequestWrapper::PutRequest(PutRequest::default()),
-        );
-        let cmd4 = Command::new(
-            vec![],
-            RequestWrapper::AuthEnableRequest(AuthEnableRequest::default()),
-        );
-        let cmd5 = Command::new(
-            vec![],
-            RequestWrapper::LeaseGrantRequest(LeaseGrantRequest { ttl: 1, id: 1 }),
-        );
-        let cmd6 = Command::new(
-            vec![],
-            RequestWrapper::LeaseRevokeRequest(LeaseRevokeRequest { id: 1 }),
-        );
+        let cmd1 = Command::new(RequestWrapper::DeleteRangeRequest(DeleteRangeRequest {
+            key: "a".into(),
+            range_end: "e".into(),
+            ..Default::default()
+        }));
+        let cmd2 = Command::new(RequestWrapper::AuthStatusRequest(
+            AuthStatusRequest::default(),
+        ));
+        let cmd3 = Command::new(RequestWrapper::DeleteRangeRequest(DeleteRangeRequest {
+            key: "c".into(),
+            range_end: "g".into(),
+            ..Default::default()
+        }));
+        let cmd4 = Command::new(RequestWrapper::AuthEnableRequest(
+            AuthEnableRequest::default(),
+        ));
+        let cmd5 = Command::new(RequestWrapper::LeaseGrantRequest(LeaseGrantRequest {
+            ttl: 1,
+            id: 1,
+        }));
+        let cmd6 = Command::new(RequestWrapper::LeaseRevokeRequest(LeaseRevokeRequest {
+            id: 1,
+        }));
 
-        let lease_grant_cmd = Command::new(
-            vec![],
-            RequestWrapper::LeaseGrantRequest(LeaseGrantRequest { ttl: 1, id: 123 }),
-        );
-        let put_with_lease_cmd = Command::new(
-            vec![KeyRange::new_one_key("foo")],
-            RequestWrapper::PutRequest(PutRequest {
-                key: b"key".to_vec(),
-                value: b"value".to_vec(),
-                lease: 123,
-                ..Default::default()
-            }),
-        );
-        let txn_with_lease_id_cmd = Command::new(
-            vec![KeyRange::new_one_key("key")],
-            RequestWrapper::TxnRequest(TxnRequest {
-                compare: vec![],
-                success: vec![RequestOp {
-                    request: Some(Request::RequestPut(PutRequest {
-                        key: b"key".to_vec(),
-                        value: b"value".to_vec(),
-                        lease: 123,
-                        ..Default::default()
-                    })),
-                }],
-                failure: vec![],
-            }),
-        );
-        let lease_leases_cmd = Command::new(
-            vec![],
-            RequestWrapper::LeaseLeasesRequest(LeaseLeasesRequest {}),
-        );
+        let lease_grant_cmd = Command::new(RequestWrapper::LeaseGrantRequest(LeaseGrantRequest {
+            ttl: 1,
+            id: 123,
+        }));
+        let put_with_lease_cmd = Command::new(RequestWrapper::PutRequest(PutRequest {
+            key: b"foo".to_vec(),
+            value: b"value".to_vec(),
+            lease: 123,
+            ..Default::default()
+        }));
+        let txn_with_lease_id_cmd = Command::new(RequestWrapper::TxnRequest(TxnRequest {
+            compare: vec![],
+            success: vec![RequestOp {
+                request: Some(Request::RequestPut(PutRequest {
+                    key: b"key".to_vec(),
+                    value: b"value".to_vec(),
+                    lease: 123,
+                    ..Default::default()
+                })),
+            }],
+            failure: vec![],
+        }));
+        let lease_leases_cmd =
+            Command::new(RequestWrapper::LeaseLeasesRequest(LeaseLeasesRequest {}));
 
         assert!(lease_grant_cmd.is_conflict(&put_with_lease_cmd)); // lease id
         assert!(lease_grant_cmd.is_conflict(&txn_with_lease_id_cmd)); // lease id
@@ -686,41 +667,30 @@ mod test {
     }
 
     fn generate_txn_command(
-        keys: Vec<KeyRange>,
         compare: Vec<Compare>,
         success: Vec<RequestOp>,
         failure: Vec<RequestOp>,
     ) -> Command {
-        Command::new(
-            keys,
-            RequestWrapper::TxnRequest(TxnRequest {
-                compare,
-                success,
-                failure,
-            }),
-        )
+        Command::new(RequestWrapper::TxnRequest(TxnRequest {
+            compare,
+            success,
+            failure,
+        }))
     }
 
     #[test]
     fn test_compaction_txn_conflict() {
-        let compaction_cmd_1 = Command::new(
-            vec![],
-            RequestWrapper::CompactionRequest(CompactionRequest {
-                revision: 3,
-                physical: false,
-            }),
-        );
+        let compaction_cmd_1 = Command::new(RequestWrapper::CompactionRequest(CompactionRequest {
+            revision: 3,
+            physical: false,
+        }));
 
-        let compaction_cmd_2 = Command::new(
-            vec![],
-            RequestWrapper::CompactionRequest(CompactionRequest {
-                revision: 5,
-                physical: false,
-            }),
-        );
+        let compaction_cmd_2 = Command::new(RequestWrapper::CompactionRequest(CompactionRequest {
+            revision: 5,
+            physical: false,
+        }));
 
         let txn_with_lease_id_cmd = generate_txn_command(
-            vec![KeyRange::new_one_key("key")],
             vec![],
             vec![RequestOp {
                 request: Some(Request::RequestPut(PutRequest {
@@ -734,7 +704,6 @@ mod test {
         );
 
         let txn_cmd_1 = generate_txn_command(
-            vec![KeyRange::new_one_key("key")],
             vec![],
             vec![RequestOp {
                 request: Some(Request::RequestRange(RangeRequest {
@@ -746,7 +715,6 @@ mod test {
         );
 
         let txn_cmd_2 = generate_txn_command(
-            vec![KeyRange::new_one_key("key")],
             vec![],
             vec![RequestOp {
                 request: Some(Request::RequestRange(RangeRequest {
@@ -759,7 +727,6 @@ mod test {
         );
 
         let txn_cmd_3 = generate_txn_command(
-            vec![KeyRange::new_one_key("key")],
             vec![],
             vec![RequestOp {
                 request: Some(Request::RequestRange(RangeRequest {
@@ -783,10 +750,7 @@ mod test {
 
     #[test]
     fn command_serialization_is_ok() {
-        let cmd = Command::new(
-            vec![KeyRange::new("a", "e")],
-            RequestWrapper::PutRequest(PutRequest::default()),
-        );
+        let cmd = Command::new(RequestWrapper::PutRequest(PutRequest::default()));
         let decoded_cmd =
             <Command as PbCodec>::decode(&cmd.encode()).expect("decode should success");
         assert_eq!(cmd, decoded_cmd);

--- a/crates/xlineapi/src/lib.rs
+++ b/crates/xlineapi/src/lib.rs
@@ -394,6 +394,7 @@ impl CommandKeys for TxnRequest {
 }
 
 impl RequestWrapper {
+    // TODO: returns a reference type to avoid copying
     /// Get keys of the request
     pub fn keys(&self) -> Vec<KeyRange> {
         match *self {


### PR DESCRIPTION
The keys are not necessary in serialization, we could generate keys only when being used.

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
