### PR TITLE
refactor: xline storage api

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -196,6 +196,6 @@ pub use crate::{
         transaction_api::TransactionApi,
     },
     error::EngineError,
-    proxy::{Engine, EngineType, Snapshot},
+    proxy::{Engine, EngineType, Snapshot, Transaction},
     snapshot_allocator::{MemorySnapshotAllocator, RocksSnapshotAllocator},
 };

--- a/crates/xline/src/server/watch_server.rs
+++ b/crates/xline/src/server/watch_server.rs
@@ -431,7 +431,8 @@ mod test {
         rpc::{PutRequest, WatchProgressRequest},
         storage::{
             compact::COMPACT_CHANNEL_SIZE, db::DB, index::Index, kv_store::KvStoreInner,
-            kvwatcher::MockKvWatcherOps, lease_store::LeaseCollection, KvStore,
+            kvwatcher::MockKvWatcherOps, lease_store::LeaseCollection,
+            storage_api::XlineStorageOps, KvStore,
         },
     };
 
@@ -456,7 +457,7 @@ mod test {
             ..Default::default()
         });
         let (_sync_res, ops) = store.after_sync(&req, revision).await.unwrap();
-        let _key_revisions = db.flush_ops(ops).unwrap();
+        db.write_ops(ops).unwrap();
     }
 
     #[tokio::test]

--- a/crates/xline/src/storage/auth_store/backend.rs
+++ b/crates/xline/src/storage/auth_store/backend.rs
@@ -6,7 +6,7 @@ use xlineapi::execute_error::ExecuteError;
 
 use crate::{
     rpc::{Role, User},
-    storage::db::DB,
+    storage::{db::DB, storage_api::XlineStorageOps},
 };
 
 /// Key of `AuthEnable`
@@ -117,7 +117,7 @@ impl AuthStoreBackend {
         &self,
         ops: Vec<crate::storage::db::WriteOp>,
     ) -> Result<(), ExecuteError> {
-        _ = self.db.flush_ops(ops)?;
+        self.db.write_ops(ops)?;
         Ok(())
     }
 }

--- a/crates/xline/src/storage/kvwatcher.rs
+++ b/crates/xline/src/storage/kvwatcher.rs
@@ -604,7 +604,7 @@ mod test {
         rpc::PutRequest,
         storage::{
             compact::COMPACT_CHANNEL_SIZE, db::DB, index::Index, lease_store::LeaseCollection,
-            KvStore,
+            storage_api::XlineStorageOps, KvStore,
         },
     };
 
@@ -774,6 +774,6 @@ mod test {
             ..Default::default()
         });
         let (_sync_res, ops) = store.after_sync(&req, revision).await.unwrap();
-        let _key_revisions = db.flush_ops(ops).unwrap();
+        db.write_ops(ops).unwrap();
     }
 }

--- a/crates/xline/src/storage/lease_store/mod.rs
+++ b/crates/xline/src/storage/lease_store/mod.rs
@@ -374,7 +374,7 @@ mod test {
     use utils::config::EngineConfig;
 
     use super::*;
-    use crate::storage::db::DB;
+    use crate::storage::{db::DB, storage_api::XlineStorageOps};
 
     #[tokio::test(flavor = "multi_thread")]
     #[abort_on_panic]
@@ -443,7 +443,7 @@ mod test {
         );
 
         let (_ignore, ops) = lease_store.after_sync(&req1, -1).await?;
-        _ = lease_store.db.flush_ops(ops)?;
+        lease_store.db.write_ops(ops)?;
         lease_store.mark_lease_synced(&req1);
 
         assert!(
@@ -464,7 +464,7 @@ mod test {
         );
 
         let (_ignore, ops) = lease_store.after_sync(&req2, -1).await?;
-        _ = lease_store.db.flush_ops(ops)?;
+        lease_store.db.write_ops(ops)?;
         lease_store.mark_lease_synced(&req2);
 
         assert!(
@@ -517,7 +517,7 @@ mod test {
     ) -> Result<ResponseWrapper, ExecuteError> {
         let cmd_res = ls.execute(req)?;
         let (_ignore, ops) = ls.after_sync(req, revision).await?;
-        _ = ls.db.flush_ops(ops)?;
+        ls.db.write_ops(ops)?;
         Ok(cmd_res.into_inner())
     }
 }

--- a/crates/xline/src/storage/mod.rs
+++ b/crates/xline/src/storage/mod.rs
@@ -16,6 +16,8 @@ pub(crate) mod kvwatcher;
 pub(crate) mod lease_store;
 /// Revision module
 pub(crate) mod revision;
+/// Storage API
+pub(crate) mod storage_api;
 
 pub use self::revision::Revision;
 pub(crate) use self::{

--- a/crates/xline/src/storage/storage_api.rs
+++ b/crates/xline/src/storage/storage_api.rs
@@ -1,13 +1,24 @@
-use std::path::Path;
-
-use engine::Snapshot;
 use xlineapi::execute_error::ExecuteError;
 
-use super::{db::WriteOp, revision::KeyRevision};
+use super::db::WriteOp;
 
-/// The Stable Storage Api
-#[async_trait::async_trait]
-pub(crate) trait StorageApi: Send + Sync + 'static + std::fmt::Debug {
+/// Storage operations in xline
+pub(crate) trait XlineStorageOps {
+    /// Write an operation to the transaction
+    fn write_op(&self, op: WriteOp) -> Result<(), ExecuteError>;
+
+    /// Write a batch of operations to the transaction
+    fn write_ops(&self, ops: Vec<WriteOp>) -> Result<(), ExecuteError>;
+
+    /// Get values by keys from storage
+    ///
+    /// # Errors
+    ///
+    /// if error occurs in storage, return `Err(error)`
+    fn get_value<K>(&self, table: &'static str, key: K) -> Result<Option<Vec<u8>>, ExecuteError>
+    where
+        K: AsRef<[u8]> + std::fmt::Debug;
+
     /// Get values by keys from storage
     ///
     /// # Errors
@@ -20,43 +31,4 @@ pub(crate) trait StorageApi: Send + Sync + 'static + std::fmt::Debug {
     ) -> Result<Vec<Option<Vec<u8>>>, ExecuteError>
     where
         K: AsRef<[u8]> + std::fmt::Debug;
-
-    /// Get values by keys from storage
-    ///
-    /// # Errors
-    ///
-    /// if error occurs in storage, return `Err(error)`
-    fn get_value<K>(&self, table: &'static str, key: K) -> Result<Option<Vec<u8>>, ExecuteError>
-    where
-        K: AsRef<[u8]> + std::fmt::Debug;
-
-    /// Get all values of the given table from storage
-    ///
-    /// # Errors
-    ///
-    /// if error occurs in storage, return `Err(error)`
-    #[allow(clippy::type_complexity)] // it's clear that (Vec<u8>, Vec<u8>) is a key-value pair
-    fn get_all(&self, table: &'static str) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ExecuteError>;
-
-    /// Reset the storage by given snapshot
-    ///
-    /// # Errors
-    ///
-    /// if error occurs in storage, return `Err(error)`
-    async fn reset(&self, snapshot: Option<Snapshot>) -> Result<(), ExecuteError>;
-
-    /// Get the snapshot of the storage
-    fn get_snapshot(&self, snap_path: impl AsRef<Path>) -> Result<Snapshot, ExecuteError>;
-
-    /// Flush the operations to storage
-    fn flush_ops(&self, ops: Vec<WriteOp>) -> Result<Vec<(Vec<u8>, KeyRevision)>, ExecuteError>;
-
-    /// Calculate the hash of the storage
-    fn hash(&self) -> Result<u32, ExecuteError>;
-
-    /// Get the cached size of the engine
-    fn estimated_file_size(&self) -> u64;
-
-    /// Get the file size of the engine
-    fn file_size(&self) -> Result<u64, ExecuteError>;
 }


### PR DESCRIPTION
Depends-On: #673 #806 

Adds an `XlineStorageOps` trait as a replacement to `StorageApi` which is removed in #806

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
