### PR TITLE
refactor(client)!: Remove request wrappers - KvClient::put

### DIFF
--- a/crates/benchmark/src/runner.rs
+++ b/crates/benchmark/src/runner.rs
@@ -20,7 +20,7 @@ use tokio::{
 };
 use tracing::debug;
 use utils::config::ClientConfig;
-use xline_client::{types::kv::PutRequest, ClientOptions};
+use xline_client::ClientOptions;
 
 use crate::{args::Commands, bench_client::BenchClient, Benchmark};
 
@@ -229,9 +229,7 @@ impl CommandRunner {
                         );
                     }
                     let start = Instant::now();
-                    let result = client
-                        .put(PutRequest::new(key.as_slice(), val_clone.as_slice()))
-                        .await;
+                    let result = client.put(key.as_slice(), val_clone.as_slice(), None).await;
                     let cmd_result = CmdResult {
                         elapsed: start.elapsed(),
                         error: result.err().map(|e| format!("{e:?}")),

--- a/crates/simulation/tests/it/xline.rs
+++ b/crates/simulation/tests/it/xline.rs
@@ -5,7 +5,7 @@ use madsim::time::sleep;
 use simulation::xline_group::{SimEtcdClient, XlineGroup};
 use xline_client::types::{
     cluster::{MemberAddRequest, MemberListRequest},
-    kv::{CompactionRequest, PutRequest},
+    kv::CompactionRequest,
     watch::WatchRequest,
 };
 
@@ -16,7 +16,7 @@ async fn basic_put() {
     init_logger();
     let group = XlineGroup::new(3).await;
     let client = group.client().await;
-    let res = client.put(PutRequest::new("key", "value")).await;
+    let res = client.put("key", "value", None).await;
     assert!(res.is_ok());
 }
 
@@ -29,9 +29,7 @@ async fn watch_compacted_revision_should_receive_canceled_response() {
     let client = SimEtcdClient::new(watch_addr, group.client_handle.clone()).await;
 
     for i in 1..=6 {
-        let result = client
-            .put(PutRequest::new("key", format!("value{}", i)))
-            .await;
+        let result = client.put("key", format!("value{}", i), None).await;
         assert!(result.is_ok());
     }
 

--- a/crates/xline-client/examples/error_handling.rs
+++ b/crates/xline-client/examples/error_handling.rs
@@ -1,6 +1,6 @@
 //! An example to show how the errors are organized in `xline-client`
 use anyhow::Result;
-use xline_client::{error::XlineClientError, types::kv::PutRequest, Client, ClientOptions};
+use xline_client::{error::XlineClientError, types::kv::PutOptions, Client, ClientOptions};
 use xlineapi::execute_error::ExecuteError;
 
 #[tokio::main]
@@ -16,7 +16,11 @@ async fn main() -> Result<()> {
     // It should return an error and it should be `key not found`
     // as we did not add it before.
     let resp = client
-        .put(PutRequest::new("key", "").with_ignore_value(true))
+        .put(
+            "key",
+            "",
+            Some(PutOptions::default().with_ignore_value(true)),
+        )
         .await;
     let err = resp.unwrap_err();
 

--- a/crates/xline-client/examples/kv.rs
+++ b/crates/xline-client/examples/kv.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use xline_client::{
     types::kv::{
-        CompactionRequest, Compare, CompareResult, DeleteRangeRequest, PutRequest, RangeRequest,
+        CompactionRequest, Compare, CompareResult, DeleteRangeRequest, PutOptions, RangeRequest,
         TxnOp, TxnRequest,
     },
     Client, ClientOptions,
@@ -17,8 +17,8 @@ async fn main() -> Result<()> {
         .kv_client();
 
     // put
-    client.put(PutRequest::new("key1", "value1")).await?;
-    client.put(PutRequest::new("key2", "value2")).await?;
+    client.put("key1", "value1", None).await?;
+    client.put("key2", "value2", None).await?;
 
     // range
     let resp = client.range(RangeRequest::new("key1")).await?;
@@ -49,7 +49,9 @@ async fn main() -> Result<()> {
         .when(&[Compare::value("key2", CompareResult::Equal, "value2")][..])
         .and_then(
             &[TxnOp::put(
-                PutRequest::new("key2", "value3").with_prev_kv(true),
+                "key2",
+                "value3",
+                Some(PutOptions::default().with_prev_kv(true)),
             )][..],
         )
         .or_else(&[TxnOp::range(RangeRequest::new("key2"))][..]);

--- a/crates/xline-client/examples/lock.rs
+++ b/crates/xline-client/examples/lock.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use xline_client::{
     clients::Xutex,
-    types::kv::{Compare, CompareResult, PutRequest, TxnOp},
+    types::kv::{Compare, CompareResult, PutOptions, TxnOp},
     Client, ClientOptions,
 };
 
@@ -23,7 +23,9 @@ async fn main() -> Result<()> {
         .txn_check_locked_key()
         .when([Compare::value("key2", CompareResult::Equal, "value2")])
         .and_then([TxnOp::put(
-            PutRequest::new("key2", "value3").with_prev_kv(true),
+            "key2",
+            "value3",
+            Some(PutOptions::default().with_prev_kv(true)),
         )])
         .or_else(&[]);
 

--- a/crates/xline-client/examples/watch.rs
+++ b/crates/xline-client/examples/watch.rs
@@ -1,8 +1,5 @@
 use anyhow::Result;
-use xline_client::{
-    types::{kv::PutRequest, watch::WatchRequest},
-    Client, ClientOptions,
-};
+use xline_client::{types::watch::WatchRequest, Client, ClientOptions};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -15,7 +12,7 @@ async fn main() -> Result<()> {
 
     // watch
     let (mut watcher, mut stream) = watch_client.watch(WatchRequest::new("key1")).await?;
-    kv_client.put(PutRequest::new("key1", "value1")).await?;
+    kv_client.put("key1", "value1", None).await?;
 
     let resp = stream.message().await?.unwrap();
     let kv = resp.events[0].kv.as_ref().unwrap();

--- a/crates/xline-client/src/clients/kv.rs
+++ b/crates/xline-client/src/clients/kv.rs
@@ -8,7 +8,7 @@ use xlineapi::{
 
 use crate::{
     error::Result,
-    types::kv::{CompactionRequest, DeleteRangeRequest, PutRequest, RangeRequest, TxnRequest},
+    types::kv::{CompactionRequest, DeleteRangeRequest, PutOptions, RangeRequest, TxnRequest},
     AuthService, CurpClient,
 };
 
@@ -65,7 +65,7 @@ impl KvClient {
     /// # Examples
     ///
     /// ```no_run
-    /// use xline_client::{types::kv::PutRequest, Client, ClientOptions};
+    /// use xline_client::{types::kv::PutOptions, Client, ClientOptions};
     /// use anyhow::Result;
     ///
     /// #[tokio::main]
@@ -76,14 +76,22 @@ impl KvClient {
     ///         .await?
     ///         .kv_client();
     ///
-    ///     client.put(PutRequest::new("key1", "value1")).await?;
+    ///     client.put("key1", "value1", None).await?;
+    ///     client.put("key1", "value1", PutOptions::default().with_prev_kv(true)).await?;
     ///
     ///     Ok(())
     /// }
     /// ```
     #[inline]
-    pub async fn put(&self, request: PutRequest) -> Result<PutResponse> {
-        let request = RequestWrapper::from(xlineapi::PutRequest::from(request));
+    pub async fn put(
+        &self,
+        key: impl Into<Vec<u8>>,
+        value: impl Into<Vec<u8>>,
+        option: Option<PutOptions>,
+    ) -> Result<PutResponse> {
+        let request = RequestWrapper::from(xlineapi::PutRequest::from(
+            option.unwrap_or_default().with_kv(key.into(), value.into()),
+        ));
         let cmd = Command::new(request);
         let (cmd_res, _sync_res) = self
             .curp_client

--- a/crates/xline-client/src/types/kv.rs
+++ b/crates/xline-client/src/types/kv.rs
@@ -4,27 +4,22 @@ pub use xlineapi::{
     RangeResponse, Response, ResponseOp, SortOrder, SortTarget, TargetUnion, TxnResponse,
 };
 
-/// Request type for `Put`
-#[derive(Debug, PartialEq)]
-pub struct PutRequest {
+/// Options for `Put`, as same as the `PutRequest` for `Put`.
+#[derive(Debug, PartialEq, Default)]
+pub struct PutOptions {
     /// Inner request
     inner: xlineapi::PutRequest,
 }
 
-impl PutRequest {
-    /// Creates a new `PutRequest`
-    ///
+impl PutOptions {
+    #[inline]
+    #[must_use]
     /// `key` is the key, in bytes, to put into the key-value store.
     /// `value` is the value, in bytes, to associate with the key in the key-value store.
-    #[inline]
-    pub fn new(key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) -> Self {
-        Self {
-            inner: xlineapi::PutRequest {
-                key: key.into(),
-                value: value.into(),
-                ..Default::default()
-            },
-        }
+    pub fn with_kv(mut self, key: Vec<u8>, value: Vec<u8>) -> Self {
+        self.inner.key = key;
+        self.inner.value = value;
+        self
     }
 
     /// lease is the lease ID to associate with the key in the key-value store.
@@ -106,9 +101,9 @@ impl PutRequest {
     }
 }
 
-impl From<PutRequest> for xlineapi::PutRequest {
+impl From<PutOptions> for xlineapi::PutRequest {
     #[inline]
-    fn from(req: PutRequest) -> Self {
+    fn from(req: PutOptions) -> Self {
         req.inner
     }
 }
@@ -567,9 +562,18 @@ impl TxnOp {
     /// Creates a `Put` operation.
     #[inline]
     #[must_use]
-    pub fn put(request: PutRequest) -> Self {
+    pub fn put(
+        key: impl Into<Vec<u8>>,
+        value: impl Into<Vec<u8>>,
+        option: Option<PutOptions>,
+    ) -> Self {
         TxnOp {
-            inner: xlineapi::Request::RequestPut(request.into()),
+            inner: xlineapi::Request::RequestPut(
+                option
+                    .unwrap_or_default()
+                    .with_kv(key.into(), value.into())
+                    .into(),
+            ),
         }
     }
 

--- a/crates/xline-client/tests/it/watch.rs
+++ b/crates/xline-client/tests/it/watch.rs
@@ -1,10 +1,7 @@
 //! The following tests are originally from `etcd-client`
 use xline_client::{
     error::Result,
-    types::{
-        kv::PutRequest,
-        watch::{EventType, WatchRequest},
-    },
+    types::watch::{EventType, WatchRequest},
 };
 
 use super::common::get_cluster_client;
@@ -17,7 +14,7 @@ async fn watch_should_receive_consistent_events() -> Result<()> {
 
     let (mut watcher, mut stream) = watch_client.watch(WatchRequest::new("watch01")).await?;
 
-    kv_client.put(PutRequest::new("watch01", "01")).await?;
+    kv_client.put("watch01", "01", None).await?;
 
     let resp = stream.message().await?.unwrap();
     assert_eq!(resp.watch_id, watcher.watch_id());
@@ -46,7 +43,7 @@ async fn watch_stream_should_work_after_watcher_dropped() -> Result<()> {
 
     let (_, mut stream) = watch_client.watch(WatchRequest::new("watch01")).await?;
 
-    kv_client.put(PutRequest::new("watch01", "01")).await?;
+    kv_client.put("watch01", "01", None).await?;
 
     let resp = stream.message().await?.unwrap();
     assert_eq!(resp.events.len(), 1);

--- a/crates/xline/tests/it/auth_test.rs
+++ b/crates/xline/tests/it/auth_test.rs
@@ -9,7 +9,7 @@ use xline_test_utils::{
     enable_auth, set_user,
     types::{
         auth::{AuthRoleDeleteRequest, AuthUserAddRequest, AuthUserGetRequest},
-        kv::{PutRequest, RangeRequest},
+        kv::RangeRequest,
     },
     Client, ClientOptions, Cluster,
 };
@@ -36,7 +36,7 @@ async fn test_auth_empty_user_put() -> Result<(), Box<dyn Error>> {
     let client = cluster.client().await;
 
     enable_auth(client).await?;
-    let res = client.kv_client().put(PutRequest::new("foo", "bar")).await;
+    let res = client.kv_client().put("foo", "bar", None).await;
     assert!(res.is_err());
 
     Ok(())
@@ -56,9 +56,9 @@ async fn test_auth_token_with_disable() -> Result<(), Box<dyn Error>> {
     )
     .await?;
     let kv_client = authed_client.kv_client();
-    kv_client.put(PutRequest::new("foo", "bar")).await?;
+    kv_client.put("foo", "bar", None).await?;
     authed_client.auth_client().auth_disable().await?;
-    kv_client.put(PutRequest::new("foo", "bar")).await?;
+    kv_client.put("foo", "bar", None).await?;
 
     Ok(())
 }
@@ -71,10 +71,7 @@ async fn test_auth_revision() -> Result<(), Box<dyn Error>> {
     let client = cluster.client().await;
     let auth_client = client.auth_client();
 
-    client
-        .kv_client()
-        .put(PutRequest::new("foo", "bar"))
-        .await?;
+    client.kv_client().put("foo", "bar", None).await?;
 
     let user_add_resp = auth_client
         .user_add(AuthUserAddRequest::new("root").with_pwd("123"))
@@ -93,10 +90,10 @@ async fn test_auth_non_authorized_rpcs() -> Result<(), Box<dyn Error>> {
     let client = cluster.client().await;
     let kv_client = client.kv_client();
 
-    let result = kv_client.put(PutRequest::new("foo", "bar")).await;
+    let result = kv_client.put("foo", "bar", None).await;
     assert!(result.is_ok());
     enable_auth(client).await?;
-    let result = kv_client.put(PutRequest::new("foo", "bar")).await;
+    let result = kv_client.put("foo", "bar", None).await;
     assert!(result.is_err());
 
     Ok(())
@@ -126,9 +123,9 @@ async fn test_kv_authorization() -> Result<(), Box<dyn Error>> {
     .await?
     .kv_client();
 
-    let result = u1_client.put(PutRequest::new("foo", "bar")).await;
+    let result = u1_client.put("foo", "bar", None).await;
     assert!(result.is_ok());
-    let result = u1_client.put(PutRequest::new("fop", "bar")).await;
+    let result = u1_client.put("fop", "bar", None).await;
     assert!(result.is_err());
 
     let result = u2_client

--- a/crates/xline/tests/it/cluster_test.rs
+++ b/crates/xline/tests/it/cluster_test.rs
@@ -3,9 +3,8 @@ use std::{error::Error, time::Duration};
 use test_macros::abort_on_panic;
 use tokio::{net::TcpListener, time::sleep};
 use xline_client::{
-    types::{
-        cluster::{MemberAddRequest, MemberListRequest, MemberRemoveRequest, MemberUpdateRequest},
-        kv::PutRequest,
+    types::cluster::{
+        MemberAddRequest, MemberListRequest, MemberRemoveRequest, MemberUpdateRequest,
     },
     Client, ClientOptions,
 };
@@ -39,7 +38,7 @@ async fn xline_add_node() -> Result<(), Box<dyn Error>> {
     let client = Client::connect(cluster.all_client_addrs(), ClientOptions::default()).await?;
     let mut cluster_client = client.cluster_client();
     let kv_client = client.kv_client();
-    _ = kv_client.put(PutRequest::new("key", "value")).await?;
+    _ = kv_client.put("key", "value", None).await?;
     let new_node_peer_listener = TcpListener::bind("0.0.0.0:0").await?;
     let new_node_peer_urls = vec![format!("http://{}", new_node_peer_listener.local_addr()?)];
     let new_node_client_listener = TcpListener::bind("0.0.0.0:0").await?;

--- a/crates/xline/tests/it/lease_test.rs
+++ b/crates/xline/tests/it/lease_test.rs
@@ -4,7 +4,7 @@ use test_macros::abort_on_panic;
 use tracing::info;
 use xline_test_utils::{
     types::{
-        kv::{PutRequest, RangeRequest},
+        kv::{PutOptions, RangeRequest},
         lease::{LeaseGrantRequest, LeaseKeepAliveRequest},
     },
     Client, ClientOptions, Cluster,
@@ -26,7 +26,11 @@ async fn test_lease_expired() -> Result<(), Box<dyn Error>> {
 
     let _ = client
         .kv_client()
-        .put(PutRequest::new("foo", "bar").with_lease(lease_id))
+        .put(
+            "foo",
+            "bar",
+            Some(PutOptions::default().with_lease(lease_id)),
+        )
         .await?;
     let res = client.kv_client().range(RangeRequest::new("foo")).await?;
     assert_eq!(res.kvs.len(), 1);
@@ -57,7 +61,11 @@ async fn test_lease_keep_alive() -> Result<(), Box<dyn Error>> {
 
     let _ = client
         .kv_client()
-        .put(PutRequest::new("foo", "bar").with_lease(lease_id))
+        .put(
+            "foo",
+            "bar",
+            Some(PutOptions::default().with_lease(lease_id)),
+        )
         .await?;
     let res = client.kv_client().range(RangeRequest::new("foo")).await?;
     assert_eq!(res.kvs.len(), 1);

--- a/crates/xline/tests/it/maintenance_test.rs
+++ b/crates/xline/tests/it/maintenance_test.rs
@@ -5,10 +5,7 @@ use tokio::io::AsyncWriteExt;
 #[cfg(test)]
 use xline::restore::restore;
 use xline_client::error::XlineClientError;
-use xline_test_utils::{
-    types::kv::{PutRequest, RangeRequest},
-    Client, ClientOptions, Cluster,
-};
+use xline_test_utils::{types::kv::RangeRequest, Client, ClientOptions, Cluster};
 use xlineapi::{execute_error::ExecuteError, AlarmAction, AlarmRequest, AlarmType};
 
 #[tokio::test(flavor = "multi_thread")]
@@ -27,7 +24,7 @@ async fn test_snapshot_and_restore() -> Result<(), Box<dyn std::error::Error>> {
         let mut cluster = Cluster::new_rocks(3).await;
         cluster.start().await;
         let client = cluster.client().await.kv_client();
-        let _ignore = client.put(PutRequest::new("key", "value")).await?;
+        let _ignore = client.put("key", "value", None).await?;
         tokio::time::sleep(Duration::from_millis(100)).await; // TODO: use `propose_index` and remove this sleep after we finished our client.
         let mut maintenance_client =
             Client::connect(vec![cluster.get_client_url(0)], ClientOptions::default())
@@ -85,8 +82,7 @@ async fn test_alarm(idx: usize) {
     for i in 1..100u8 {
         let key: Vec<u8> = vec![i];
         let value: Vec<u8> = vec![i];
-        let req = PutRequest::new(key, value);
-        if let Err(err) = k_client.put(req).await {
+        if let Err(err) = k_client.put(key, value, None).await {
             assert!(matches!(
                 err,
                 XlineClientError::ExecuteError(ExecuteError::Nospace)

--- a/crates/xline/tests/it/tls_test.rs
+++ b/crates/xline/tests/it/tls_test.rs
@@ -7,7 +7,6 @@ use utils::config::{
     AuthConfig, ClusterConfig, CompactConfig, LogConfig, MetricsConfig, StorageConfig, TlsConfig,
     TraceConfig, XlineServerConfig,
 };
-use xline_client::types::kv::PutRequest;
 use xline_test_utils::{enable_auth, set_user, Cluster};
 
 #[tokio::test(flavor = "multi_thread")]
@@ -19,7 +18,7 @@ async fn test_basic_tls() {
     let client = cluster
         .client_with_tls_config(basic_tls_client_config())
         .await;
-    let res = client.kv_client().put(PutRequest::new("foo", "bar")).await;
+    let res = client.kv_client().put("foo", "bar", None).await;
     assert!(res.is_ok());
 }
 
@@ -32,7 +31,7 @@ async fn test_mtls() {
     let client = cluster
         .client_with_tls_config(mtls_client_config("root"))
         .await;
-    let res = client.kv_client().put(PutRequest::new("foo", "bar")).await;
+    let res = client.kv_client().put("foo", "bar", None).await;
     assert!(res.is_ok());
 }
 
@@ -59,10 +58,7 @@ async fn test_certificate_authenticate() {
     let u1_client = cluster
         .client_with_tls_config(mtls_client_config("u1"))
         .await;
-    let res = u1_client
-        .kv_client()
-        .put(PutRequest::new("foo", "bar"))
-        .await;
+    let res = u1_client.kv_client().put("foo", "bar", None).await;
     assert!(res.is_err());
 
     set_user(&root_client, "u1", "123", "r1", b"foo", &[])
@@ -74,10 +70,7 @@ async fn test_certificate_authenticate() {
 
     let res = etcd_u2_client.put("foa", "bar", None).await;
     assert!(res.is_ok());
-    let res = u1_client
-        .kv_client()
-        .put(PutRequest::new("foo", "bar"))
-        .await;
+    let res = u1_client.kv_client().put("foo", "bar", None).await;
     assert!(res.is_ok());
 }
 

--- a/crates/xline/tests/it/watch_test.rs
+++ b/crates/xline/tests/it/watch_test.rs
@@ -2,10 +2,7 @@ use std::error::Error;
 
 use test_macros::abort_on_panic;
 use xline_test_utils::{
-    types::{
-        kv::{DeleteRangeRequest, PutRequest},
-        watch::WatchRequest,
-    },
+    types::{kv::DeleteRangeRequest, watch::WatchRequest},
     Cluster,
 };
 use xlineapi::EventType;
@@ -45,7 +42,7 @@ async fn test_watch() -> Result<(), Box<dyn Error>> {
         }
     });
 
-    kv_client.put(PutRequest::new("foo", "bar")).await?;
+    kv_client.put("foo", "bar", None).await?;
     kv_client.delete(DeleteRangeRequest::new("foo")).await?;
 
     handle.await?;

--- a/crates/xlinectl/src/command/put.rs
+++ b/crates/xlinectl/src/command/put.rs
@@ -1,8 +1,13 @@
 use anyhow::Result;
 use clap::{arg, value_parser, ArgMatches, Command};
-use xline_client::{types::kv::PutRequest, Client};
+use xline_client::{types::kv::PutOptions, Client};
 
 use crate::utils::printer::Printer;
+
+/// Indicates the type of the request builted.
+/// The first `Vec<u8>` is the key, the second `Vec<u8>` is the value,
+/// and the third is the options.
+type PutRequest = (Vec<u8>, Vec<u8>, PutOptions);
 
 /// Definition of `get` command
 pub(crate) fn command() -> Command {
@@ -30,19 +35,19 @@ pub(crate) fn build_request(matches: &ArgMatches) -> PutRequest {
     let ignore_value = matches.get_flag("ignore_value");
     let ignore_lease = matches.get_flag("ignore_lease");
 
-    let mut request = PutRequest::new(key.as_bytes(), value.as_bytes());
-    request = request.with_lease(*lease);
-    request = request.with_prev_kv(prev_kv);
-    request = request.with_ignore_value(ignore_value);
-    request = request.with_ignore_lease(ignore_lease);
+    let request = PutOptions::default()
+        .with_lease(*lease)
+        .with_prev_kv(prev_kv)
+        .with_ignore_value(ignore_value)
+        .with_ignore_lease(ignore_lease);
 
-    request
+    (key.as_bytes().to_vec(), value.as_bytes().to_vec(), request)
 }
 
 /// Execute the command
 pub(crate) async fn execute(client: &mut Client, matches: &ArgMatches) -> Result<()> {
     let req = build_request(matches);
-    let resp = client.kv_client().put(req).await?;
+    let resp = client.kv_client().put(req.0, req.1, Some(req.2)).await?;
     resp.print();
 
     Ok(())
@@ -60,27 +65,39 @@ mod tests {
         let test_cases = vec![
             TestCase::new(
                 vec!["put", "key1", "value1"],
-                Some(PutRequest::new("key1".as_bytes(), "value1".as_bytes())),
+                Some(("key1".into(), "value1".into(), PutOptions::default())),
             ),
             TestCase::new(
                 vec!["put", "key2", "value2", "--lease", "1"],
-                Some(PutRequest::new("key2".as_bytes(), "value2".as_bytes()).with_lease(1)),
+                Some((
+                    "key2".into(),
+                    "value2".into(),
+                    PutOptions::default().with_lease(1),
+                )),
             ),
             TestCase::new(
                 vec!["put", "key3", "value3", "--prev_kv"],
-                Some(PutRequest::new("key3".as_bytes(), "value3".as_bytes()).with_prev_kv(true)),
+                Some((
+                    "key3".into(),
+                    "value3".into(),
+                    PutOptions::default().with_prev_kv(true),
+                )),
             ),
             TestCase::new(
                 vec!["put", "key4", "value4", "--ignore_value"],
-                Some(
-                    PutRequest::new("key4".as_bytes(), "value4".as_bytes()).with_ignore_value(true),
-                ),
+                Some((
+                    "key4".into(),
+                    "value4".into(),
+                    PutOptions::default().with_ignore_value(true),
+                )),
             ),
             TestCase::new(
                 vec!["put", "key5", "value5", "--ignore_lease"],
-                Some(
-                    PutRequest::new("key5".as_bytes(), "value5".as_bytes()).with_ignore_lease(true),
-                ),
+                Some((
+                    "key5".into(),
+                    "value5".into(),
+                    PutOptions::default().with_ignore_lease(true),
+                )),
             ),
         ];
 

--- a/crates/xlinectl/src/command/txn.rs
+++ b/crates/xlinectl/src/command/txn.rs
@@ -140,7 +140,7 @@ fn parse_op_line(line: &str) -> Result<TxnOp> {
         "put" => {
             let matches = put_cmd.try_get_matches_from(args.clone())?;
             let req = put::build_request(&matches);
-            Ok(TxnOp::put(req))
+            Ok(TxnOp::put(req.0, req.1, Some(req.2)))
         }
         "get" => {
             let matches = get_cmd.try_get_matches_from(args.clone())?;
@@ -167,7 +167,7 @@ pub(crate) async fn execute(client: &mut Client, matches: &ArgMatches) -> Result
 
 #[cfg(test)]
 mod tests {
-    use xline_client::types::kv::{PutRequest, RangeRequest};
+    use xline_client::types::kv::RangeRequest;
 
     use super::*;
 
@@ -187,7 +187,7 @@ mod tests {
     fn parse_op() {
         assert_eq!(
             parse_op_line(r#"put key1 "created-key1""#).unwrap(),
-            TxnOp::put(PutRequest::new("key1", "created-key1"))
+            TxnOp::put("key1", "created-key1", None)
         );
         assert_eq!(
             parse_op_line(r"get key1 key11").unwrap(),


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    - one of the series of #819 refactor, to remove request wrappers in xline-client and make user interface easier to use.

* what changes does this pull request make?

    - change function in `clients/kv.rs` from `fn put(&self, request: PutRequest)` to `put(&self, key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>, option: Option<PutOptions>)`
    - Renames `types::PutRequest` to `types::PutOptions`, made it an option for put function. The option will be combined with key and value to a `xlineapi::PutRequest` inside the `KvClient.put()` function.
        -  If it gets a None, construct a default PutOptions instead.
    - TxnOp::put function has been changed as well.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

    - yes, it's a breaking change and changes all `put()` function thoughtout the crate. 