### PR TITLE
refactor(client)!: Remove request wrappers - AuthClient::authenticate

### DIFF
--- a/crates/xline-client/src/clients/auth.rs
+++ b/crates/xline-client/src/clients/auth.rs
@@ -17,7 +17,7 @@ use crate::{
         AuthRoleAddRequest, AuthRoleDeleteRequest, AuthRoleGetRequest,
         AuthRoleGrantPermissionRequest, AuthRoleRevokePermissionRequest, AuthUserAddRequest,
         AuthUserChangePasswordRequest, AuthUserDeleteRequest, AuthUserGetRequest,
-        AuthUserGrantRoleRequest, AuthUserRevokeRoleRequest, AuthenticateRequest,
+        AuthUserGrantRoleRequest, AuthUserRevokeRoleRequest,
     },
     AuthService, CurpClient,
 };
@@ -182,7 +182,7 @@ impl AuthClient {
     ///         .auth_client();
     ///
     ///     let resp = client
-    ///         .authenticate(AuthenticateRequest::new("root", "root pass word"))
+    ///         .authenticate("root", "root pass word")
     ///         .await?;
     ///
     ///     println!("auth token: {}", resp.token);
@@ -193,11 +193,15 @@ impl AuthClient {
     #[inline]
     pub async fn authenticate(
         &mut self,
-        request: AuthenticateRequest,
+        name: impl Into<String>,
+        password: impl Into<String>,
     ) -> Result<AuthenticateResponse> {
         Ok(self
             .auth_client
-            .authenticate(xlineapi::AuthenticateRequest::from(request))
+            .authenticate(xlineapi::AuthenticateRequest {
+                name: name.into(),
+                password: password.into(),
+            })
             .await?
             .into_inner())
     }

--- a/crates/xline-client/src/lib.rs
+++ b/crates/xline-client/src/lib.rs
@@ -253,7 +253,7 @@ impl Client {
             Some((username, password)) => {
                 let mut tmp_auth = AuthClient::new(Arc::clone(&curp_client), channel.clone(), None);
                 let resp = tmp_auth
-                    .authenticate(types::auth::AuthenticateRequest::new(username, password))
+                    .authenticate(username, password)
                     .await
                     .map_err(|err| XlineClientBuildError::AuthError(err.to_string()))?;
 

--- a/crates/xline-client/src/types/auth.rs
+++ b/crates/xline-client/src/types/auth.rs
@@ -9,33 +9,6 @@ pub use xlineapi::{
 };
 
 /// Request for `Authenticate`
-#[derive(Debug)]
-pub struct AuthenticateRequest {
-    /// Inner request
-    pub(crate) inner: xlineapi::AuthenticateRequest,
-}
-
-impl AuthenticateRequest {
-    /// Creates a new `AuthenticateRequest`.
-    #[inline]
-    pub fn new(user_name: impl Into<String>, user_password: impl Into<String>) -> Self {
-        Self {
-            inner: xlineapi::AuthenticateRequest {
-                name: user_name.into(),
-                password: user_password.into(),
-            },
-        }
-    }
-}
-
-impl From<AuthenticateRequest> for xlineapi::AuthenticateRequest {
-    #[inline]
-    fn from(req: AuthenticateRequest) -> Self {
-        req.inner
-    }
-}
-
-/// Request for `Authenticate`
 #[derive(Debug, PartialEq)]
 pub struct AuthUserAddRequest {
     /// Inner request


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
    - one of the series of #819 refactor, to remove request wrappers in xline-client and make user interface easier to use.

* what changes does this pull request make?

    - change function in `clients/auth.rs` from `fn authenticate(&mut self, request: AuthenticateRequest)` to `fn authenticate(&mut self, name: impl Into<String>, password: impl Into<String>)`
    - remove `struct AuthenticateRequest`

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

    - yes, it's a breaking change and may break code uses old version of `authenticate()`.