### PR TITLE
refactor(client)!: Remove request wrappers - AuthClient::user_add

### DIFF
--- a/crates/xline-client/examples/auth_user.rs
+++ b/crates/xline-client/examples/auth_user.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use xline_client::{
     types::auth::{
-        AuthUserAddRequest, AuthUserChangePasswordRequest, AuthUserDeleteRequest,
-        AuthUserGetRequest, AuthUserGrantRoleRequest, AuthUserRevokeRoleRequest,
+        AuthUserChangePasswordRequest, AuthUserDeleteRequest, AuthUserGetRequest,
+        AuthUserGrantRoleRequest, AuthUserRevokeRoleRequest,
     },
     Client, ClientOptions,
 };
@@ -17,8 +17,8 @@ async fn main() -> Result<()> {
         .auth_client();
 
     // add user
-    client.user_add(AuthUserAddRequest::new("user1")).await?;
-    client.user_add(AuthUserAddRequest::new("user2")).await?;
+    client.user_add("user1", "", true).await?;
+    client.user_add("user2", "", true).await?;
 
     // change user1's password to "123"
     client

--- a/crates/xline-client/src/types/auth.rs
+++ b/crates/xline-client/src/types/auth.rs
@@ -8,43 +8,6 @@ pub use xlineapi::{
     AuthenticateResponse, Type as PermissionType,
 };
 
-/// Request for `Authenticate`
-#[derive(Debug, PartialEq)]
-pub struct AuthUserAddRequest {
-    /// Inner request
-    pub(crate) inner: xlineapi::AuthUserAddRequest,
-}
-
-impl AuthUserAddRequest {
-    /// Creates a new `AuthUserAddRequest`.
-    #[inline]
-    pub fn new(user_name: impl Into<String>) -> Self {
-        Self {
-            inner: xlineapi::AuthUserAddRequest {
-                name: user_name.into(),
-                options: Some(xlineapi::UserAddOptions { no_password: true }),
-                ..Default::default()
-            },
-        }
-    }
-
-    /// Sets the password.
-    #[inline]
-    #[must_use]
-    pub fn with_pwd(mut self, password: impl Into<String>) -> Self {
-        self.inner.password = password.into();
-        self.inner.options = Some(xlineapi::UserAddOptions { no_password: false });
-        self
-    }
-}
-
-impl From<AuthUserAddRequest> for xlineapi::AuthUserAddRequest {
-    #[inline]
-    fn from(req: AuthUserAddRequest) -> Self {
-        req.inner
-    }
-}
-
 /// Request for `AuthUserGet`
 #[derive(Debug, PartialEq)]
 pub struct AuthUserGetRequest {

--- a/crates/xline-client/tests/it/auth.rs
+++ b/crates/xline-client/tests/it/auth.rs
@@ -3,7 +3,7 @@ use xline_client::{
     error::Result,
     types::auth::{
         AuthRoleAddRequest, AuthRoleDeleteRequest, AuthRoleGetRequest,
-        AuthRoleGrantPermissionRequest, AuthRoleRevokePermissionRequest, AuthUserAddRequest,
+        AuthRoleGrantPermissionRequest, AuthRoleRevokePermissionRequest,
         AuthUserChangePasswordRequest, AuthUserDeleteRequest, AuthUserGetRequest,
         AuthUserGrantRoleRequest, AuthUserRevokeRoleRequest, Permission, PermissionType,
     },
@@ -128,9 +128,7 @@ async fn user_operations_should_success_in_normal_path() -> Result<()> {
     let password1 = "pwd1";
     let password2 = "pwd2";
 
-    client
-        .user_add(AuthUserAddRequest::new(name1).with_pwd(password1))
-        .await?;
+    client.user_add(name1, password1, false).await?;
     client.user_get(AuthUserGetRequest::new(name1)).await?;
 
     let user_list_resp = client.user_list().await?;
@@ -160,7 +158,7 @@ async fn user_role_operations_should_success_in_normal_path() -> Result<()> {
     let role1 = "role1";
     let role2 = "role2";
 
-    client.user_add(AuthUserAddRequest::new(name1)).await?;
+    client.user_add(name1, "", true).await?;
     client.role_add(AuthRoleAddRequest::new(role1)).await?;
     client.role_add(AuthRoleAddRequest::new(role2)).await?;
 

--- a/crates/xline-test-utils/src/lib.rs
+++ b/crates/xline-test-utils/src/lib.rs
@@ -15,8 +15,8 @@ use utils::config::{
 };
 use xline::server::XlineServer;
 use xline_client::types::auth::{
-    AuthRoleAddRequest, AuthRoleGrantPermissionRequest, AuthUserAddRequest,
-    AuthUserGrantRoleRequest, Permission, PermissionType,
+    AuthRoleAddRequest, AuthRoleGrantPermissionRequest, AuthUserGrantRoleRequest, Permission,
+    PermissionType,
 };
 pub use xline_client::{clients, types, Client, ClientOptions};
 
@@ -348,9 +348,7 @@ pub async fn set_user(
     range_end: &[u8],
 ) -> Result<(), Box<dyn std::error::Error>> {
     let client = client.auth_client();
-    client
-        .user_add(AuthUserAddRequest::new(name).with_pwd(password))
-        .await?;
+    client.user_add(name, password, false).await?;
     client.role_add(AuthRoleAddRequest::new(role)).await?;
     client
         .user_grant_role(AuthUserGrantRoleRequest::new(name, role))

--- a/crates/xline/tests/it/auth_test.rs
+++ b/crates/xline/tests/it/auth_test.rs
@@ -8,7 +8,7 @@ use utils::config::{
 use xline_test_utils::{
     enable_auth, set_user,
     types::{
-        auth::{AuthRoleDeleteRequest, AuthUserAddRequest, AuthUserGetRequest},
+        auth::{AuthRoleDeleteRequest, AuthUserGetRequest},
         kv::RangeRequest,
     },
     Client, ClientOptions, Cluster,
@@ -73,9 +73,7 @@ async fn test_auth_revision() -> Result<(), Box<dyn Error>> {
 
     client.kv_client().put("foo", "bar", None).await?;
 
-    let user_add_resp = auth_client
-        .user_add(AuthUserAddRequest::new("root").with_pwd("123"))
-        .await?;
+    let user_add_resp = auth_client.user_add("root", "123", false).await?;
     let auth_rev = user_add_resp.header.unwrap().revision;
     assert_eq!(auth_rev, 2);
 
@@ -181,16 +179,12 @@ async fn test_no_root_user_do_admin_ops() -> Result<(), Box<dyn Error>> {
     .await?
     .auth_client();
 
-    let result = user_client
-        .user_add(AuthUserAddRequest::new("u2").with_pwd("123"))
-        .await;
+    let result = user_client.user_add("u2", "123", false).await;
     assert!(
         result.is_err(),
         "normal user should not allow to add user when auth is enabled: {result:?}"
     );
-    let result = root_client
-        .user_add(AuthUserAddRequest::new("u2").with_pwd("123"))
-        .await;
+    let result = root_client.user_add("u2", "123", false).await;
     assert!(result.is_ok(), "root user failed to add user: {result:?}");
 
     Ok(())


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    - one of the series of #819 refactor, to remove request wrappers in xline-client and make user interface easier to use.

* what changes does this pull request make?

    - change `fn user_add(&self, mut request: AuthUserAddRequest)` to `user_add(&self, name: impl Into<String>,  password: impl AsRef<str>, options: Option<xlineapi::UserAddOptions>)`
    - remove `types::AuthUserAddRequest`

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

    - yes, it's a breaking change and may break code uses old version of `user_add()`.
