### PR TITLE
refactor(client)!: Remove request wrappers - AuthClient::user_get

### DIFF
--- a/crates/xline-client/examples/auth_user.rs
+++ b/crates/xline-client/examples/auth_user.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use xline_client::{
     types::auth::{
-        AuthUserChangePasswordRequest, AuthUserDeleteRequest, AuthUserGetRequest,
-        AuthUserGrantRoleRequest, AuthUserRevokeRoleRequest,
+        AuthUserChangePasswordRequest, AuthUserDeleteRequest, AuthUserGrantRoleRequest,
+        AuthUserRevokeRoleRequest,
     },
     Client, ClientOptions,
 };
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
     let resp = client.user_list().await?;
     for user in resp.users {
         println!("user: {}", user);
-        let get_resp = client.user_get(AuthUserGetRequest::new(user)).await?;
+        let get_resp = client.user_get(user).await?;
         println!("roles:");
         for role in get_resp.roles.iter() {
             print!("{} ", role);

--- a/crates/xline-client/src/clients/auth.rs
+++ b/crates/xline-client/src/clients/auth.rs
@@ -16,8 +16,8 @@ use crate::{
     types::auth::{
         AuthRoleAddRequest, AuthRoleDeleteRequest, AuthRoleGetRequest,
         AuthRoleGrantPermissionRequest, AuthRoleRevokePermissionRequest,
-        AuthUserChangePasswordRequest, AuthUserDeleteRequest, AuthUserGetRequest,
-        AuthUserGrantRoleRequest, AuthUserRevokeRoleRequest,
+        AuthUserChangePasswordRequest, AuthUserDeleteRequest, AuthUserGrantRoleRequest,
+        AuthUserRevokeRoleRequest,
     },
     AuthService, CurpClient,
 };
@@ -278,7 +278,7 @@ impl AuthClient {
     /// # Examples
     ///
     /// ```no_run
-    /// use xline_client::{types::auth::AuthUserGetRequest, Client, ClientOptions};
+    /// use xline_client::{Client, ClientOptions};
     /// use anyhow::Result;
     ///
     /// #[tokio::main]
@@ -289,7 +289,7 @@ impl AuthClient {
     ///         .await?
     ///         .auth_client();
     ///
-    ///     let resp = client.user_get(AuthUserGetRequest::new("user")).await?;
+    ///     let resp = client.user_get("user").await?;
     ///
     ///     for role in resp.roles {
     ///         print!("{} ", role);
@@ -299,8 +299,9 @@ impl AuthClient {
     /// }
     ///```
     #[inline]
-    pub async fn user_get(&self, request: AuthUserGetRequest) -> Result<AuthUserGetResponse> {
-        self.handle_req(request.inner, true).await
+    pub async fn user_get(&self, name: impl Into<String>) -> Result<AuthUserGetResponse> {
+        self.handle_req(xlineapi::AuthUserGetRequest { name: name.into() }, true)
+            .await
     }
 
     /// Lists all users.

--- a/crates/xline-client/src/types/auth.rs
+++ b/crates/xline-client/src/types/auth.rs
@@ -8,32 +8,6 @@ pub use xlineapi::{
     AuthenticateResponse, Type as PermissionType,
 };
 
-/// Request for `AuthUserGet`
-#[derive(Debug, PartialEq)]
-pub struct AuthUserGetRequest {
-    /// Inner request
-    pub(crate) inner: xlineapi::AuthUserGetRequest,
-}
-
-impl AuthUserGetRequest {
-    /// Creates a new `AuthUserGetRequest`.
-    #[inline]
-    pub fn new(user_name: impl Into<String>) -> Self {
-        Self {
-            inner: xlineapi::AuthUserGetRequest {
-                name: user_name.into(),
-            },
-        }
-    }
-}
-
-impl From<AuthUserGetRequest> for xlineapi::AuthUserGetRequest {
-    #[inline]
-    fn from(req: AuthUserGetRequest) -> Self {
-        req.inner
-    }
-}
-
 /// Request for `AuthUserDelete`
 #[derive(Debug, PartialEq)]
 pub struct AuthUserDeleteRequest {

--- a/crates/xline-client/tests/it/auth.rs
+++ b/crates/xline-client/tests/it/auth.rs
@@ -4,8 +4,8 @@ use xline_client::{
     types::auth::{
         AuthRoleAddRequest, AuthRoleDeleteRequest, AuthRoleGetRequest,
         AuthRoleGrantPermissionRequest, AuthRoleRevokePermissionRequest,
-        AuthUserChangePasswordRequest, AuthUserDeleteRequest, AuthUserGetRequest,
-        AuthUserGrantRoleRequest, AuthUserRevokeRoleRequest, Permission, PermissionType,
+        AuthUserChangePasswordRequest, AuthUserDeleteRequest, AuthUserGrantRoleRequest,
+        AuthUserRevokeRoleRequest, Permission, PermissionType,
     },
 };
 
@@ -129,7 +129,7 @@ async fn user_operations_should_success_in_normal_path() -> Result<()> {
     let password2 = "pwd2";
 
     client.user_add(name1, password1, false).await?;
-    client.user_get(AuthUserGetRequest::new(name1)).await?;
+    client.user_get(name1).await?;
 
     let user_list_resp = client.user_list().await?;
     assert!(user_list_resp.users.contains(&name1.to_string()));
@@ -141,10 +141,7 @@ async fn user_operations_should_success_in_normal_path() -> Result<()> {
     client
         .user_delete(AuthUserDeleteRequest::new(name1))
         .await?;
-    client
-        .user_get(AuthUserGetRequest::new(name1))
-        .await
-        .unwrap_err();
+    client.user_get(name1).await.unwrap_err();
 
     Ok(())
 }
@@ -169,7 +166,7 @@ async fn user_role_operations_should_success_in_normal_path() -> Result<()> {
         .user_grant_role(AuthUserGrantRoleRequest::new(name1, role2))
         .await?;
 
-    let user_get_resp = client.user_get(AuthUserGetRequest::new(name1)).await?;
+    let user_get_resp = client.user_get(name1).await?;
     assert_eq!(
         user_get_resp.roles,
         vec![role1.to_owned(), role2.to_owned()]

--- a/crates/xline/tests/it/auth_test.rs
+++ b/crates/xline/tests/it/auth_test.rs
@@ -7,10 +7,7 @@ use utils::config::{
 };
 use xline_test_utils::{
     enable_auth, set_user,
-    types::{
-        auth::{AuthRoleDeleteRequest, AuthUserGetRequest},
-        kv::RangeRequest,
-    },
+    types::{auth::AuthRoleDeleteRequest, kv::RangeRequest},
     Client, ClientOptions, Cluster,
 };
 
@@ -146,12 +143,12 @@ async fn test_role_delete() -> Result<(), Box<dyn Error>> {
     let client = cluster.client().await;
     let auth_client = client.auth_client();
     set_user(client, "u", "123", "r", b"foo", &[]).await?;
-    let user = auth_client.user_get(AuthUserGetRequest::new("u")).await?;
+    let user = auth_client.user_get("u").await?;
     assert_eq!(user.roles.len(), 1);
     auth_client
         .role_delete(AuthRoleDeleteRequest::new("r"))
         .await?;
-    let user = auth_client.user_get(AuthUserGetRequest::new("u")).await?;
+    let user = auth_client.user_get("u").await?;
     assert_eq!(user.roles.len(), 0);
 
     Ok(())

--- a/crates/xlinectl/src/command/user/get.rs
+++ b/crates/xlinectl/src/command/user/get.rs
@@ -1,9 +1,5 @@
 use clap::{arg, ArgMatches, Command};
-use xline_client::{
-    error::Result,
-    types::auth::{AuthRoleGetRequest, AuthUserGetRequest},
-    Client,
-};
+use xline_client::{error::Result, types::auth::AuthRoleGetRequest, Client};
 
 use crate::utils::printer::Printer;
 
@@ -16,9 +12,9 @@ pub(super) fn command() -> Command {
 }
 
 /// Build request from matches
-pub(super) fn build_request(matches: &ArgMatches) -> AuthUserGetRequest {
+pub(super) fn build_request(matches: &ArgMatches) -> String {
     let name = matches.get_one::<String>("name").expect("required");
-    AuthUserGetRequest::new(name.as_str())
+    name.to_owned()
 }
 
 /// Execute the command
@@ -50,18 +46,15 @@ mod tests {
     use super::*;
     use crate::test_case_struct;
 
-    test_case_struct!(AuthUserGetRequest);
+    test_case_struct!(String);
 
     #[test]
     fn command_parse_should_be_valid() {
         let test_cases = vec![
-            TestCase::new(
-                vec!["get", "JohnDoe"],
-                Some(AuthUserGetRequest::new("JohnDoe")),
-            ),
+            TestCase::new(vec!["get", "JohnDoe"], Some("JohnDoe".into())),
             TestCase::new(
                 vec!["get", "--detail", "JaneSmith"],
-                Some(AuthUserGetRequest::new("JaneSmith")),
+                Some("JaneSmith".into()),
             ),
         ];
 


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    - one of the series of #819 refactor

* what changes does this pull request make?

    - change `user_get(&self, request: AuthUserGetRequest)` to `user_get(&self, name: impl Into<String>)`
    - remove `types::AuthUserGetRequest`

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

    - yes, it's a breaking change and may break code uses old version of `user_get()`.
