### PR TITLE
refactor(client)!: Remove request wrappers - AuthClient::user_delete

### DIFF
--- a/crates/xline-client/examples/auth_user.rs
+++ b/crates/xline-client/examples/auth_user.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
 use xline_client::{
     types::auth::{
-        AuthUserChangePasswordRequest, AuthUserDeleteRequest, AuthUserGrantRoleRequest,
-        AuthUserRevokeRoleRequest,
+        AuthUserChangePasswordRequest, AuthUserGrantRoleRequest, AuthUserRevokeRoleRequest,
     },
     Client, ClientOptions,
 };
@@ -54,12 +53,8 @@ async fn main() -> Result<()> {
         .await?;
 
     // delete users
-    client
-        .user_delete(AuthUserDeleteRequest::new("user1"))
-        .await?;
-    client
-        .user_delete(AuthUserDeleteRequest::new("user2"))
-        .await?;
+    client.user_delete("user1").await?;
+    client.user_delete("user2").await?;
 
     Ok(())
 }

--- a/crates/xline-client/src/clients/auth.rs
+++ b/crates/xline-client/src/clients/auth.rs
@@ -16,8 +16,7 @@ use crate::{
     types::auth::{
         AuthRoleAddRequest, AuthRoleDeleteRequest, AuthRoleGetRequest,
         AuthRoleGrantPermissionRequest, AuthRoleRevokePermissionRequest,
-        AuthUserChangePasswordRequest, AuthUserDeleteRequest, AuthUserGrantRoleRequest,
-        AuthUserRevokeRoleRequest,
+        AuthUserChangePasswordRequest, AuthUserGrantRoleRequest, AuthUserRevokeRoleRequest,
     },
     AuthService, CurpClient,
 };
@@ -359,23 +358,15 @@ impl AuthClient {
     ///         .await?
     ///         .auth_client();
     ///
-    ///     // add the user
-    ///
-    ///     let resp = client.user_list().await?;
-    ///
-    ///     for user in resp.users {
-    ///         println!("user: {}", user);
-    ///     }
+    ///     let resp = client.user_delete("user").await?;
     ///
     ///     Ok(())
     /// }
     ///```
     #[inline]
-    pub async fn user_delete(
-        &self,
-        request: AuthUserDeleteRequest,
-    ) -> Result<AuthUserDeleteResponse> {
-        self.handle_req(request.inner, false).await
+    pub async fn user_delete(&self, name: impl Into<String>) -> Result<AuthUserDeleteResponse> {
+        self.handle_req(xlineapi::AuthUserDeleteRequest { name: name.into() }, false)
+            .await
     }
 
     /// Change password for an user.

--- a/crates/xline-client/src/types/auth.rs
+++ b/crates/xline-client/src/types/auth.rs
@@ -8,32 +8,6 @@ pub use xlineapi::{
     AuthenticateResponse, Type as PermissionType,
 };
 
-/// Request for `AuthUserDelete`
-#[derive(Debug, PartialEq)]
-pub struct AuthUserDeleteRequest {
-    /// Inner request
-    pub(crate) inner: xlineapi::AuthUserDeleteRequest,
-}
-
-impl AuthUserDeleteRequest {
-    /// Creates a new `AuthUserDeleteRequest`.
-    #[inline]
-    pub fn new(user_name: impl Into<String>) -> Self {
-        Self {
-            inner: xlineapi::AuthUserDeleteRequest {
-                name: user_name.into(),
-            },
-        }
-    }
-}
-
-impl From<AuthUserDeleteRequest> for xlineapi::AuthUserDeleteRequest {
-    #[inline]
-    fn from(req: AuthUserDeleteRequest) -> Self {
-        req.inner
-    }
-}
-
 /// Request for `AuthUserChangePassword`
 #[derive(Debug, PartialEq)]
 pub struct AuthUserChangePasswordRequest {

--- a/crates/xline-client/tests/it/auth.rs
+++ b/crates/xline-client/tests/it/auth.rs
@@ -4,8 +4,8 @@ use xline_client::{
     types::auth::{
         AuthRoleAddRequest, AuthRoleDeleteRequest, AuthRoleGetRequest,
         AuthRoleGrantPermissionRequest, AuthRoleRevokePermissionRequest,
-        AuthUserChangePasswordRequest, AuthUserDeleteRequest, AuthUserGrantRoleRequest,
-        AuthUserRevokeRoleRequest, Permission, PermissionType,
+        AuthUserChangePasswordRequest, AuthUserGrantRoleRequest, AuthUserRevokeRoleRequest,
+        Permission, PermissionType,
     },
 };
 
@@ -138,9 +138,7 @@ async fn user_operations_should_success_in_normal_path() -> Result<()> {
         .user_change_password(AuthUserChangePasswordRequest::new(name1, password2))
         .await?;
 
-    client
-        .user_delete(AuthUserDeleteRequest::new(name1))
-        .await?;
+    client.user_delete(name1).await?;
     client.user_get(name1).await.unwrap_err();
 
     Ok(())

--- a/crates/xlinectl/src/command/user/delete.rs
+++ b/crates/xlinectl/src/command/user/delete.rs
@@ -1,5 +1,5 @@
 use clap::{arg, ArgMatches, Command};
-use xline_client::{error::Result, types::auth::AuthUserDeleteRequest, Client};
+use xline_client::{error::Result, Client};
 
 use crate::utils::printer::Printer;
 
@@ -11,9 +11,9 @@ pub(super) fn command() -> Command {
 }
 
 /// Build request from matches
-pub(super) fn build_request(matches: &ArgMatches) -> AuthUserDeleteRequest {
+pub(super) fn build_request(matches: &ArgMatches) -> String {
     let name = matches.get_one::<String>("name").expect("required");
-    AuthUserDeleteRequest::new(name)
+    name.to_owned()
 }
 
 /// Execute the command
@@ -30,13 +30,13 @@ mod tests {
     use super::*;
     use crate::test_case_struct;
 
-    test_case_struct!(AuthUserDeleteRequest);
+    test_case_struct!(String);
 
     #[test]
     fn command_parse_should_be_valid() {
         let test_cases = vec![TestCase::new(
             vec!["delete", "JohnDoe"],
-            Some(AuthUserDeleteRequest::new("JohnDoe")),
+            Some("JohnDoe".into()),
         )];
 
         for case in test_cases {


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    - one of the series of #819 

* what changes does this pull request make?

    - change `user_delete(&self, request: AuthUserDeleteRequest)` to `user_delete(&self, name: impl Into<String>)`
    - remove `types::AuthUserDeleteRequest`

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

    - yes, it's a breaking change and may break code uses old version of `user_delete()`.