### PR TITLE
refactor(client)!: refactor AuthClient::user_change_password

### DIFF
--- a/crates/xline-client/examples/auth_user.rs
+++ b/crates/xline-client/examples/auth_user.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use xline_client::{types::auth::AuthUserChangePasswordRequest, Client, ClientOptions};
+use xline_client::{Client, ClientOptions};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -15,9 +15,7 @@ async fn main() -> Result<()> {
     client.user_add("user2", "", true).await?;
 
     // change user1's password to "123"
-    client
-        .user_change_password(AuthUserChangePasswordRequest::new("user1", "123"))
-        .await?;
+    client.user_change_password("user1", "123").await?;
 
     // grant roles
     client.user_grant_role("user1", "role1").await?;

--- a/crates/xline-client/src/types/auth.rs
+++ b/crates/xline-client/src/types/auth.rs
@@ -8,34 +8,6 @@ pub use xlineapi::{
     AuthenticateResponse, Type as PermissionType,
 };
 
-/// Request for `AuthUserChangePassword`
-#[derive(Debug, PartialEq)]
-pub struct AuthUserChangePasswordRequest {
-    /// Inner request
-    pub(crate) inner: xlineapi::AuthUserChangePasswordRequest,
-}
-
-impl AuthUserChangePasswordRequest {
-    /// Creates a new `AuthUserChangePasswordRequest`.
-    #[inline]
-    pub fn new(user_name: impl Into<String>, new_password: impl Into<String>) -> Self {
-        Self {
-            inner: xlineapi::AuthUserChangePasswordRequest {
-                name: user_name.into(),
-                password: new_password.into(),
-                hashed_password: String::new(),
-            },
-        }
-    }
-}
-
-impl From<AuthUserChangePasswordRequest> for xlineapi::AuthUserChangePasswordRequest {
-    #[inline]
-    fn from(req: AuthUserChangePasswordRequest) -> Self {
-        req.inner
-    }
-}
-
 /// Request for `AuthRoleAdd`
 #[derive(Debug, PartialEq)]
 pub struct AuthRoleAddRequest {

--- a/crates/xline-client/tests/it/auth.rs
+++ b/crates/xline-client/tests/it/auth.rs
@@ -3,8 +3,8 @@ use xline_client::{
     error::Result,
     types::auth::{
         AuthRoleAddRequest, AuthRoleDeleteRequest, AuthRoleGetRequest,
-        AuthRoleGrantPermissionRequest, AuthRoleRevokePermissionRequest,
-        AuthUserChangePasswordRequest, Permission, PermissionType,
+        AuthRoleGrantPermissionRequest, AuthRoleRevokePermissionRequest, Permission,
+        PermissionType,
     },
 };
 
@@ -133,9 +133,7 @@ async fn user_operations_should_success_in_normal_path() -> Result<()> {
     let user_list_resp = client.user_list().await?;
     assert!(user_list_resp.users.contains(&name1.to_string()));
 
-    client
-        .user_change_password(AuthUserChangePasswordRequest::new(name1, password2))
-        .await?;
+    client.user_change_password(name1, password2).await?;
 
     client.user_delete(name1).await?;
     client.user_get(name1).await.unwrap_err();

--- a/crates/xlinectl/src/command/user/passwd.rs
+++ b/crates/xlinectl/src/command/user/passwd.rs
@@ -1,7 +1,10 @@
 use clap::{arg, ArgMatches, Command};
-use xline_client::{error::Result, types::auth::AuthUserChangePasswordRequest, Client};
+use xline_client::{error::Result, Client};
 
 use crate::utils::printer::Printer;
+
+/// Temporary request for changing password. 0 is name, 1 is password
+type AuthUserChangePasswordRequest = (String, String);
 
 /// Definition of `passwd` command
 // TODO: interactive mode
@@ -16,13 +19,16 @@ pub(super) fn command() -> Command {
 pub(super) fn build_request(matches: &ArgMatches) -> AuthUserChangePasswordRequest {
     let name = matches.get_one::<String>("name").expect("required");
     let password = matches.get_one::<String>("password").expect("required");
-    AuthUserChangePasswordRequest::new(name, password)
+    (name.to_owned(), password.to_owned())
 }
 
 /// Execute the command
 pub(super) async fn execute(client: &mut Client, matches: &ArgMatches) -> Result<()> {
     let req = build_request(matches);
-    let resp = client.auth_client().user_change_password(req).await?;
+    let resp = client
+        .auth_client()
+        .user_change_password(req.0, req.1)
+        .await?;
     resp.print();
 
     Ok(())
@@ -39,10 +45,7 @@ mod tests {
     fn command_parse_should_be_valid() {
         let test_cases = vec![TestCase::new(
             vec!["passwd", "JohnDoe", "new_password"],
-            Some(AuthUserChangePasswordRequest::new(
-                "JohnDoe",
-                "new_password",
-            )),
+            Some(("JohnDoe".into(), "new_password".into())),
         )];
 
         for case in test_cases {


### PR DESCRIPTION
Depends-On: #882 

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

    - change `user_change_password(&self,mut request: AuthUserChangePasswordRequest)` to `user_change_password(&self,name: impl Into<String>,password: impl AsRef<str>)`
    - remove `types::AuthUserChangePasswordRequest`
 
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

    - yes
