### PR TITLE
refactor(client)!: Remove request wrappers - MaintenanceClient::alarm

### DIFF
--- a/crates/xline-client/src/clients/maintenance.rs
+++ b/crates/xline-client/src/clients/maintenance.rs
@@ -2,7 +2,8 @@ use std::{fmt::Debug, sync::Arc};
 
 use tonic::{transport::Channel, Streaming};
 use xlineapi::{
-    AlarmRequest, AlarmResponse, SnapshotRequest, SnapshotResponse, StatusRequest, StatusResponse,
+    AlarmAction, AlarmRequest, AlarmResponse, AlarmType, SnapshotRequest, SnapshotResponse,
+    StatusRequest, StatusResponse,
 };
 
 use crate::{error::Result, AuthService};
@@ -95,14 +96,27 @@ impl MaintenanceClient {
     ///         .await?
     ///         .maintenance_client();
     ///
-    ///     client.alarm(AlarmRequest::new(AlarmAction::Get, 0, AlarmType::None)).await?;
+    ///     client.alarm(AlarmAction::Get, 0, AlarmType::None).await?;
     ///
     ///     Ok(())
     /// }
     /// ```
     #[inline]
-    pub async fn alarm(&mut self, request: AlarmRequest) -> Result<AlarmResponse> {
-        Ok(self.inner.alarm(request).await?.into_inner())
+    pub async fn alarm(
+        &mut self,
+        action: AlarmAction,
+        member_id: u64,
+        alarm_type: AlarmType,
+    ) -> Result<AlarmResponse> {
+        Ok(self
+            .inner
+            .alarm(AlarmRequest {
+                action: action.into(),
+                member_id,
+                alarm: alarm_type.into(),
+            })
+            .await?
+            .into_inner())
     }
 
     /// Sends a status request

--- a/crates/xline-client/src/types/maintenance.rs
+++ b/crates/xline-client/src/types/maintenance.rs
@@ -1,1 +1,0 @@
-pub use xlineapi::SnapshotResponse;

--- a/crates/xline-client/src/types/mod.rs
+++ b/crates/xline-client/src/types/mod.rs
@@ -6,8 +6,6 @@ pub mod cluster;
 pub mod kv;
 /// Lease type definitions
 pub mod lease;
-/// Maintenance type definitions.
-pub mod maintenance;
 /// Range Option definitions, to build a `range_end` from key.
 pub mod range_end;
 /// Watch type definitions.

--- a/crates/xline/tests/it/maintenance_test.rs
+++ b/crates/xline/tests/it/maintenance_test.rs
@@ -6,7 +6,7 @@ use tokio::io::AsyncWriteExt;
 use xline::restore::restore;
 use xline_client::error::XlineClientError;
 use xline_test_utils::{Client, ClientOptions, Cluster};
-use xlineapi::{execute_error::ExecuteError, AlarmAction, AlarmRequest, AlarmType};
+use xlineapi::{execute_error::ExecuteError, AlarmAction, AlarmType};
 
 #[tokio::test(flavor = "multi_thread")]
 #[abort_on_panic]
@@ -92,7 +92,7 @@ async fn test_alarm(idx: usize) {
     }
     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     let res = m_client
-        .alarm(AlarmRequest::new(AlarmAction::Get, 0, AlarmType::None))
+        .alarm(AlarmAction::Get, 0, AlarmType::None)
         .await
         .unwrap();
     assert!(!res.alarms.is_empty());


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    - one of the series of #819 refactor, to remove request wrappers in xline-client and make user interface easier to use.

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
