### PR TITLE
fix(ci): add doc test

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,13 +24,13 @@ jobs:
               name: "Normal",
               args: "",
               rustflags: "",
-              test: "llvm-cov nextest --all-features --workspace --codecov --output-path codecov.info",
+              test: "llvm-cov nextest --all-features --workspace --codecov --output-path codecov.info && cargo test --doc",
             }
           - {
               name: "Madsim",
               args: "--package=simulation",
               rustflags: "--cfg madsim",
-              test: "nextest run --package=simulation",
+              test: "nextest run --package=simulation && cargo test -p simulation --doc",
             }
     name: Tests ${{ matrix.config.name }}
     steps:


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    - ci does not test doc

* what changes does this pull request make?

    - add a doc test
        - note that [nextest does not support doc test](https://nexte.st/docs/running/#fn:doctest). [ref](https://github.com/nextest-rs/nextest/issues/16)

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

    - no
