### PR TITLE
refactor(client)!: Remove request wrappers - WatchClient::watch

### DIFF
--- a/crates/simulation/tests/it/xline.rs
+++ b/crates/simulation/tests/it/xline.rs
@@ -6,7 +6,7 @@ use simulation::xline_group::{SimEtcdClient, XlineGroup};
 use xline_client::types::{
     cluster::{MemberAddRequest, MemberListRequest},
     kv::CompactionRequest,
-    watch::WatchRequest,
+    watch::WatchOptions,
 };
 
 // TODO: Add more tests if needed
@@ -39,7 +39,7 @@ async fn watch_compacted_revision_should_receive_canceled_response() {
     assert!(result.is_ok());
 
     let (_, mut watch_stream) = client
-        .watch(WatchRequest::new("key").with_start_revision(4))
+        .watch("key", Some(WatchOptions::default().with_start_revision(4)))
         .await
         .unwrap();
     let r = watch_stream.message().await.unwrap().unwrap();

--- a/crates/xline-client/examples/watch.rs
+++ b/crates/xline-client/examples/watch.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use xline_client::{types::watch::WatchRequest, Client, ClientOptions};
+use xline_client::{Client, ClientOptions};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -11,7 +11,7 @@ async fn main() -> Result<()> {
     let kv_client = client.kv_client();
 
     // watch
-    let (mut watcher, mut stream) = watch_client.watch(WatchRequest::new("key1")).await?;
+    let (mut watcher, mut stream) = watch_client.watch("key1", None).await?;
     kv_client.put("key1", "value1", None).await?;
 
     let resp = stream.message().await?.unwrap();

--- a/crates/xline-client/src/clients/lock.rs
+++ b/crates/xline-client/src/clients/lock.rs
@@ -16,7 +16,7 @@ use crate::{
     clients::{lease::LeaseClient, watch::WatchClient, DEFAULT_SESSION_TTL},
     error::{Result, XlineClientError},
     lease_gen::LeaseIdGenerator,
-    types::{kv::TxnRequest as KvTxnRequest, watch::WatchRequest},
+    types::kv::TxnRequest as KvTxnRequest,
     CurpClient,
 };
 
@@ -192,7 +192,7 @@ impl Xutex {
                 ..Default::default()
             })),
         };
-        let range_end = KeyRange::get_prefix(prefix.as_bytes());
+        let range_end = KeyRange::get_prefix(prefix);
         #[allow(clippy::as_conversions)] // this cast is always safe
         let get_owner = RequestOp {
             request: Some(Request::RequestRange(RangeRequest {
@@ -406,7 +406,7 @@ impl LockClient {
         let rev = my_rev.overflow_sub(1);
         let mut watch_client = self.watch_client.clone();
         loop {
-            let range_end = KeyRange::get_prefix(pfx.as_bytes());
+            let range_end = KeyRange::get_prefix(&pfx);
             #[allow(clippy::as_conversions)] // this cast is always safe
             let get_req = RangeRequest {
                 key: pfx.as_bytes().to_vec(),
@@ -424,7 +424,7 @@ impl LockClient {
                 Some(kv) => kv.key.clone(),
                 None => return Ok(()),
             };
-            let (_, mut response_stream) = watch_client.watch(WatchRequest::new(last_key)).await?;
+            let (_, mut response_stream) = watch_client.watch(last_key, None).await?;
             while let Some(watch_res) = response_stream.message().await? {
                 #[allow(clippy::as_conversions)] // this cast is always safe
                 if watch_res

--- a/crates/xline-client/src/clients/watch.rs
+++ b/crates/xline-client/src/clients/watch.rs
@@ -6,7 +6,7 @@ use xlineapi::{self, RequestUnion};
 
 use crate::{
     error::{Result, XlineClientError},
-    types::watch::{WatchRequest, WatchStreaming, Watcher},
+    types::watch::{WatchOptions, WatchStreaming, Watcher},
     AuthService,
 };
 
@@ -53,10 +53,7 @@ impl WatchClient {
     /// # Examples
     ///
     /// ```no_run
-    /// use xline_client::{
-    ///     types::watch::WatchRequest,
-    ///     Client, ClientOptions,
-    /// };
+    /// use xline_client::{Client, ClientOptions};
     /// use anyhow::Result;
     ///
     /// #[tokio::main]
@@ -67,7 +64,7 @@ impl WatchClient {
     ///     let mut watch_client = client.watch_client();
     ///     let mut kv_client = client.kv_client();
     ///
-    ///     let (mut watcher, mut stream) = watch_client.watch(WatchRequest::new("key1")).await?;
+    ///     let (mut watcher, mut stream) = watch_client.watch("key1", None).await?;
     ///     kv_client.put("key1", "value1", None).await?;
     ///
     ///     let resp = stream.message().await?.unwrap();
@@ -86,12 +83,18 @@ impl WatchClient {
     /// }
     /// ```
     #[inline]
-    pub async fn watch(&mut self, request: WatchRequest) -> Result<(Watcher, WatchStreaming)> {
+    pub async fn watch(
+        &mut self,
+        key: impl Into<Vec<u8>>,
+        options: Option<WatchOptions>,
+    ) -> Result<(Watcher, WatchStreaming)> {
         let (mut request_sender, request_receiver) =
             channel::<xlineapi::WatchRequest>(CHANNEL_SIZE);
 
         let request = xlineapi::WatchRequest {
-            request_union: Some(RequestUnion::CreateRequest(request.into())),
+            request_union: Some(RequestUnion::CreateRequest(
+                options.unwrap_or_default().with_key(key.into()).into(),
+            )),
         };
 
         request_sender

--- a/crates/xline-client/src/types/mod.rs
+++ b/crates/xline-client/src/types/mod.rs
@@ -8,5 +8,7 @@ pub mod kv;
 pub mod lease;
 /// Maintenance type definitions.
 pub mod maintenance;
+/// Range Option definitions, to build a `range_end` from key.
+pub mod range_end;
 /// Watch type definitions.
 pub mod watch;

--- a/crates/xline-client/src/types/range_end.rs
+++ b/crates/xline-client/src/types/range_end.rs
@@ -1,0 +1,63 @@
+use xlineapi::command::KeyRange;
+
+/// Range end options, indicates how to set `range_end` from a key.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum RangeOption {
+    /// Only lookup the given single key. Use empty Vec as `range_end`
+    #[default]
+    SingleKey,
+    /// If set, Xline will lookup all keys match the given prefix
+    Prefix,
+    /// If set, Xline will lookup all keys that are equal to or greater than the given key
+    FromKey,
+    /// Set `range_end` directly
+    RangeEnd(Vec<u8>),
+}
+
+impl RangeOption {
+    /// Get the `range_end` for request, and modify key if necessary.
+    #[inline]
+    pub fn get_range_end(self, key: &mut Vec<u8>) -> Vec<u8> {
+        match self {
+            RangeOption::SingleKey => vec![],
+            RangeOption::Prefix => {
+                if key.is_empty() {
+                    key.push(0);
+                    vec![0]
+                } else {
+                    KeyRange::get_prefix(key)
+                }
+            }
+            RangeOption::FromKey => {
+                if key.is_empty() {
+                    key.push(0);
+                }
+                vec![0]
+            }
+            RangeOption::RangeEnd(range_end) => range_end,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_range_end() {
+        let mut key = vec![];
+        assert!(RangeOption::SingleKey.get_range_end(&mut key).is_empty());
+        assert!(key.is_empty());
+        assert!(RangeOption::FromKey.get_range_end(&mut key).first() == Some(&0));
+        assert!(key.first() == Some(&0));
+        assert_eq!(
+            RangeOption::Prefix.get_range_end(&mut key),
+            KeyRange::get_prefix(&key)
+        );
+        assert_eq!(
+            RangeOption::RangeEnd(vec![1, 2, 3]).get_range_end(&mut key),
+            vec![1, 2, 3]
+        );
+    }
+}

--- a/crates/xline-client/tests/it/watch.rs
+++ b/crates/xline-client/tests/it/watch.rs
@@ -1,8 +1,5 @@
 //! The following tests are originally from `etcd-client`
-use xline_client::{
-    error::Result,
-    types::watch::{EventType, WatchRequest},
-};
+use xline_client::{error::Result, types::watch::EventType};
 
 use super::common::get_cluster_client;
 
@@ -12,7 +9,7 @@ async fn watch_should_receive_consistent_events() -> Result<()> {
     let mut watch_client = client.watch_client();
     let kv_client = client.kv_client();
 
-    let (mut watcher, mut stream) = watch_client.watch(WatchRequest::new("watch01")).await?;
+    let (mut watcher, mut stream) = watch_client.watch("watch01", None).await?;
 
     kv_client.put("watch01", "01", None).await?;
 
@@ -41,7 +38,7 @@ async fn watch_stream_should_work_after_watcher_dropped() -> Result<()> {
     let mut watch_client = client.watch_client();
     let kv_client = client.kv_client();
 
-    let (_, mut stream) = watch_client.watch(WatchRequest::new("watch01")).await?;
+    let (_, mut stream) = watch_client.watch("watch01", None).await?;
 
     kv_client.put("watch01", "01", None).await?;
 

--- a/crates/xline/src/server/lock_server.rs
+++ b/crates/xline/src/server/lock_server.rs
@@ -107,7 +107,7 @@ impl LockServer {
                 ..Default::default()
             })),
         };
-        let range_end = KeyRange::get_prefix(prefix.as_bytes());
+        let range_end = KeyRange::get_prefix(prefix);
         #[allow(clippy::as_conversions)] // this cast is always safe
         let get_owner = RequestOp {
             request: Some(Request::RequestRange(RangeRequest {
@@ -137,7 +137,7 @@ impl LockServer {
         let mut watch_client =
             WatchClient::new(Channel::balance_list(self.addrs.clone().into_iter()));
         loop {
-            let range_end = KeyRange::get_prefix(pfx.as_bytes());
+            let range_end = KeyRange::get_prefix(&pfx);
             #[allow(clippy::as_conversions)] // this cast is always safe
             let get_req = RangeRequest {
                 key: pfx.as_bytes().to_vec(),

--- a/crates/xline/tests/it/watch_test.rs
+++ b/crates/xline/tests/it/watch_test.rs
@@ -1,10 +1,7 @@
 use std::error::Error;
 
 use test_macros::abort_on_panic;
-use xline_test_utils::{
-    types::{kv::DeleteRangeRequest, watch::WatchRequest},
-    Cluster,
-};
+use xline_test_utils::{types::kv::DeleteRangeRequest, Cluster};
 use xlineapi::EventType;
 
 fn event_type(event_type: i32) -> EventType {
@@ -24,7 +21,7 @@ async fn test_watch() -> Result<(), Box<dyn Error>> {
     let mut watch_client = client.watch_client();
     let kv_client = client.kv_client();
 
-    let (_watcher, mut stream) = watch_client.watch(WatchRequest::new("foo")).await?;
+    let (_watcher, mut stream) = watch_client.watch("foo", None).await?;
     let handle = tokio::spawn(async move {
         if let Ok(Some(res)) = stream.message().await {
             let event = res.events.get(0).unwrap();

--- a/crates/xlineapi/src/command.rs
+++ b/crates/xlineapi/src/command.rs
@@ -131,7 +131,8 @@ impl KeyRange {
     #[allow(clippy::indexing_slicing)] // end[i] is always valid
     #[must_use]
     #[inline]
-    pub fn get_prefix(key: &[u8]) -> Vec<u8> {
+    pub fn get_prefix(key: impl AsRef<[u8]>) -> Vec<u8> {
+        let key = key.as_ref();
         let mut end = key.to_vec();
         for i in (0..key.len()).rev() {
             if key[i] < 0xFF {


### PR DESCRIPTION
Depends-On: #905 

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

    - use `enum WatchKeyOptions` to record `with_prefix` and `with_from_key` because when constructing `WatchRequest`, the key is not given.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
