### PR TITLE
reafctor: add CE to CurpNode

### DIFF
--- a/crates/curp/src/server/mod.rs
+++ b/crates/curp/src/server/mod.rs
@@ -289,7 +289,7 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> Rpc<C, CE, RC> {
     #[cfg(madsim)]
     #[allow(clippy::too_many_arguments)]
     #[inline]
-    pub async fn run_from_addr<CE>(
+    pub async fn run_from_addr(
         cluster_info: Arc<ClusterInfo>,
         is_leader: bool,
         addr: std::net::SocketAddr,
@@ -302,10 +302,7 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> Rpc<C, CE, RC> {
         client_tls_config: Option<ClientTlsConfig>,
         sps: Vec<SpObject<C>>,
         ucps: Vec<UcpObject<C>>,
-    ) -> Result<(), crate::error::ServerError>
-    where
-        CE: CommandExecutor<C>,
-    {
+    ) -> Result<(), crate::error::ServerError> {
         use utils::task_manager::tasks::TaskName;
 
         use crate::rpc::{InnerProtocolServer, ProtocolServer};

--- a/crates/curp/tests/it/common/curp_group.rs
+++ b/crates/curp/tests/it/common/curp_group.rs
@@ -217,7 +217,7 @@ impl CurpGroup {
     }
 
     async fn run(
-        server: Arc<Rpc<TestCommand, TestRoleChange>>,
+        server: Arc<Rpc<TestCommand, TestCE, TestRoleChange>>,
         listener: TcpListener,
         shutdown_listener: Listener,
     ) -> Result<(), tonic::transport::Error> {

--- a/crates/xline/src/server/xline_server.rs
+++ b/crates/xline/src/server/xline_server.rs
@@ -68,7 +68,7 @@ use crate::{
 };
 
 /// Rpc Server of curp protocol
-pub(crate) type CurpServer = Rpc<Command, State<Arc<CurpClient>>>;
+pub(crate) type CurpServer = Rpc<Command, CommandExecutor, State<Arc<CurpClient>>>;
 
 /// Xline server
 #[derive(Debug)]


### PR DESCRIPTION
This pr adds the cmd executor to a field of `CurpNode`

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
