### PR TITLE
refactor(task_manager): introduce atomic_enum to remove magic numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic_enum"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99e1aca718ea7b89985790c94aad72d77533063fe00bc497bb79a7c2dae6a661"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3414,6 +3425,7 @@ name = "utils"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "atomic_enum",
  "clippy-utilities",
  "dashmap",
  "derive_builder",

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -19,6 +19,7 @@ parking_lot = ["dep:parking_lot"]
 
 [dependencies]
 async-trait = { version = "0.1.80", optional = true }
+atomic_enum = "0.3.0"
 clippy-utilities = "0.2.0"
 dashmap = "5.5.3"
 derive_builder = "0.20.0"


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    - I found the `State` in task_manager is stored as `Arc<AtomicU8>` in `Listener` and `TaskManager`. And the code performs some `AtomicU8 -> State` transform, but there's no  `State -> AtomicU8` code, instead it uses magic numbers directly in the code.

* what changes does this pull request make?

    - Introduce [`atomic_enum`](https://crates.io/crates/atomic_enum) to make the enum `State` Atomic.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

   - no