### PR TITLE
refactor: reimplement client propose in curp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3846,6 +3846,7 @@ dependencies = [
  "engine",
  "etcd-client",
  "event-listener",
+ "flume",
  "futures",
  "hyper",
  "itertools 0.13.0",

--- a/crates/curp/src/client/retry.rs
+++ b/crates/curp/src/client/retry.rs
@@ -177,6 +177,13 @@ where
                 CurpError::Redirect(Redirect { leader_id, term }) => {
                     let _ig = self.inner.update_leader(leader_id, term).await;
                 }
+
+                // update the cluster state if got Zombie
+                CurpError::Zombie(()) => {
+                    if let Err(e) = self.inner.fetch_cluster(true).await {
+                        warn!("fetch cluster failed, error {e:?}");
+                    }
+                }
             }
 
             #[cfg(feature = "client-metrics")]

--- a/crates/curp/src/client/tests.rs
+++ b/crates/curp/src/client/tests.rs
@@ -8,6 +8,7 @@ use curp_test_utils::test_cmd::TestCommand;
 use futures::{future::BoxFuture, Stream};
 #[cfg(not(madsim))]
 use tonic::transport::ClientTlsConfig;
+use tonic::Status;
 use tracing_test::traced_test;
 #[cfg(madsim)]
 use utils::ClientTlsConfig;
@@ -567,7 +568,7 @@ impl ConnectApi for MockedStreamConnectApi {
         _request: ProposeRequest,
         _token: Option<String>,
         _timeout: Duration,
-    ) -> Result<tonic::Response<Box<dyn Stream<Item = tonic::Result<OpResponse>> + Send>>, CurpError>
+    ) -> Result<tonic::Response<Box<dyn Stream<Item = Result<OpResponse, Status>> + Send>>, CurpError>
     {
         unreachable!("please use MockedConnectApi")
     }

--- a/crates/curp/src/client/unary.rs
+++ b/crates/curp/src/client/unary.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, marker::PhantomData, sync::Arc, time::Duration};
 use async_trait::async_trait;
 use curp_external_api::cmd::Command;
 use futures::{future, stream::FuturesUnordered, Future, Stream, StreamExt};
-use tonic::Response;
+use tonic::{Response, Status};
 use tracing::{debug, warn};
 
 use super::{state::State, ClientApi, LeaderStateUpdate, ProposeResponse, RepeatableClientApi};
@@ -109,7 +109,7 @@ impl<C: Command> Unary<C> {
     where
         PF: Future<
             Output = Result<
-                Response<Box<dyn Stream<Item = tonic::Result<OpResponse>> + Send>>,
+                Response<Box<dyn Stream<Item = Result<OpResponse, Status>> + Send>>,
                 CurpError,
             >,
         >,
@@ -130,7 +130,7 @@ impl<C: Command> Unary<C> {
     where
         PF: Future<
             Output = Result<
-                Response<Box<dyn Stream<Item = tonic::Result<OpResponse>> + Send>>,
+                Response<Box<dyn Stream<Item = Result<OpResponse, Status>> + Send>>,
                 CurpError,
             >,
         >,

--- a/crates/curp/src/lib.rs
+++ b/crates/curp/src/lib.rs
@@ -203,6 +203,9 @@ pub mod rpc;
 /// Snapshot
 mod snapshot;
 
+/// Propose response sender
+mod response;
+
 /// Calculate the super quorum
 #[inline]
 #[must_use]

--- a/crates/curp/src/log_entry.rs
+++ b/crates/curp/src/log_entry.rs
@@ -93,6 +93,12 @@ where
     }
 }
 
+impl<C> AsRef<LogEntry<C>> for LogEntry<C> {
+    fn as_ref(&self) -> &LogEntry<C> {
+        self
+    }
+}
+
 /// Propose id to inflight id
 pub(super) fn propose_id_to_inflight_id(id: ProposeId) -> InflightId {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();

--- a/crates/curp/src/response.rs
+++ b/crates/curp/src/response.rs
@@ -1,0 +1,134 @@
+use std::{
+    pin::Pin,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use curp_external_api::cmd::Command;
+use futures::Stream;
+use tokio_stream::StreamExt;
+use tonic::Status;
+
+use crate::rpc::{CurpError, OpResponse, ProposeResponse, ResponseOp, SyncedResponse};
+
+/// The response sender
+#[derive(Debug)]
+pub(super) struct ResponseSender {
+    /// The stream sender
+    tx: flume::Sender<Result<OpResponse, Status>>,
+    /// Whether the command will be speculatively executed
+    conflict: AtomicBool,
+}
+
+impl ResponseSender {
+    /// Creates a new `ResponseSender`
+    pub(super) fn new(tx: flume::Sender<Result<OpResponse, Status>>) -> ResponseSender {
+        ResponseSender {
+            tx,
+            conflict: AtomicBool::new(false),
+        }
+    }
+
+    /// Gets whether the command associated with this sender will be
+    /// speculatively executed
+    pub(super) fn is_conflict(&self) -> bool {
+        self.conflict.load(Ordering::SeqCst)
+    }
+
+    /// Sets the the command associated with this sender will be
+    /// speculatively executed
+    pub(super) fn set_conflict(&self, conflict: bool) {
+        let _ignore = self.conflict.fetch_or(conflict, Ordering::SeqCst);
+    }
+
+    /// Sends propose result
+    pub(super) fn send_propose(&self, resp: ProposeResponse) {
+        let resp = OpResponse {
+            op: Some(ResponseOp::Propose(resp)),
+        };
+        // Ignore the result because the client might close the receiving stream
+        let _ignore = self.tx.try_send(Ok(resp));
+    }
+
+    /// Sends after sync result
+    pub(super) fn send_synced(&self, resp: SyncedResponse) {
+        let resp = OpResponse {
+            op: Some(ResponseOp::Synced(resp)),
+        };
+        // Ignore the result because the client might close the receiving stream
+        let _ignore = self.tx.try_send(Ok(resp));
+    }
+}
+
+/// Receiver for obtaining execution or after sync results
+pub(crate) struct ResponseReceiver {
+    /// The response stream
+    resp_stream: Pin<Box<dyn Stream<Item = tonic::Result<OpResponse>> + Send>>,
+}
+
+impl ResponseReceiver {
+    /// Creates a new [`ResponseReceiver`].
+    pub(crate) fn new(
+        resp_stream: Box<dyn Stream<Item = tonic::Result<OpResponse>> + Send>,
+    ) -> Self {
+        Self {
+            resp_stream: Box::into_pin(resp_stream),
+        }
+    }
+
+    /// Receives the results
+    pub(crate) async fn recv<C: Command>(
+        &mut self,
+        both: bool,
+    ) -> Result<Result<(C::ER, Option<C::ASR>), C::Error>, CurpError> {
+        let fst = self.recv_resp().await?;
+
+        match fst {
+            ResponseOp::Propose(propose_resp) => {
+                let conflict = propose_resp.conflict;
+                let er_result = propose_resp.map_result::<C, _, _>(|res| {
+                    res.map(|er| er.unwrap_or_else(|| unreachable!()))
+                })?;
+                if let Err(e) = er_result {
+                    return Ok(Err(e));
+                }
+                if conflict || both {
+                    let snd = self.recv_resp().await?;
+                    let ResponseOp::Synced(synced_resp) = snd else {
+                        unreachable!()
+                    };
+                    let asr_result = synced_resp
+                        .map_result::<C, _, _>(|res| res.unwrap_or_else(|| unreachable!()))?;
+                    return Ok(er_result.and_then(|er| asr_result.map(|asr| (er, Some(asr)))));
+                }
+                Ok(er_result.map(|er| (er, None)))
+            }
+            ResponseOp::Synced(synced_resp) => {
+                let asr_result = synced_resp
+                    .map_result::<C, _, _>(|res| res.unwrap_or_else(|| unreachable!()))?;
+                if let Err(e) = asr_result {
+                    return Ok(Err(e));
+                }
+                let snd = self.recv_resp().await?;
+                let ResponseOp::Propose(propose_resp) = snd else {
+                    unreachable!("op: {snd:?}")
+                };
+                let er_result = propose_resp.map_result::<C, _, _>(|res| {
+                    res.map(|er| er.unwrap_or_else(|| unreachable!()))
+                })?;
+                Ok(er_result.and_then(|er| asr_result.map(|asr| (er, Some(asr)))))
+            }
+        }
+    }
+
+    /// Receives a single response from stream
+    async fn recv_resp(&mut self) -> Result<ResponseOp, CurpError> {
+        let resp = self
+            .resp_stream
+            .next()
+            .await
+            .ok_or(CurpError::internal("stream reaches on an end".to_owned()))??;
+        Ok(resp
+            .op
+            .unwrap_or_else(|| unreachable!("op should always exist")))
+    }
+}

--- a/crates/curp/src/response.rs
+++ b/crates/curp/src/response.rs
@@ -62,13 +62,13 @@ impl ResponseSender {
 /// Receiver for obtaining execution or after sync results
 pub(crate) struct ResponseReceiver {
     /// The response stream
-    resp_stream: Pin<Box<dyn Stream<Item = tonic::Result<OpResponse>> + Send>>,
+    resp_stream: Pin<Box<dyn Stream<Item = Result<OpResponse, Status>> + Send>>,
 }
 
 impl ResponseReceiver {
     /// Creates a new [`ResponseReceiver`].
     pub(crate) fn new(
-        resp_stream: Box<dyn Stream<Item = tonic::Result<OpResponse>> + Send>,
+        resp_stream: Box<dyn Stream<Item = Result<OpResponse, Status>> + Send>,
     ) -> Self {
         Self {
             resp_stream: Box::into_pin(resp_stream),

--- a/crates/curp/src/rpc/connect.rs
+++ b/crates/curp/src/rpc/connect.rs
@@ -164,7 +164,10 @@ pub(crate) trait ConnectApi: Send + Sync + 'static {
         request: ProposeRequest,
         token: Option<String>,
         timeout: Duration,
-    ) -> Result<tonic::Response<Box<dyn Stream<Item = tonic::Result<OpResponse>> + Send>>, CurpError>;
+    ) -> Result<
+        tonic::Response<Box<dyn Stream<Item = Result<OpResponse, tonic::Status>> + Send>>,
+        CurpError,
+    >;
 
     /// Send `RecordRequest`
     async fn record(
@@ -397,8 +400,10 @@ impl ConnectApi for Connect<ProtocolClient<Channel>> {
         request: ProposeRequest,
         token: Option<String>,
         timeout: Duration,
-    ) -> Result<tonic::Response<Box<dyn Stream<Item = tonic::Result<OpResponse>> + Send>>, CurpError>
-    {
+    ) -> Result<
+        tonic::Response<Box<dyn Stream<Item = Result<OpResponse, tonic::Status>> + Send>>,
+        CurpError,
+    > {
         let mut client = self.rpc_connect.clone();
         let mut req = tonic::Request::new(request);
         if let Some(token) = token {
@@ -681,8 +686,10 @@ where
         request: ProposeRequest,
         token: Option<String>,
         _timeout: Duration,
-    ) -> Result<tonic::Response<Box<dyn Stream<Item = tonic::Result<OpResponse>> + Send>>, CurpError>
-    {
+    ) -> Result<
+        tonic::Response<Box<dyn Stream<Item = Result<OpResponse, tonic::Status>> + Send>>,
+        CurpError,
+    > {
         let mut req = tonic::Request::new(request);
         req.metadata_mut().inject_bypassed();
         req.metadata_mut().inject_current();

--- a/crates/curp/src/server/cmd_board.rs
+++ b/crates/curp/src/server/cmd_board.rs
@@ -1,3 +1,4 @@
+#![allow(unused)]
 use std::{collections::HashMap, sync::Arc};
 
 use event_listener::{Event, EventListener};

--- a/crates/curp/src/server/cmd_worker/mod.rs
+++ b/crates/curp/src/server/cmd_worker/mod.rs
@@ -32,7 +32,7 @@ fn remove_from_sp_ucp<C: Command>(
         EntryData::Command(ref c) => PoolEntry::new(entry.propose_id, Arc::clone(c)),
         EntryData::ConfChange(ref c) => PoolEntry::new(entry.propose_id, c.clone()),
         EntryData::Empty | EntryData::Shutdown | EntryData::SetNodeState(_, _, _) => {
-            unreachable!()
+            unreachable!("should never exist in sp and ucp {:?}", entry.entry_data)
         }
     };
     sp.remove(pool_entry.clone());

--- a/crates/curp/src/server/cmd_worker/mod.rs
+++ b/crates/curp/src/server/cmd_worker/mod.rs
@@ -105,8 +105,7 @@ async fn after_sync_cmds<C: Command, CE: CommandExecutor<C>, RC: RoleChange>(
             for ((asr, er_opt), tx) in resps
                 .into_iter()
                 .zip(resp_txs)
-                .map(|(resp, tx_opt)| tx_opt.as_ref().map(|tx| (resp, tx)))
-                .flatten()
+                .filter_map(|(resp, tx_opt)| tx_opt.as_ref().map(|tx| (resp, tx)))
             {
                 if let Some(er) = er_opt {
                     tx.send_propose(ProposeResponse::new_result::<C>(&Ok(er), true));
@@ -122,7 +121,7 @@ async fn after_sync_cmds<C: Command, CE: CommandExecutor<C>, RC: RoleChange>(
     }
 
     for (entry, _) in &cmd_entries {
-        curp.trigger(entry.propose_id);
+        curp.trigger(&entry.propose_id);
         ce.trigger(entry.inflight_id());
     }
     let mut sp_l = sp.lock();

--- a/crates/curp/src/server/cmd_worker/mod.rs
+++ b/crates/curp/src/server/cmd_worker/mod.rs
@@ -49,10 +49,6 @@ pub(super) fn execute<C: Command, CE: CommandExecutor<C>, RC: RoleChange>(
     match entry.entry_data {
         EntryData::Command(ref cmd) => {
             let er = ce.execute(cmd);
-            if er.is_err() {
-                remove_from_sp_ucp(curp, Some(entry));
-                ce.trigger(entry.inflight_id());
-            }
             debug!(
                 "{id} cmd({}) is speculatively executed, exe status: {}",
                 entry.propose_id,

--- a/crates/curp/src/server/curp_node.rs
+++ b/crates/curp/src/server/curp_node.rs
@@ -182,7 +182,7 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> CurpNode<C, CE, RC> {
         }
         let id = req.propose_id();
         let cmd: Arc<C> = Arc::new(req.cmd()?);
-        let conflict = self.curp.follower_record(id, cmd);
+        let conflict = self.curp.follower_record(id, &cmd);
 
         Ok(RecordResponse { conflict })
     }

--- a/crates/curp/src/server/curp_node.rs
+++ b/crates/curp/src/server/curp_node.rs
@@ -63,6 +63,9 @@ use crate::{
     snapshot::{Snapshot, SnapshotMeta},
 };
 
+/// After sync entry, composed of a log entry and response sender
+pub(crate) type AfterSyncEntry<C> = (Arc<LogEntry<C>>, Option<Arc<ResponseSender>>);
+
 /// The after sync task type
 #[derive(Debug)]
 pub(super) enum TaskType<C: Command> {

--- a/crates/curp/src/server/curp_node.rs
+++ b/crates/curp/src/server/curp_node.rs
@@ -152,7 +152,6 @@ pub(super) struct CurpNode<C: Command, CE: CommandExecutor<C>, RC: RoleChange> {
 
 /// Handlers for clients
 impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> CurpNode<C, CE, RC> {
-    // TODO: Add term to req
     /// Handle `ProposeStream` requests
     pub(super) fn propose_stream(
         &self,
@@ -824,7 +823,6 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> CurpNode<C, CE, RC> {
         let last_applied = cmd_executor
             .last_applied()
             .map_err(|e| CurpError::internal(format!("get applied index error, {e}")))?;
-        // TODO: after sync task
         let (as_tx, as_rx) = flume::unbounded();
         let (propose_tx, propose_rx) = flume::bounded(4096);
 

--- a/crates/curp/src/server/curp_node.rs
+++ b/crates/curp/src/server/curp_node.rs
@@ -12,7 +12,7 @@ use futures::{pin_mut, stream::FuturesUnordered, Stream, StreamExt};
 use madsim::rand::{thread_rng, Rng};
 use parking_lot::{Mutex, RwLock};
 use tokio::{
-    sync::{broadcast, mpsc},
+    sync::{broadcast, oneshot},
     time::MissedTickBehavior,
 };
 #[cfg(not(madsim))]
@@ -21,17 +21,16 @@ use tracing::{debug, error, info, trace, warn};
 #[cfg(madsim)]
 use utils::ClientTlsConfig;
 use utils::{
+    barrier::IdBarrier,
     config::CurpConfig,
     task_manager::{tasks::TaskName, Listener, State, TaskManager},
 };
 
 use super::{
     cmd_board::{CmdBoardRef, CommandBoard},
-    cmd_worker::{conflict_checked_mpmc, start_cmd_workers},
-    conflict::{
-        spec_pool_new::{SpObject, SpeculativePool},
-        uncommitted_pool::{UcpObject, UncommittedPool},
-    },
+    cmd_worker::execute,
+    conflict::spec_pool_new::{SpObject, SpeculativePool},
+    conflict::uncommitted_pool::{UcpObject, UncommittedPool},
     gc::gc_cmd_board,
     lease_manager::LeaseManager,
     raw_curp::{AppendEntries, RawCurp, Vote},
@@ -41,6 +40,7 @@ use crate::{
     cmd::{Command, CommandExecutor},
     log_entry::{EntryData, LogEntry},
     members::{ClusterInfo, ServerId},
+    response::ResponseSender,
     role_change::RoleChange,
     rpc::{
         self,
@@ -48,15 +48,85 @@ use crate::{
         AppendEntriesRequest, AppendEntriesResponse, ConfChange, ConfChangeType, CurpError,
         FetchClusterRequest, FetchClusterResponse, FetchReadStateRequest, FetchReadStateResponse,
         InstallSnapshotRequest, InstallSnapshotResponse, LeaseKeepAliveMsg, MoveLeaderRequest,
-        MoveLeaderResponse, ProposeConfChangeRequest, ProposeConfChangeResponse, ProposeRequest,
-        ProposeResponse, PublishRequest, PublishResponse, ShutdownRequest, ShutdownResponse,
-        TriggerShutdownRequest, TriggerShutdownResponse, TryBecomeLeaderNowRequest,
-        TryBecomeLeaderNowResponse, VoteRequest, VoteResponse, WaitSyncedRequest,
-        WaitSyncedResponse,
+        MoveLeaderResponse, PoolEntry, ProposeConfChangeRequest, ProposeConfChangeResponse,
+        ProposeId, ProposeRequest, ProposeResponse, PublishRequest, PublishResponse, RecordRequest,
+        RecordResponse, ShutdownRequest, ShutdownResponse, TriggerShutdownRequest,
+        TriggerShutdownResponse, TryBecomeLeaderNowRequest, TryBecomeLeaderNowResponse,
+        VoteRequest, VoteResponse,
     },
-    server::{cmd_worker::CEEventTxApi, metrics, raw_curp::SyncAction, storage::db::DB},
+    server::{
+        cmd_worker::{after_sync, worker_reset, worker_snapshot},
+        metrics,
+        raw_curp::SyncAction,
+        storage::db::DB,
+    },
     snapshot::{Snapshot, SnapshotMeta},
 };
+
+/// The after sync task type
+#[derive(Debug)]
+pub(super) enum TaskType<C: Command> {
+    /// After sync an entry
+    Entries(Vec<AfterSyncEntry<C>>),
+    /// Reset the CE
+    Reset(Option<Snapshot>, oneshot::Sender<()>),
+    /// Snapshot
+    Snapshot(SnapshotMeta, oneshot::Sender<Snapshot>),
+}
+
+/// A propose type
+pub(super) struct Propose<C> {
+    /// The command of the propose
+    pub(super) cmd: Arc<C>,
+    /// Propose id
+    pub(super) id: ProposeId,
+    /// Term the client proposed
+    /// NOTE: this term should be equal to the cluster's latest term
+    /// for the propose to be accepted.
+    pub(super) term: u64,
+    /// Tx used for sending the streaming response back to client
+    pub(super) resp_tx: Arc<ResponseSender>,
+}
+
+impl<C> Propose<C>
+where
+    C: Command,
+{
+    /// Attempts to create a new `Propose` from request
+    fn try_new(req: &ProposeRequest, resp_tx: Arc<ResponseSender>) -> Result<Self, CurpError> {
+        let cmd: Arc<C> = Arc::new(req.cmd()?);
+        Ok(Self {
+            cmd,
+            id: req.propose_id(),
+            term: req.term,
+            resp_tx,
+        })
+    }
+
+    /// Returns `true` if the proposed command is read-only
+    fn is_read_only(&self) -> bool {
+        self.cmd.is_read_only()
+    }
+
+    /// Gets response sender
+    fn response_tx(&self) -> Arc<ResponseSender> {
+        Arc::clone(&self.resp_tx)
+    }
+
+    /// Convert self into parts
+    fn into_parts(self) -> (Arc<C>, ProposeId, u64, Arc<ResponseSender>) {
+        let Self {
+            cmd,
+            id,
+            term,
+            resp_tx,
+        } = self;
+        (cmd, id, term, resp_tx)
+    }
+}
+
+/// Entry to execute
+type ExecutorEntry<C> = (Arc<LogEntry<C>>, Arc<ResponseSender>);
 
 /// `CurpNode` represents a single node of curp cluster
 pub(super) struct CurpNode<C: Command, CE: CommandExecutor<C>, RC: RoleChange> {
@@ -64,8 +134,6 @@ pub(super) struct CurpNode<C: Command, CE: CommandExecutor<C>, RC: RoleChange> {
     curp: Arc<RawCurp<C, RC>>,
     /// Cmd watch board for tracking the cmd sync results
     cmd_board: CmdBoardRef<C>,
-    /// CE event tx,
-    ce_event_tx: Arc<dyn CEEventTxApi<C>>,
     /// Storage
     storage: Arc<dyn StorageApi<Command = C>>,
     /// Snapshot allocator
@@ -73,28 +141,147 @@ pub(super) struct CurpNode<C: Command, CE: CommandExecutor<C>, RC: RoleChange> {
     /// Command Executor
     #[allow(unused)]
     cmd_executor: Arc<CE>,
+    /// Tx to send entries to after_sync
+    as_tx: flume::Sender<TaskType<C>>,
+    /// Tx to send to propose task
+    propose_tx: flume::Sender<Propose<C>>,
 }
 
 /// Handlers for clients
 impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> CurpNode<C, CE, RC> {
-    /// Handle `Propose` requests
-    pub(super) async fn propose(&self, req: ProposeRequest) -> Result<ProposeResponse, CurpError> {
+    // TODO: Add term to req
+    /// Handle `ProposeStream` requests
+    pub(super) fn propose_stream(
+        &self,
+        req: &ProposeRequest,
+        resp_tx: Arc<ResponseSender>,
+    ) -> Result<(), CurpError> {
+        if self.curp.is_shutdown() {
+            return Err(CurpError::shutting_down());
+        }
+        self.curp.check_leader_transfer()?;
+        self.check_cluster_version(req.cluster_version)?;
+        self.curp.check_term(req.term)?;
+
+        if req.slow_path {
+            resp_tx.set_conflict(true);
+        } else {
+            info!("not using slow path for: {req:?}");
+        }
+
+        let propose = Propose::try_new(req, resp_tx)?;
+        let _ignore = self.propose_tx.send(propose);
+
+        Ok(())
+    }
+
+    /// Handle `Record` requests
+    pub(super) fn record(&self, req: &RecordRequest) -> Result<RecordResponse, CurpError> {
         if self.curp.is_shutdown() {
             return Err(CurpError::shutting_down());
         }
         let id = req.propose_id();
-        self.check_cluster_version(req.cluster_version)?;
         let cmd: Arc<C> = Arc::new(req.cmd()?);
-        // handle proposal
-        let sp_exec = self.curp.handle_propose(id, Arc::clone(&cmd))?;
+        let conflict = self.curp.follower_record(id, cmd);
 
-        // if speculatively executed, wait for the result and return
-        if sp_exec {
-            let er_res = CommandBoard::wait_for_er(&self.cmd_board, id).await;
-            return Ok(ProposeResponse::new_result::<C>(&er_res));
+        Ok(RecordResponse { conflict })
+    }
+
+    /// Handle propose task
+    async fn handle_propose_task(
+        ce: Arc<CE>,
+        curp: Arc<RawCurp<C, RC>>,
+        rx: flume::Receiver<Propose<C>>,
+        shutdown_listener: Listener,
+    ) {
+        /// Max number of propose in a batch
+        const MAX_BATCH_SIZE: usize = 1024;
+
+        let cmd_executor = Self::build_executor(ce, Arc::clone(&curp));
+        loop {
+            let Ok(first) = rx.recv_async().await else {
+                info!("handle propose task exit");
+                break;
+            };
+            let mut addition: Vec<_> = std::iter::repeat_with(|| rx.try_recv())
+                .take(MAX_BATCH_SIZE)
+                .flatten()
+                .collect();
+            addition.push(first);
+            if shutdown_listener.is_shutdown() {
+                break;
+            }
+            let (read_onlys, mutatives): (Vec<_>, Vec<_>) =
+                addition.into_iter().partition(Propose::is_read_only);
+
+            Self::handle_read_onlys(cmd_executor.clone(), &curp, read_onlys);
+            Self::handle_mutatives(cmd_executor.clone(), &curp, mutatives);
         }
+    }
 
-        Ok(ProposeResponse::new_empty())
+    /// Handle read-only proposes
+    fn handle_read_onlys<Executor>(
+        cmd_executor: Executor,
+        curp: &RawCurp<C, RC>,
+        proposes: Vec<Propose<C>>,
+    ) where
+        Executor: Fn(ExecutorEntry<C>) + Clone + Send + 'static,
+    {
+        for propose in proposes {
+            info!("handle read only cmd: {:?}", propose.cmd);
+            // TODO: Disable dedup if the command is read only or commute
+            let Propose {
+                cmd, resp_tx, id, ..
+            } = propose;
+            // Use default value for the entry as we don't need to put it into curp log
+            let entry = Arc::new(LogEntry::new(0, 0, id, Arc::clone(&cmd)));
+            let wait_fut = curp.wait_conflicts_synced(cmd);
+            let cmd_executor_c = cmd_executor.clone();
+            let _ignore = tokio::spawn(async move {
+                wait_fut.await;
+                cmd_executor_c((entry, resp_tx));
+            });
+        }
+    }
+
+    /// Handle read-only proposes
+    fn handle_mutatives<Executor>(
+        cmd_executor: Executor,
+        curp: &RawCurp<C, RC>,
+        proposes: Vec<Propose<C>>,
+    ) where
+        Executor: Fn(ExecutorEntry<C>),
+    {
+        if proposes.is_empty() {
+            return;
+        }
+        let pool_entries = proposes
+            .iter()
+            .map(|p| PoolEntry::new(p.id, Arc::clone(&p.cmd)));
+        let conflicts = curp.leader_record(pool_entries);
+        for (p, conflict) in proposes.iter().zip(conflicts) {
+            info!("handle mutative cmd: {:?}, conflict: {conflict}", p.cmd);
+            p.resp_tx.set_conflict(conflict);
+        }
+        let resp_txs: Vec<_> = proposes.iter().map(Propose::response_tx).collect();
+        let logs: Vec<_> = proposes.into_iter().map(Propose::into_parts).collect();
+        let entries = curp.push_logs(logs);
+        #[allow(clippy::pattern_type_mismatch)] // Can't be fixed
+        entries
+            .into_iter()
+            .zip(resp_txs)
+            .filter(|(_, tx)| !tx.is_conflict())
+            .for_each(cmd_executor);
+    }
+
+    /// Speculatively execute a command
+    fn build_executor(ce: Arc<CE>, curp: Arc<RawCurp<C, RC>>) -> impl Fn(ExecutorEntry<C>) + Clone {
+        move |(entry, resp_tx): (_, Arc<ResponseSender>)| {
+            info!("spec execute entry: {entry:?}");
+            let er_res = execute(&entry, ce.as_ref(), curp.as_ref());
+            let resp = ProposeResponse::new_result::<C>(&er_res, false);
+            resp_tx.send_propose(resp);
+        }
     }
 
     /// Handle `Shutdown` requests
@@ -171,7 +358,11 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> CurpNode<C, CE, RC> {
             req.leader_commit,
         );
         let resp = match result {
-            Ok(term) => AppendEntriesResponse::new_accept(term),
+            Ok((term, to_persist)) => {
+                self.storage
+                    .put_log_entries(&to_persist.iter().map(Arc::as_ref).collect::<Vec<_>>())?;
+                AppendEntriesResponse::new_accept(term)
+            }
             Err((term, hint)) => AppendEntriesResponse::new_reject(term, hint),
         };
 
@@ -217,25 +408,6 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> CurpNode<C, CE, RC> {
     ) -> TriggerShutdownResponse {
         self.curp.task_manager().mark_leader_notified();
         TriggerShutdownResponse::default()
-    }
-
-    /// handle `WaitSynced` requests
-    pub(super) async fn wait_synced(
-        &self,
-        req: WaitSyncedRequest,
-    ) -> Result<WaitSyncedResponse, CurpError> {
-        if self.curp.is_shutdown() {
-            return Err(CurpError::shutting_down());
-        }
-        self.check_cluster_version(req.cluster_version)?;
-        let id = req.propose_id();
-        debug!("{} get wait synced request for cmd({id})", self.curp.id());
-        if self.curp.get_transferee().is_some() {
-            return Err(CurpError::leader_transfer("leader transferring"));
-        }
-        let (er, asr) = CommandBoard::wait_for_er_asr(&self.cmd_board, id).await;
-        debug!("{} wait synced for cmd({id}) finishes", self.curp.id());
-        Ok(WaitSyncedResponse::new_from_result::<C>(er, asr))
     }
 
     /// Handle `FetchCluster` requests
@@ -311,15 +483,14 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> CurpNode<C, CE, RC> {
                     "{} successfully received a snapshot, {snapshot:?}",
                     self.curp.id(),
                 );
-                self.ce_event_tx
-                    .send_reset(Some(snapshot))
-                    .await
-                    .map_err(|err| {
-                        error!("failed to reset the command executor by snapshot, {err}");
-                        CurpError::internal(format!(
-                            "failed to reset the command executor by snapshot, {err}"
-                        ))
-                    })?;
+                let (tx, rx) = oneshot::channel();
+                self.as_tx.send(TaskType::Reset(Some(snapshot), tx))?;
+                rx.await.map_err(|err| {
+                    error!("failed to reset the command executor by snapshot, {err}");
+                    CurpError::internal(format!(
+                        "failed to reset the command executor by snapshot, {err}"
+                    ))
+                })?;
                 metrics::get().apply_snapshot_in_progress.add(-1, &[]);
                 metrics::get()
                     .snapshot_install_total_duration_seconds
@@ -575,33 +746,46 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> CurpNode<C, CE, RC> {
         debug!("{} to {} sync follower task exits", curp.id(), connect.id());
     }
 
-    /// Log persist task
-    pub(super) async fn log_persist_task(
-        mut log_rx: mpsc::UnboundedReceiver<Arc<LogEntry<C>>>,
-        storage: Arc<dyn StorageApi<Command = C>>,
+    /// After sync task
+    async fn after_sync_task(
+        curp: Arc<RawCurp<C, RC>>,
+        cmd_executor: Arc<CE>,
+        as_rx: flume::Receiver<TaskType<C>>,
         shutdown_listener: Listener,
     ) {
-        #[allow(clippy::arithmetic_side_effects, clippy::ignored_unit_patterns)]
+        #[allow(
+            clippy::arithmetic_side_effects,
+            clippy::ignored_unit_patterns,
+            clippy::pattern_type_mismatch
+        )]
         // introduced by tokio select
         loop {
             tokio::select! {
-                e = log_rx.recv() => {
-                    let Some(e) = e else {
-                        return;
-                    };
-                    if let Err(err) = storage.put_log_entries(&[e.as_ref()]) {
-                        error!("storage error, {err}");
-                    }
+                _ = shutdown_listener.wait() => {
+                    break;
                 }
-                _ = shutdown_listener.wait() => break,
+                Ok(task) = as_rx.recv_async() => {
+                    Self::handle_as_task(&curp, &cmd_executor, task).await;
+                }
             }
         }
-        while let Ok(e) = log_rx.try_recv() {
-            if let Err(err) = storage.put_log_entries(&[e.as_ref()]) {
-                error!("storage error, {err}");
+        debug!("after sync task exits");
+    }
+
+    /// Handles a after sync task
+    async fn handle_as_task(curp: &RawCurp<C, RC>, cmd_executor: &CE, task: TaskType<C>) {
+        debug!("after sync: {task:?}");
+        match task {
+            TaskType::Entries(entries) => {
+                after_sync(entries, cmd_executor, curp).await;
+            }
+            TaskType::Reset(snap, tx) => {
+                let _ignore = worker_reset(snap, tx, cmd_executor, curp).await;
+            }
+            TaskType::Snapshot(meta, tx) => {
+                let _ignore = worker_snapshot(meta, tx, cmd_executor, curp).await;
             }
         }
-        debug!("log persist task exits");
     }
 }
 
@@ -632,15 +816,14 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> CurpNode<C, CE, RC> {
             .await
             .map_err(|e| CurpError::internal(format!("parse peers addresses failed, err {e:?}")))?
             .collect();
-        let (log_tx, log_rx) = mpsc::unbounded_channel();
         let cmd_board = Arc::new(RwLock::new(CommandBoard::new()));
         let lease_manager = Arc::new(RwLock::new(LeaseManager::new()));
         let last_applied = cmd_executor
             .last_applied()
             .map_err(|e| CurpError::internal(format!("get applied index error, {e}")))?;
-        let (ce_event_tx, task_rx, done_tx) =
-            conflict_checked_mpmc::channel(Arc::clone(&cmd_executor), Arc::clone(&task_manager));
-        let ce_event_tx: Arc<dyn CEEventTxApi<C>> = Arc::new(ce_event_tx);
+        // TODO: after sync task
+        let (as_tx, as_rx) = flume::unbounded();
+        let (propose_tx, propose_rx) = flume::bounded(4096);
 
         // create curp state machine
         let (voted_for, entries) = storage.recover()?;
@@ -651,9 +834,7 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> CurpNode<C, CE, RC> {
                 .cmd_board(Arc::clone(&cmd_board))
                 .lease_manager(lease_manager)
                 .cfg(Arc::clone(&curp_cfg))
-                .cmd_tx(Arc::clone(&ce_event_tx))
                 .sync_events(sync_events)
-                .log_tx(log_tx)
                 .role_change(role_change)
                 .task_manager(Arc::clone(&task_manager))
                 .connects(connects)
@@ -664,40 +845,43 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> CurpNode<C, CE, RC> {
                 .client_tls_config(client_tls_config)
                 .spec_pool(Arc::new(Mutex::new(SpeculativePool::new(sps))))
                 .uncommitted_pool(Arc::new(Mutex::new(UncommittedPool::new(ucps))))
+                .as_tx(as_tx.clone())
+                .resp_txs(Arc::new(Mutex::default()))
+                .id_barrier(Arc::new(IdBarrier::new()))
                 .build_raw_curp()
                 .map_err(|e| CurpError::internal(format!("build raw curp failed, {e}")))?,
         );
 
         metrics::Metrics::register_callback(Arc::clone(&curp))?;
 
-        start_cmd_workers(
-            Arc::clone(&cmd_executor),
-            Arc::clone(&curp),
-            task_rx,
-            done_tx,
-        );
-
         task_manager.spawn(TaskName::GcCmdBoard, |n| {
             gc_cmd_board(Arc::clone(&cmd_board), curp_cfg.gc_interval, n)
         });
 
-        Self::run_bg_tasks(Arc::clone(&curp), Arc::clone(&storage), log_rx);
+        Self::run_bg_tasks(
+            Arc::clone(&curp),
+            Arc::clone(&cmd_executor),
+            propose_rx,
+            as_rx,
+        );
 
         Ok(Self {
             curp,
             cmd_board,
-            ce_event_tx,
             storage,
             snapshot_allocator,
             cmd_executor,
+            as_tx,
+            propose_tx,
         })
     }
 
     /// Run background tasks for Curp server
     fn run_bg_tasks(
         curp: Arc<RawCurp<C, RC>>,
-        storage: Arc<impl StorageApi<Command = C> + 'static>,
-        log_rx: mpsc::UnboundedReceiver<Arc<LogEntry<C>>>,
+        cmd_executor: Arc<CE>,
+        propose_rx: flume::Receiver<Propose<C>>,
+        as_rx: flume::Receiver<TaskType<C>>,
     ) {
         let task_manager = curp.task_manager();
 
@@ -723,10 +907,13 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> CurpNode<C, CE, RC> {
         }
 
         task_manager.spawn(TaskName::ConfChange, |n| {
-            Self::conf_change_handler(curp, remove_events, n)
+            Self::conf_change_handler(Arc::clone(&curp), remove_events, n)
         });
-        task_manager.spawn(TaskName::LogPersist, |n| {
-            Self::log_persist_task(log_rx, storage, n)
+        task_manager.spawn(TaskName::HandlePropose, |n| {
+            Self::handle_propose_task(Arc::clone(&cmd_executor), Arc::clone(&curp), propose_rx, n)
+        });
+        task_manager.spawn(TaskName::AfterSync, |n| {
+            Self::after_sync_task(curp, cmd_executor, as_rx, n)
         });
     }
 
@@ -1002,10 +1189,7 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::*;
-    use crate::{
-        rpc::{connect::MockInnerConnectApi, ConfChange},
-        server::cmd_worker::MockCEEventTxApi,
-    };
+    use crate::rpc::{connect::MockInnerConnectApi, ConfChange};
 
     #[traced_test]
     #[tokio::test]
@@ -1013,7 +1197,6 @@ mod tests {
         let task_manager = Arc::new(TaskManager::new());
         let curp = Arc::new(RawCurp::new_test(
             3,
-            MockCEEventTxApi::<TestCommand>::default(),
             mock_role_change(),
             Arc::clone(&task_manager),
         ));
@@ -1043,10 +1226,8 @@ mod tests {
     async fn tick_task_will_bcast_votes() {
         let task_manager = Arc::new(TaskManager::new());
         let curp = {
-            let exe_tx = MockCEEventTxApi::<TestCommand>::default();
             Arc::new(RawCurp::new_test(
                 3,
-                exe_tx,
                 mock_role_change(),
                 Arc::clone(&task_manager),
             ))
@@ -1093,10 +1274,8 @@ mod tests {
     async fn vote_will_not_send_to_learner_during_election() {
         let task_manager = Arc::new(TaskManager::new());
         let curp = {
-            let exe_tx = MockCEEventTxApi::<TestCommand>::default();
             Arc::new(RawCurp::new_test(
                 3,
-                exe_tx,
                 mock_role_change(),
                 Arc::clone(&task_manager),
             ))

--- a/crates/curp/src/server/raw_curp/log.rs
+++ b/crates/curp/src/server/raw_curp/log.rs
@@ -315,6 +315,9 @@ type ConfChangeEntries<C> = Vec<Arc<LogEntry<C>>>;
 /// Fallback indexes type
 type FallbackIndexes = HashSet<LogIndex>;
 
+/// Type returned when append success
+type AppendSuccess<C> = (Vec<Arc<LogEntry<C>>>, ConfChangeEntries<C>, FallbackIndexes);
+
 impl<C: Command> Log<C> {
     /// Create a new log
     pub(super) fn new(batch_limit: u64, entries_cap: usize) -> Self {
@@ -373,8 +376,7 @@ impl<C: Command> Log<C> {
         entries: Vec<LogEntry<C>>,
         prev_log_index: LogIndex,
         prev_log_term: u64,
-    ) -> Result<(Vec<Arc<LogEntry<C>>>, ConfChangeEntries<C>, FallbackIndexes), Vec<LogEntry<C>>>
-    {
+    ) -> Result<AppendSuccess<C>, Vec<LogEntry<C>>> {
         let mut to_persist = Vec::with_capacity(entries.len());
         let mut conf_changes = vec![];
         let mut need_fallback_indexes = HashSet::new();

--- a/crates/curp/src/server/raw_curp/mod.rs
+++ b/crates/curp/src/server/raw_curp/mod.rs
@@ -109,10 +109,6 @@ pub struct RawCurp<C: Command, RC: RoleChange> {
 }
 
 /// Tmp struct for building `RawCurp`
-///
-/// WARN: To avoid deadlock, the lock order should be:
-/// 1. `spec_pool`
-/// 2. `uncommitted_pool`
 #[derive(Builder)]
 #[builder(name = "RawCurpBuilder")]
 pub(super) struct RawCurpArgs<C: Command, RC: RoleChange> {
@@ -301,6 +297,10 @@ enum Role {
 }
 
 /// Relevant context for Curp
+///
+/// WARN: To avoid deadlock, the lock order should be:
+/// 1. `spec_pool`
+/// 2. `uncommitted_pool`
 #[derive(Builder)]
 #[builder(build_fn(skip))]
 struct Context<C: Command, RC: RoleChange> {

--- a/crates/curp/src/server/raw_curp/mod.rs
+++ b/crates/curp/src/server/raw_curp/mod.rs
@@ -109,6 +109,10 @@ pub struct RawCurp<C: Command, RC: RoleChange> {
 }
 
 /// Tmp struct for building `RawCurp`
+///
+/// WARN: To avoid deadlock, the lock order should be:
+/// 1. `spec_pool`
+/// 2. `uncommitted_pool`
 #[derive(Builder)]
 #[builder(name = "RawCurpBuilder")]
 pub(super) struct RawCurpArgs<C: Command, RC: RoleChange> {

--- a/crates/curp/src/server/raw_curp/mod.rs
+++ b/crates/curp/src/server/raw_curp/mod.rs
@@ -1336,13 +1336,13 @@ impl<C: Command, RC: RoleChange> RawCurp<C, RC> {
     }
 
     /// Get a reference to spec pool
-    pub(super) fn spec_pool(&self) -> Arc<Mutex<SpeculativePool<C>>> {
-        Arc::clone(&self.ctx.spec_pool)
+    pub(super) fn spec_pool(&self) -> &Mutex<SpeculativePool<C>> {
+        &self.ctx.spec_pool
     }
 
     /// Get a reference to uncommitted pool
-    pub(super) fn uncommitted_pool(&self) -> Arc<Mutex<UncommittedPool<C>>> {
-        Arc::clone(&self.ctx.uncommitted_pool)
+    pub(super) fn uncommitted_pool(&self) -> &Mutex<UncommittedPool<C>> {
+        &self.ctx.uncommitted_pool
     }
 
     /// Get sync event

--- a/crates/curp/tests/it/common/curp_group.rs
+++ b/crates/curp/tests/it/common/curp_group.rs
@@ -55,11 +55,7 @@ pub use commandpb::{
 
 /// `BOTTOM_TASKS` are tasks which not dependent on other tasks in the task group.
 /// `CurpGroup` uses `BOTTOM_TASKS` to detect whether the curp group is closed or not.
-const BOTTOM_TASKS: [TaskName; 3] = [
-    TaskName::WatchTask,
-    TaskName::ConfChange,
-    TaskName::LogPersist,
-];
+const BOTTOM_TASKS: [TaskName; 2] = [TaskName::WatchTask, TaskName::ConfChange];
 
 /// The default shutdown timeout used in `wait_for_targets_shutdown`
 pub(crate) const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(7);

--- a/crates/curp/tests/it/read_state.rs
+++ b/crates/curp/tests/it/read_state.rs
@@ -15,7 +15,7 @@ async fn read_state() {
     init_logger();
     let group = CurpGroup::new(3).await;
     let put_client = group.new_client().await;
-    let put_cmd = TestCommand::new_put(vec![0], 0).set_exe_dur(Duration::from_millis(100));
+    let put_cmd = TestCommand::new_put(vec![0], 0).set_exe_dur(Duration::from_millis(200));
     tokio::spawn(async move {
         assert_eq!(
             put_client

--- a/crates/curp/tests/it/server.rs
+++ b/crates/curp/tests/it/server.rs
@@ -12,15 +12,14 @@ use curp_test_utils::{
     init_logger, sleep_millis, sleep_secs,
     test_cmd::{TestCommand, TestCommandResult, TestCommandType},
 };
+use futures::stream::FuturesUnordered;
 use madsim::rand::{thread_rng, Rng};
 use test_macros::abort_on_panic;
 use tokio::net::TcpListener;
+use tokio_stream::StreamExt;
 use utils::{config::ClientConfig, timestamp};
 
-use crate::common::curp_group::{
-    commandpb::ProposeId, CurpGroup, FetchClusterRequest, ProposeRequest, ProposeResponse,
-    DEFAULT_SHUTDOWN_TIMEOUT,
-};
+use crate::common::curp_group::{CurpGroup, FetchClusterRequest, DEFAULT_SHUTDOWN_TIMEOUT};
 
 #[tokio::test(flavor = "multi_thread")]
 #[abort_on_panic]
@@ -58,17 +57,22 @@ async fn synced_propose() {
 
     let mut group = CurpGroup::new(5).await;
     let client = group.new_client().await;
-    let cmd = TestCommand::new_get(vec![0]);
+    let cmd = TestCommand::new_put(vec![0], 0);
 
     let (er, index) = client.propose(&cmd, None, false).await.unwrap().unwrap();
     assert_eq!(er, TestCommandResult::new(vec![], vec![]));
     assert_eq!(index.unwrap(), 1.into()); // log[0] is a fake one
 
-    for exe_rx in group.exe_rxs() {
-        let (cmd1, er) = exe_rx.recv().await.unwrap();
+    {
+        let mut exe_futs = group
+            .exe_rxs()
+            .map(|rx| rx.recv())
+            .collect::<FuturesUnordered<_>>();
+        let (cmd1, er) = exe_futs.next().await.unwrap().unwrap();
         assert_eq!(cmd1, cmd);
         assert_eq!(er, TestCommandResult::new(vec![], vec![]));
     }
+
     for as_rx in group.as_rxs() {
         let (cmd1, index) = as_rx.recv().await.unwrap();
         assert_eq!(cmd1, cmd);
@@ -76,23 +80,27 @@ async fn synced_propose() {
     }
 }
 
-// Each command should be executed once and only once on each node
+// Each command should be executed once and only once on leader
 #[tokio::test(flavor = "multi_thread")]
 #[abort_on_panic]
-async fn exe_exact_n_times() {
+async fn exe_exactly_once_on_leader() {
     init_logger();
 
     let mut group = CurpGroup::new(3).await;
     let client = group.new_client().await;
-    let cmd = TestCommand::new_get(vec![0]);
+    let cmd = TestCommand::new_put(vec![0], 0);
 
     let er = client.propose(&cmd, None, true).await.unwrap().unwrap().0;
     assert_eq!(er, TestCommandResult::new(vec![], vec![]));
 
-    for exe_rx in group.exe_rxs() {
-        let (cmd1, er) = exe_rx.recv().await.unwrap();
+    {
+        let mut exe_futs = group
+            .exe_rxs()
+            .map(|rx| rx.recv())
+            .collect::<FuturesUnordered<_>>();
+        let (cmd1, er) = exe_futs.next().await.unwrap().unwrap();
         assert!(
-            tokio::time::timeout(Duration::from_millis(100), exe_rx.recv())
+            tokio::time::timeout(Duration::from_millis(100), exe_futs.next())
                 .await
                 .is_err()
         );
@@ -112,6 +120,8 @@ async fn exe_exact_n_times() {
     }
 }
 
+// TODO: rewrite this test for propose_stream
+#[cfg(ignore)]
 // To verify PR #86 is fixed
 #[tokio::test(flavor = "multi_thread")]
 #[abort_on_panic]
@@ -133,6 +143,7 @@ async fn fast_round_is_slower_than_slow_round() {
             }),
             command: bincode::serialize(&cmd).unwrap(),
             cluster_version: 0,
+            term: 0,
         }))
         .await
         .unwrap();
@@ -154,6 +165,7 @@ async fn fast_round_is_slower_than_slow_round() {
             }),
             command: bincode::serialize(&cmd).unwrap(),
             cluster_version: 0,
+            term: 0,
         }))
         .await
         .unwrap()
@@ -161,6 +173,8 @@ async fn fast_round_is_slower_than_slow_round() {
     assert!(resp.result.is_none());
 }
 
+// TODO: rewrite this test for propose_stream
+#[cfg(ignore)]
 #[tokio::test(flavor = "multi_thread")]
 #[abort_on_panic]
 async fn concurrent_cmd_order() {
@@ -183,6 +197,7 @@ async fn concurrent_cmd_order() {
             }),
             command: bincode::serialize(&cmd0).unwrap(),
             cluster_version: 0,
+            term: 0,
         })
         .await
         .expect("propose failed");
@@ -197,6 +212,7 @@ async fn concurrent_cmd_order() {
             }),
             command: bincode::serialize(&cmd1).unwrap(),
             cluster_version: 0,
+            term: 0,
         })
         .await;
     assert!(response.is_err());
@@ -208,6 +224,7 @@ async fn concurrent_cmd_order() {
             }),
             command: bincode::serialize(&cmd2).unwrap(),
             cluster_version: 0,
+            term: 0,
         })
         .await;
     assert!(response.is_err());
@@ -498,9 +515,9 @@ async fn check_new_node(is_learner: bool) {
         .iter()
         .any(|m| m.id == node_id && m.name == "new_node" && is_learner == m.is_learner));
 
-    // 4. check if the new node executes the command from old cluster
+    // 4. check if the new node syncs the command from old cluster
     let new_node = group.nodes.get_mut(&node_id).unwrap();
-    let (cmd, res) = new_node.exe_rx.recv().await.unwrap();
+    let (cmd, _) = new_node.as_rx.recv().await.unwrap();
     assert_eq!(
         cmd,
         TestCommand {
@@ -509,7 +526,6 @@ async fn check_new_node(is_learner: bool) {
             ..Default::default()
         }
     );
-    assert!(res.values.is_empty());
 
     // 5. check if the old client can propose to the new cluster
     client

--- a/crates/simulation/src/curp_group.rs
+++ b/crates/simulation/src/curp_group.rs
@@ -9,8 +9,8 @@ use curp::{
     cmd::Command,
     members::{ClusterInfo, ServerId},
     rpc::{
-        ConfChange, FetchClusterRequest, FetchClusterResponse, Member, ProposeConfChangeRequest,
-        ProposeConfChangeResponse, ReadState,
+        ConfChange, FetchClusterRequest, FetchClusterResponse, Member, OpResponse,
+        ProposeConfChangeRequest, ProposeConfChangeResponse, ReadState,
     },
     server::{
         conflict::test_pools::{TestSpecPool, TestUncomPool},
@@ -400,15 +400,15 @@ pub struct SimProtocolClient {
 
 impl SimProtocolClient {
     #[inline]
-    pub async fn propose(
+    pub async fn propose_stream(
         &mut self,
         cmd: impl tonic::IntoRequest<ProposeRequest> + 'static + Send,
-    ) -> Result<tonic::Response<ProposeResponse>, tonic::Status> {
+    ) -> Result<tonic::Response<tonic::Streaming<OpResponse>>, tonic::Status> {
         let addr = self.addr.clone();
         self.handle
             .spawn(async move {
                 let mut client = ProtocolClient::connect(addr).await.unwrap();
-                client.propose(cmd).await
+                client.propose_stream(cmd).await
             })
             .await
             .unwrap()

--- a/crates/utils/src/task_manager/mod.rs
+++ b/crates/utils/src/task_manager/mod.rs
@@ -363,6 +363,14 @@ impl Listener {
         self.state()
     }
 
+    /// Checks whether self has shutdown.
+    #[inline]
+    #[must_use]
+    pub fn is_shutdown(&self) -> bool {
+        let state = self.state();
+        matches!(state, State::Shutdown)
+    }
+
     /// Get a sync follower guard
     #[must_use]
     #[inline]

--- a/crates/utils/src/task_manager/tasks.rs
+++ b/crates/utils/src/task_manager/tasks.rs
@@ -1,13 +1,13 @@
 //                LEASE_KEEP_ALIVE
 //                       |
-// KV_UPDATES      TONIC_SERVER       ELECTION
-//       \        /      |      \       /
-//      WATCH_TASK  CONF_CHANGE  LOG_PERSIST
+// KV_UPDATES      TONIC_SERVER
+//       \        /      |
+//      WATCH_TASK  CONF_CHANGE
 //
 // Other tasks like `CompactBg`, `GcSpecPool`, `GcCmdBoard`, `RevokeExpiredLeases`, `SyncVictims`,
-// and `AutoCompactor` do not have dependent tasks.
+// `Election`, and `AutoCompactor` do not have dependent tasks.
 
-// NOTE: In integration tests, we use bottom tasks, like `WatchTask`, `ConfChange`, and `LogPersist`,
+// NOTE: In integration tests, we use bottom tasks, like `WatchTask` and `ConfChange`,
 // which are not dependent on other tasks to detect the curp group is closed or not. If you want
 // to refactor the task group, don't forget to modify the `BOTTOM_TASKS` in `crates/curp/tests/it/common/curp_group.rs`
 // to prevent the integration tests from failing.
@@ -41,7 +41,6 @@ enum_with_iter! {
     WatchTask,
     LeaseKeepAlive,
     TonicServer,
-    LogPersist,
     Election,
     SyncFollower,
     ConfChange,
@@ -50,14 +49,14 @@ enum_with_iter! {
     RevokeExpiredLeases,
     SyncVictims,
     AutoCompactor,
+    AfterSync,
+    HandlePropose,
 }
 
 /// All edges of task graph, the first item in each pair must be shut down before the second item
-pub const ALL_EDGES: [(TaskName, TaskName); 6] = [
+pub const ALL_EDGES: [(TaskName, TaskName); 4] = [
     (TaskName::KvUpdates, TaskName::WatchTask),
     (TaskName::LeaseKeepAlive, TaskName::TonicServer),
     (TaskName::TonicServer, TaskName::WatchTask),
     (TaskName::TonicServer, TaskName::ConfChange),
-    (TaskName::TonicServer, TaskName::LogPersist),
-    (TaskName::Election, TaskName::LogPersist),
 ];

--- a/crates/xline/Cargo.toml
+++ b/crates/xline/Cargo.toml
@@ -26,6 +26,7 @@ curp-external-api = { path = "../curp-external-api" }
 dashmap = "5.5.3"
 engine = { path = "../engine" }
 event-listener = "5.3.1"
+flume = "0.11.0"
 futures = "0.3.25"
 hyper = "0.14.27"
 itertools = "0.13"


### PR DESCRIPTION
Depends-On: #917

This PR reimplements the client propose process on both curp server and client.

This refactor includes:
- Use serial execution for execute and after sync
- Curp client will now use a gRPC stream for propose(Remove of `WaitSyncedRequest`).
- Use `Record` rpc to record to speculative pools (witnesses)

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
