### PR TITLE
refactor: use zero to reprenset no leader id

### DIFF
--- a/crates/curp/src/client/tests.rs
+++ b/crates/curp/src/client/tests.rs
@@ -82,7 +82,7 @@ async fn test_unary_fetch_clusters_serializable() {
     let connects = init_mocked_connects(3, |_id, conn| {
         conn.expect_fetch_cluster().return_once(|_req, _timeout| {
             Ok(tonic::Response::new(FetchClusterResponse {
-                leader_id: Some(0),
+                leader_id: 1,
                 term: 1,
                 cluster_id: 123,
                 members: vec![
@@ -119,7 +119,7 @@ async fn test_unary_fetch_clusters_serializable_local_first() {
                     panic!("other server's `fetch_cluster` should not be invoked");
                 };
                 Ok(tonic::Response::new(FetchClusterResponse {
-                    leader_id: Some(0),
+                    leader_id: 1,
                     term: 1,
                     cluster_id: 123,
                     members,
@@ -140,7 +140,7 @@ async fn test_unary_fetch_clusters_linearizable() {
             .return_once(move |_req, _timeout| {
                 let resp = match id {
                     0 => FetchClusterResponse {
-                        leader_id: Some(0),
+                        leader_id: 1,
                         term: 2,
                         cluster_id: 123,
                         members: vec![
@@ -153,22 +153,22 @@ async fn test_unary_fetch_clusters_linearizable() {
                         cluster_version: 1,
                     },
                     1 | 4 => FetchClusterResponse {
-                        leader_id: Some(0),
+                        leader_id: 1,
                         term: 2,
                         cluster_id: 123,
                         members: vec![], // linearizable read from follower returns empty members
                         cluster_version: 1,
                     },
                     2 => FetchClusterResponse {
-                        leader_id: None,
+                        leader_id: 0,
                         term: 23, // abnormal term
                         cluster_id: 123,
                         members: vec![],
                         cluster_version: 1,
                     },
                     3 => FetchClusterResponse {
-                        leader_id: Some(3), // imagine this node is a old leader
-                        term: 1,            // with the old term
+                        leader_id: 3, // imagine this node is a old leader
+                        term: 1,      // with the old term
                         cluster_id: 123,
                         members: vec![
                             Member::new(0, "S0", vec!["B0".to_owned()], [], false),
@@ -206,7 +206,7 @@ async fn test_unary_fetch_clusters_linearizable_failed() {
             .return_once(move |_req, _timeout| {
                 let resp = match id {
                     0 => FetchClusterResponse {
-                        leader_id: Some(0),
+                        leader_id: 1,
                         term: 2,
                         cluster_id: 123,
                         members: vec![
@@ -219,22 +219,22 @@ async fn test_unary_fetch_clusters_linearizable_failed() {
                         cluster_version: 1,
                     },
                     1 => FetchClusterResponse {
-                        leader_id: Some(0),
+                        leader_id: 1,
                         term: 2,
                         cluster_id: 123,
                         members: vec![], // linearizable read from follower returns empty members
                         cluster_version: 1,
                     },
                     2 => FetchClusterResponse {
-                        leader_id: None, // imagine this node is a disconnected candidate
-                        term: 23,        // with a high term
+                        leader_id: 0, // imagine this node is a disconnected candidate
+                        term: 23,     // with a high term
                         cluster_id: 123,
                         members: vec![],
                         cluster_version: 1,
                     },
                     3 => FetchClusterResponse {
-                        leader_id: Some(3), // imagine this node is a old leader
-                        term: 1,            // with the old term
+                        leader_id: 3, // imagine this node is a old leader
+                        term: 1,      // with the old term
                         cluster_id: 123,
                         members: vec![
                             Member::new(0, "S0", vec!["B0".to_owned()], [], false),
@@ -246,8 +246,8 @@ async fn test_unary_fetch_clusters_linearizable_failed() {
                         cluster_version: 1,
                     },
                     4 => FetchClusterResponse {
-                        leader_id: Some(3), // imagine this node is a old follower of old leader(3)
-                        term: 1,            // with the old term
+                        leader_id: 3, // imagine this node is a old follower of old leader(3)
+                        term: 1,      // with the old term
                         cluster_id: 123,
                         members: vec![],
                         cluster_version: 1,
@@ -420,7 +420,7 @@ async fn test_unary_slow_round_fetch_leader_first() {
             .return_once(move |_req, _timeout| {
                 flag_c.store(true, std::sync::atomic::Ordering::Relaxed);
                 Ok(tonic::Response::new(FetchClusterResponse {
-                    leader_id: Some(0),
+                    leader_id: 1,
                     term: 1,
                     cluster_id: 123,
                     members: vec![
@@ -684,7 +684,7 @@ async fn test_retry_propose_return_retry_error() {
             conn.expect_fetch_cluster()
                 .returning(move |_req, _timeout| {
                     Ok(tonic::Response::new(FetchClusterResponse {
-                        leader_id: Some(0),
+                        leader_id: 1,
                         term: 2,
                         cluster_id: 123,
                         members: vec![
@@ -940,7 +940,7 @@ async fn test_stream_client_keep_alive_resume_on_leadership_changed() {
         tokio::time::sleep(Duration::from_millis(100)).await;
         // check the local id
         assert_ne!(stream.state.client_id(), 0);
-        stream.state.check_and_update_leader(Some(1), 2).await;
+        stream.state.check_and_update_leader(1, 2).await;
         // wait for stream to resume
         tokio::time::sleep(Duration::from_millis(100)).await;
     };

--- a/crates/curp/src/client/unary.rs
+++ b/crates/curp/src/client/unary.rs
@@ -348,7 +348,7 @@ impl<C: Command> ClientApi for Unary<C> {
                 }
             };
             // Ignore the response of a node that doesn't know who the leader is.
-            if inner.leader_id.is_some() {
+            if inner.leader_id != 0 {
                 #[allow(clippy::arithmetic_side_effects)]
                 match max_term.cmp(&inner.term) {
                     Ordering::Less => {
@@ -546,7 +546,7 @@ impl<C: Command> RepeatableClientApi for Unary<C> {
 #[async_trait]
 impl<C: Command> LeaderStateUpdate for Unary<C> {
     /// Update leader
-    async fn update_leader(&self, leader_id: Option<ServerId>, term: u64) -> bool {
+    async fn update_leader(&self, leader_id: ServerId, term: u64) -> bool {
         self.state.check_and_update_leader(leader_id, term).await
     }
 }

--- a/crates/curp/src/members.rs
+++ b/crates/curp/src/members.rs
@@ -289,6 +289,10 @@ impl ClusterInfo {
     }
 
     /// Calculate the member id
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the calculated id is zero
     #[inline]
     #[must_use]
     pub fn calculate_member_id(
@@ -306,7 +310,10 @@ impl ClusterInfo {
         if let Some(ts) = timestamp {
             hasher.write_u64(ts);
         }
-        hasher.finish()
+        let id = hasher.finish();
+        // We use zero as an empty server id
+        assert_ne!(id, 0, "Server id should not be zero");
+        id
     }
 
     /// Calculate the cluster id

--- a/crates/curp/src/rpc/mod.rs
+++ b/crates/curp/src/rpc/mod.rs
@@ -110,7 +110,7 @@ impl FetchClusterResponse {
         cluster_version: u64,
     ) -> Self {
         Self {
-            leader_id,
+            leader_id: leader_id.unwrap_or(0),
             term,
             cluster_id,
             members,
@@ -674,7 +674,10 @@ impl CurpError {
 
     /// `Redirect` error
     pub(crate) fn redirect(leader_id: Option<ServerId>, term: u64) -> Self {
-        Self::Redirect(Redirect { leader_id, term })
+        Self::Redirect(Redirect {
+            leader_id: leader_id.unwrap_or(0),
+            term,
+        })
     }
 
     /// `Internal` error

--- a/crates/curp/src/server/raw_curp/tests.rs
+++ b/crates/curp/src/server/raw_curp/tests.rs
@@ -845,7 +845,7 @@ fn follower_handle_shutdown_will_reject() {
     assert!(matches!(
         res,
         Err(CurpError::Redirect(Redirect {
-            leader_id: None,
+            leader_id: 0,
             term: 1,
         }))
     ));
@@ -1114,7 +1114,7 @@ fn follower_handle_propose_conf_change() {
     assert!(matches!(
         result,
         Err(CurpError::Redirect(Redirect {
-            leader_id: None,
+            leader_id: 0,
             term: 2,
         }))
     ));

--- a/crates/simulation/tests/it/curp/server_election.rs
+++ b/crates/simulation/tests/it/curp/server_election.rs
@@ -49,11 +49,7 @@ async fn election() {
 
     // check after some time, the term and the leader is still not changed
     sleep_secs(15).await;
-    let leader2 = group
-        .try_get_leader()
-        .await
-        .expect("There should be one leader")
-        .0;
+    let leader2 = group.try_get_leader().await.0;
     let term2 = group.get_term_checked().await;
     check_role_state(&group, 5, leader0);
 
@@ -102,7 +98,7 @@ async fn reelect() {
 
     // after some time, no leader should be elected
     sleep_secs(15).await;
-    assert!(group.try_get_leader().await.is_none());
+    assert_eq!(group.try_get_leader().await.0, 0);
 
     // recover network partition
     println!("enable all");

--- a/crates/simulation/tests/it/curp/server_recovery.rs
+++ b/crates/simulation/tests/it/curp/server_recovery.rs
@@ -17,7 +17,7 @@ async fn leader_crash_and_recovery() {
     let mut group = CurpGroup::new(5).await;
     let client = group.new_client().await;
 
-    let leader = group.try_get_leader().await.unwrap().0;
+    let leader = group.try_get_leader().await.0;
     group.crash(leader).await;
 
     // wait for election, or we might get Duplicated Error
@@ -71,7 +71,7 @@ async fn follower_crash_and_recovery() {
     let mut group = CurpGroup::new(5).await;
     let client = group.new_client().await;
 
-    let leader = group.try_get_leader().await.unwrap().0;
+    let leader = group.try_get_leader().await.0;
     let follower = *group.nodes.keys().find(|&id| id != &leader).unwrap();
     group.crash(follower).await;
 
@@ -118,7 +118,7 @@ async fn leader_and_follower_both_crash_and_recovery() {
     let mut group = CurpGroup::new(5).await;
     let client = group.new_client().await;
 
-    let leader = group.try_get_leader().await.unwrap().0;
+    let leader = group.try_get_leader().await.0;
     let follower = *group.nodes.keys().find(|&id| id != &leader).unwrap();
     group.crash(follower).await;
 


### PR DESCRIPTION
Some gRPC implementations don't support the `optional` field, which was introduced in a later version. For better compatibility, I suggest removing all `optional` fields.

In our case, only the `leader_id` in the CURP protocol uses an optional field. We can switch to using a zero value to represent an empty `leader_id`.

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
