### PR TITLE
refactor: use a custom `OptionalU64` to replace Option<u64>

### DIFF
--- a/crates/curp/src/client/retry.rs
+++ b/crates/curp/src/client/retry.rs
@@ -174,8 +174,14 @@ where
                 }
 
                 // update the leader state if got Redirect
-                CurpError::Redirect(Redirect { leader_id, term }) => {
-                    let _ig = self.inner.update_leader(leader_id, term).await;
+                CurpError::Redirect(Redirect {
+                    ref leader_id,
+                    term,
+                }) => {
+                    let _ig = self
+                        .inner
+                        .update_leader(leader_id.as_ref().map(Into::into), term)
+                        .await;
                 }
             }
 

--- a/crates/curp/src/client/state.rs
+++ b/crates/curp/src/client/state.rs
@@ -242,7 +242,11 @@ impl State {
         res: &FetchClusterResponse,
     ) -> Result<(), tonic::transport::Error> {
         let mut state = self.mutable.write().await;
-        if !self.check_and_update_leader_inner(&mut state, res.leader_id, res.term) {
+        if !self.check_and_update_leader_inner(
+            &mut state,
+            res.leader_id.as_ref().map(Into::into),
+            res.term,
+        ) {
             return Ok(());
         }
         if state.cluster_version == res.cluster_version {

--- a/crates/curp/src/client/stream.rs
+++ b/crates/curp/src/client/stream.rs
@@ -76,7 +76,10 @@ impl Streaming {
                     #[allow(clippy::wildcard_enum_match_arm)]
                     match err {
                         CurpError::Redirect(Redirect { leader_id, term }) => {
-                            let _ig = self.state.check_and_update_leader(leader_id, term).await;
+                            let _ig = self
+                                .state
+                                .check_and_update_leader(leader_id.map(Into::into), term)
+                                .await;
                         }
                         CurpError::WrongClusterVersion(()) => {
                             warn!(

--- a/crates/curp/src/client/tests.rs
+++ b/crates/curp/src/client/tests.rs
@@ -82,7 +82,7 @@ async fn test_unary_fetch_clusters_serializable() {
     let connects = init_mocked_connects(3, |_id, conn| {
         conn.expect_fetch_cluster().return_once(|_req, _timeout| {
             Ok(tonic::Response::new(FetchClusterResponse {
-                leader_id: Some(0),
+                leader_id: Some(0.into()),
                 term: 1,
                 cluster_id: 123,
                 members: vec![
@@ -119,7 +119,7 @@ async fn test_unary_fetch_clusters_serializable_local_first() {
                     panic!("other server's `fetch_cluster` should not be invoked");
                 };
                 Ok(tonic::Response::new(FetchClusterResponse {
-                    leader_id: Some(0),
+                    leader_id: Some(0.into()),
                     term: 1,
                     cluster_id: 123,
                     members,
@@ -140,7 +140,7 @@ async fn test_unary_fetch_clusters_linearizable() {
             .return_once(move |_req, _timeout| {
                 let resp = match id {
                     0 => FetchClusterResponse {
-                        leader_id: Some(0),
+                        leader_id: Some(0.into()),
                         term: 2,
                         cluster_id: 123,
                         members: vec![
@@ -153,7 +153,7 @@ async fn test_unary_fetch_clusters_linearizable() {
                         cluster_version: 1,
                     },
                     1 | 4 => FetchClusterResponse {
-                        leader_id: Some(0),
+                        leader_id: Some(0.into()),
                         term: 2,
                         cluster_id: 123,
                         members: vec![], // linearizable read from follower returns empty members
@@ -167,8 +167,8 @@ async fn test_unary_fetch_clusters_linearizable() {
                         cluster_version: 1,
                     },
                     3 => FetchClusterResponse {
-                        leader_id: Some(3), // imagine this node is a old leader
-                        term: 1,            // with the old term
+                        leader_id: Some(3.into()), // imagine this node is a old leader
+                        term: 1,                   // with the old term
                         cluster_id: 123,
                         members: vec![
                             Member::new(0, "S0", vec!["B0".to_owned()], [], false),
@@ -206,7 +206,7 @@ async fn test_unary_fetch_clusters_linearizable_failed() {
             .return_once(move |_req, _timeout| {
                 let resp = match id {
                     0 => FetchClusterResponse {
-                        leader_id: Some(0),
+                        leader_id: Some(0.into()),
                         term: 2,
                         cluster_id: 123,
                         members: vec![
@@ -219,7 +219,7 @@ async fn test_unary_fetch_clusters_linearizable_failed() {
                         cluster_version: 1,
                     },
                     1 => FetchClusterResponse {
-                        leader_id: Some(0),
+                        leader_id: Some(0.into()),
                         term: 2,
                         cluster_id: 123,
                         members: vec![], // linearizable read from follower returns empty members
@@ -233,8 +233,8 @@ async fn test_unary_fetch_clusters_linearizable_failed() {
                         cluster_version: 1,
                     },
                     3 => FetchClusterResponse {
-                        leader_id: Some(3), // imagine this node is a old leader
-                        term: 1,            // with the old term
+                        leader_id: Some(3.into()), // imagine this node is a old leader
+                        term: 1,                   // with the old term
                         cluster_id: 123,
                         members: vec![
                             Member::new(0, "S0", vec!["B0".to_owned()], [], false),
@@ -246,8 +246,8 @@ async fn test_unary_fetch_clusters_linearizable_failed() {
                         cluster_version: 1,
                     },
                     4 => FetchClusterResponse {
-                        leader_id: Some(3), // imagine this node is a old follower of old leader(3)
-                        term: 1,            // with the old term
+                        leader_id: Some(3.into()), // imagine this node is a old follower of old leader(3)
+                        term: 1,                   // with the old term
                         cluster_id: 123,
                         members: vec![],
                         cluster_version: 1,
@@ -420,7 +420,7 @@ async fn test_unary_slow_round_fetch_leader_first() {
             .return_once(move |_req, _timeout| {
                 flag_c.store(true, std::sync::atomic::Ordering::Relaxed);
                 Ok(tonic::Response::new(FetchClusterResponse {
-                    leader_id: Some(0),
+                    leader_id: Some(0.into()),
                     term: 1,
                     cluster_id: 123,
                     members: vec![
@@ -684,7 +684,7 @@ async fn test_retry_propose_return_retry_error() {
             conn.expect_fetch_cluster()
                 .returning(move |_req, _timeout| {
                     Ok(tonic::Response::new(FetchClusterResponse {
-                        leader_id: Some(0),
+                        leader_id: Some(0.into()),
                         term: 2,
                         cluster_id: 123,
                         members: vec![

--- a/crates/curp/src/rpc/mod.rs
+++ b/crates/curp/src/rpc/mod.rs
@@ -34,6 +34,7 @@ pub use self::proto::{
         Member,
         MoveLeaderRequest,
         MoveLeaderResponse,
+        OptionalU64,
         ProposeConfChangeRequest,
         ProposeConfChangeResponse,
         ProposeId as PbProposeId,
@@ -100,6 +101,27 @@ impl From<ProposeId> for PbProposeId {
     }
 }
 
+impl From<u64> for OptionalU64 {
+    #[inline]
+    fn from(value: u64) -> Self {
+        Self { value }
+    }
+}
+
+impl From<OptionalU64> for u64 {
+    #[inline]
+    fn from(value: OptionalU64) -> Self {
+        value.value
+    }
+}
+
+impl From<&OptionalU64> for u64 {
+    #[inline]
+    fn from(value: &OptionalU64) -> Self {
+        value.value
+    }
+}
+
 impl FetchClusterResponse {
     /// Create a new `FetchClusterResponse`
     pub(crate) fn new(
@@ -110,7 +132,7 @@ impl FetchClusterResponse {
         cluster_version: u64,
     ) -> Self {
         Self {
-            leader_id,
+            leader_id: leader_id.map(Into::into),
             term,
             cluster_id,
             members,
@@ -674,7 +696,10 @@ impl CurpError {
 
     /// `Redirect` error
     pub(crate) fn redirect(leader_id: Option<ServerId>, term: u64) -> Self {
-        Self::Redirect(Redirect { leader_id, term })
+        Self::Redirect(Redirect {
+            leader_id: leader_id.map(Into::into),
+            term,
+        })
     }
 
     /// `Internal` error

--- a/crates/curp/tests/it/common/curp_group.rs
+++ b/crates/curp/tests/it/common/curp_group.rs
@@ -434,7 +434,7 @@ impl CurpGroup {
                 leader = leader_id;
             }
         }
-        leader.map(|l| (l, max_term))
+        leader.map(|l| (l.value, max_term))
     }
 
     pub async fn get_leader(&self) -> (ServerId, u64) {
@@ -506,7 +506,7 @@ impl CurpGroup {
             .map(|m| Member::new(m.id, m.name, m.peer_urls, m.client_urls, m.is_learner))
             .collect();
         let cluster_res = curp::rpc::FetchClusterResponse {
-            leader_id: cluster_res_base.leader_id,
+            leader_id: cluster_res_base.leader_id.map(|l| l.value.into()),
             term: cluster_res_base.term,
             cluster_id: cluster_res_base.cluster_id,
             members,

--- a/crates/simulation/src/curp_group.rs
+++ b/crates/simulation/src/curp_group.rs
@@ -253,7 +253,7 @@ impl CurpGroup {
                         leader = leader_id;
                     }
                 }
-                leader.map(|l| (l, max_term))
+                leader.map(|l| (l.into(), max_term))
             })
             .await
             .unwrap()


### PR DESCRIPTION
Make it competible with gRPC implementations that do not support the `optional` keyword

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
