### PR TITLE
fix(ci): free disk space to avoid CI runs out of space problem

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,12 +17,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Setup sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.5
 
   call_build_xline:
     name: Build and Upload Artifacts

--- a/.github/workflows/build_env.yml
+++ b/.github/workflows/build_env.yml
@@ -1,7 +1,11 @@
 name: Build CI Env Image
 
 on:
-  workflow_dispatch: {}
+  push:
+    paths:
+      - "ci/build-env.sh"
+      - "ci/Dockerfile"
+  workflow_dispatch:
 
 jobs:
   build_env:

--- a/.github/workflows/build_xline.yml
+++ b/.github/workflows/build_xline.yml
@@ -39,12 +39,9 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Setup sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.5
+
       - name: Prepare release binaries
         id: prepare_binaries
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,8 +14,15 @@ jobs:
       run:
         shell: bash
     env:
-      SCCACHE_GHA_ENABLED: "on"
-    container: ghcr.io/xline-kv/build-env:latest
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: 0 # CI will compile all crates from beginning. So disable incremental compile may reduce compile target size.
+    container:
+      image: ghcr.io/xline-kv/build-env:latest
+      volumes:
+        - /usr/local/lib/android/:/tmp/android/
+        - /usr/share/dotnet:/tmp/dotnet
+        - /opt/ghc:/tmp/ghc
+        - /usr/lib/firefox:/tmp/firefox
     strategy:
       fail-fast: true
       matrix:
@@ -34,16 +41,25 @@ jobs:
             }
     name: Tests ${{ matrix.config.name }}
     steps:
+      - name: View free disk space
+        run: df -h /
+
+      - name: Setup sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.5
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Free Disk Space
+        run: |
+          rm -rf /tmp/android/* || true
+          rm -rf /tmp/dotnet/* || true
+          rm -rf /tmp/ghc/* || true
+          rm -rf /tmp/firefox/* || true
+
+      - name: View free disk space
+        run: df -h /
 
       - name: Trailing spaces check
         run: ci/scripts/check-trailing-spaces.sh
@@ -63,7 +79,7 @@ jobs:
       - name: Workspace hack check
         run: cargo hakari generate --diff && cargo hakari manage-deps --dry-run && cargo hakari verify
 
-      - run: sccache --zero-stats > /dev/null
+      - run: ${SCCACHE_PATH} --zero-stats > /dev/null
 
       - name: Clippy ${{ matrix.config.name }}
         env:
@@ -71,7 +87,7 @@ jobs:
         run: cargo clippy ${{ matrix.config.args }} --all-targets --all-features -- -D warnings
 
       - name: Sccache stats ${{ matrix.config.name }}
-        run: sccache --show-stats && sccache --zero-stats > /dev/null
+        run: ${SCCACHE_PATH} --show-stats && ${SCCACHE_PATH} --zero-stats > /dev/null
 
       - name: Test ${{ matrix.config.name }}
         env:
@@ -79,7 +95,7 @@ jobs:
         run: cargo ${{ matrix.config.test }}
 
       - name: Sccache stats ${{ matrix.config.name }}
-        run: sccache --show-stats
+        run: ${SCCACHE_PATH} --show-stats
 
       - name: Upload coverage to Codecov
         if: matrix.config.name == 'Normal'
@@ -122,12 +138,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Setup sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.5
 
       - name: Build xline image
         run: |

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -16,18 +16,14 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Setup sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.5
 
   call_build_xline:
     name: Build and Upload Artifacts
     uses: ./.github/workflows/build_xline.yml
     with:
-      docker_xline_image: 'ghcr.io/xline-kv/build-env:latest'
+      docker_xline_image: "ghcr.io/xline-kv/build-env:latest"
       additional_setup_commands: |
         sudo apt-get install -y --force-yes expect
         ldd ./xline
@@ -35,6 +31,6 @@ jobs:
         cp ../fixtures/{private,public}.pem .
         docker build . -t ghcr.io/xline-kv/xline:latest
         docker pull gcr.io/etcd-development/etcd:v3.5.5
-      binaries: 'xline,benchmark'
-      script_name: 'validation_test.sh'
+      binaries: "xline,benchmark"
+      script_name: "validation_test.sh"
       uploadLogs: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ madsim = { git = "https://github.com/Phoenix500526/madsim.git", branch = "update
 madsim-tonic = { git = "https://github.com/Phoenix500526/madsim.git", branch = "update-tonic" }
 madsim-tonic-build = { git = "https://github.com/Phoenix500526/madsim.git", branch = "update-tonic" }
 madsim-tokio = { git = "https://github.com/Phoenix500526/madsim.git", branch = "update-tonic" }
+

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -28,9 +28,7 @@ RUN echo "=== Install rusty stuff 🦀️ ===" && \
     rustup component add rustfmt llvm-tools clippy && \
     rustup show -v && \
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash && \
-    cargo binstall -y --no-symlinks cargo-llvm-cov cargo-nextest cargo-hakari cargo-sort cargo-cache cargo-audit cargo-machete && \
-    cargo install --locked sccache && \
-    cargo cache --autoclean && \
+    cargo binstall -y --no-symlinks cargo-llvm-cov cargo-nextest cargo-hakari cargo-sort cargo-cache cargo-audit cargo-machete sccache && \
     rm -rf "/root/.cargo/registry/index" && \
     rm -rf "/root/.cargo/registry/cache" && \
     rm -rf "/root/.cargo/git/db" && \
@@ -65,3 +63,4 @@ ENV CARGO_TERM_COLOR=always
 
 # Enable sccache
 ENV RUSTC_WRAPPER="sccache"
+ENV SCCACHE_GHA_ENABLED="true"


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    - The CI failed a lot of time without error message, and it's not problem of code. When retry, the ci may pass, or fail as same.
    - related ci: https://github.com/xline-kv/Xline/actions/runs/10209311482/job/28247138131?pr=880
    - after one failure, i captured the output of github: 
![图片](https://github.com/user-attachments/assets/7a57bafb-eba5-46a8-8c24-1a904e864fd3)


* what changes does this pull request make?

    - ~~introduce [free-disk-space](https://github.com/marketplace/actions/free-disk-space-ubuntu)~~
    - mount some big dirs to image, and delete them manually.
    - use sccache action instead of set up variables manually.
    
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

    - no