### PR TITLE
refactor: after sync implementation

### DIFF
--- a/crates/curp-external-api/src/cmd.rs
+++ b/crates/curp-external-api/src/cmd.rs
@@ -109,7 +109,7 @@ where
         &self,
         cmds: Vec<AfterSyncCmd<'_, C>>,
         highest_index: LogIndex,
-    ) -> Result<Vec<(C::ASR, Option<C::ER>)>, C::Error>;
+    ) -> Vec<Result<AfterSyncOk<C>, C::Error>>;
 
     /// Set the index of the last log entry that has been successfully applied
     /// to the command executor
@@ -207,7 +207,31 @@ impl<'a, C> AfterSyncCmd<'a, C> {
     /// Convert self into parts
     #[inline]
     #[must_use]
-    pub fn into_parts(self) -> (&'a C, bool) {
+    pub fn into_parts(&'a self) -> (&'a C, bool) {
         (self.cmd, self.to_exectue)
+    }
+}
+
+/// Ok type of the after sync result
+#[derive(Debug)]
+pub struct AfterSyncOk<C: Command> {
+    /// After Sync Result
+    asr: C::ASR,
+    /// Optional Execution Result
+    er_opt: Option<C::ER>,
+}
+
+impl<C: Command> AfterSyncOk<C> {
+    /// Creates a new [`AfterSyncOk<C>`].
+    #[inline]
+    pub fn new(asr: C::ASR, er_opt: Option<C::ER>) -> Self {
+        Self { asr, er_opt }
+    }
+
+    /// Decomposes `AfterSyncOk` into its constituent parts.
+    #[inline]
+    pub fn into_parts(self) -> (C::ASR, Option<C::ER>) {
+        let Self { asr, er_opt } = self;
+        (asr, er_opt)
     }
 }

--- a/crates/curp-external-api/src/cmd.rs
+++ b/crates/curp-external-api/src/cmd.rs
@@ -105,7 +105,7 @@ where
     fn execute(&self, cmd: &C) -> Result<C::ER, C::Error>;
 
     /// Batch execute the after_sync callback
-    async fn after_sync(
+    fn after_sync(
         &self,
         cmds: Vec<AfterSyncCmd<'_, C>>,
         highest_index: LogIndex,

--- a/crates/curp-test-utils/src/test_cmd.rs
+++ b/crates/curp-test-utils/src/test_cmd.rs
@@ -18,7 +18,7 @@ use engine::{
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tokio::{sync::mpsc, time::sleep};
+use tokio::sync::mpsc;
 use tracing::debug;
 use utils::config::EngineConfig;
 
@@ -284,7 +284,7 @@ impl CommandExecutor<TestCommand> for TestCE {
         Ok(result)
     }
 
-    async fn after_sync(
+    fn after_sync(
         &self,
         cmds: Vec<AfterSyncCmd<'_, TestCommand>>,
         highest_index: LogIndex,
@@ -298,7 +298,7 @@ impl CommandExecutor<TestCommand> for TestCE {
         let as_duration = cmds
             .iter()
             .fold(Duration::default(), |acc, c| acc + c.cmd().as_dur);
-        sleep(as_duration).await;
+        std::thread::sleep(as_duration);
         if cmds.iter().any(|c| c.cmd().as_should_fail) {
             return Err(ExecuteError("fail".to_owned()));
         }

--- a/crates/curp/src/client/stream.rs
+++ b/crates/curp/src/client/stream.rs
@@ -29,6 +29,9 @@ pub(super) struct Streaming {
     config: StreamingConfig,
 }
 
+/// Prevent lock contention when leader crashed or some unknown errors
+const RETRY_DELAY: Duration = Duration::from_millis(100);
+
 impl Streaming {
     /// Create a stream client
     pub(super) fn new(state: Arc<State>, config: StreamingConfig) -> Self {
@@ -43,8 +46,9 @@ impl Streaming {
     ) -> Result<R, CurpError> {
         loop {
             let Some(leader_id) = self.state.leader_id().await else {
-                debug!("cannot find the leader id in state, wait for leadership update");
-                self.state.leader_notifier().listen().await;
+                warn!("cannot find leader_id, refreshing state...");
+                let _ig = self.state.try_refresh_state().await;
+                tokio::time::sleep(RETRY_DELAY).await;
                 continue;
             };
             if let Some(local_id) = self.state.local_server_id() {
@@ -61,8 +65,6 @@ impl Streaming {
 
     /// Keep heartbeat
     pub(super) async fn keep_heartbeat(&self) {
-        /// Prevent lock contention when leader crashed or some unknown errors
-        const RETRY_DELAY: Duration = Duration::from_millis(100);
         #[allow(clippy::ignored_unit_patterns)] // tokio select internal triggered
         loop {
             let heartbeat = self.map_remote_leader::<(), _>(|conn| async move {
@@ -87,6 +89,13 @@ impl Streaming {
                         CurpError::ShuttingDown(()) => {
                             debug!("shutting down stream client background task");
                             break Err(err);
+                        }
+                        CurpError::RpcTransport(()) => {
+                            warn!(
+                                "got rpc transport error when keep heartbeat, refreshing state..."
+                            );
+                            let _ig = self.state.try_refresh_state().await;
+                            tokio::time::sleep(RETRY_DELAY).await;
                         }
                         _ => {
                             warn!("got unexpected error {err:?} when keep heartbeat, retrying...");

--- a/crates/curp/src/server/cmd_worker/mod.rs
+++ b/crates/curp/src/server/cmd_worker/mod.rs
@@ -97,7 +97,7 @@ async fn after_sync_cmds<C: Command, CE: CommandExecutor<C>, RC: RoleChange>(
         })
         .collect();
 
-    match ce.after_sync(cmds, highest_index).await {
+    match ce.after_sync(cmds, highest_index) {
         Ok(resps) => {
             for ((asr, er_opt), tx) in resps
                 .into_iter()

--- a/crates/simulation/tests/it/curp/server_recovery.rs
+++ b/crates/simulation/tests/it/curp/server_recovery.rs
@@ -193,6 +193,8 @@ async fn new_leader_will_recover_spec_cmds_cond1() {
         }),
         command: bincode::serialize(&cmd1).unwrap(),
         cluster_version: 0,
+        term: 1,
+        slow_path: false,
     };
     for id in group
         .all_members
@@ -201,7 +203,7 @@ async fn new_leader_will_recover_spec_cmds_cond1() {
         .take(4)
     {
         let mut connect = group.get_connect(id).await;
-        connect.propose(req1.clone()).await.unwrap();
+        connect.propose_stream(req1.clone()).await.unwrap();
     }
 
     // 2: disable leader1 and wait election
@@ -304,9 +306,11 @@ async fn old_leader_will_keep_original_states() {
         }),
         command: bincode::serialize(&cmd1).unwrap(),
         cluster_version: 0,
+        term: 1,
+        slow_path: false,
     };
     let mut leader1_connect = group.get_connect(&leader1).await;
-    leader1_connect.propose(req1).await.unwrap();
+    leader1_connect.propose_stream(req1).await.unwrap();
 
     // 3: recover all others and disable leader, a new leader will be elected
     group.disable_node(leader1);

--- a/crates/xline/src/server/command.rs
+++ b/crates/xline/src/server/command.rs
@@ -359,7 +359,7 @@ impl<'a> ASResults<'a> {
     where
         F: Fn(&AfterSyncCmd<'_, Command>) -> Result<(), ExecuteError>,
     {
-        self.map_results(|(cmd, result_opt)| {
+        self.for_each_none_result(|(cmd, result_opt)| {
             if let Err(e) = op(cmd) {
                 let _ignore = result_opt.replace(Err(e));
             }
@@ -372,14 +372,14 @@ impl<'a> ASResults<'a> {
     where
         F: Fn(&AfterSyncCmd<'_, Command>) -> AfterSyncResult,
     {
-        self.map_results(|(cmd, result_opt)| {
+        self.for_each_none_result(|(cmd, result_opt)| {
             let _ignore = result_opt.replace(op(cmd));
         });
     }
 
-    /// Applies a given operation to each command-result pair in `cmd_results` where the result is `None`.
+    /// Applies the provided operation to each command-result pair in `cmd_results` where the result is `None`.
     #[allow(clippy::pattern_type_mismatch)] // can't be fixed
-    fn map_results<F>(&mut self, op: F)
+    fn for_each_none_result<F>(&mut self, op: F)
     where
         F: FnMut(&mut (AfterSyncCmd<'_, Command>, Option<AfterSyncResult>)),
     {

--- a/crates/xline/src/server/watch_server.rs
+++ b/crates/xline/src/server/watch_server.rs
@@ -443,7 +443,7 @@ mod test {
             && wr.header.as_ref().map_or(false, |h| h.revision != 0)
     }
 
-    async fn put(store: &KvStore, key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) {
+    fn put(store: &KvStore, key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) {
         let req = RequestWrapper::from(PutRequest {
             key: key.into(),
             value: value.into(),
@@ -604,8 +604,8 @@ mod test {
             Duration::from_millis(10),
             &task_manager,
         );
-        put(&kv_store, "foo", "old_bar").await;
-        put(&kv_store, "foo", "bar").await;
+        put(&kv_store, "foo", "old_bar");
+        put(&kv_store, "foo", "bar");
 
         let (req_tx, req_rx) = mpsc::channel(CHANNEL_SIZE);
         let req_stream = ReceiverStream::new(req_rx);
@@ -790,9 +790,9 @@ mod test {
             Duration::from_millis(10),
             &task_manager,
         );
-        put(&kv_store, "foo", "old_bar").await;
-        put(&kv_store, "foo", "bar").await;
-        put(&kv_store, "foo", "new_bar").await;
+        put(&kv_store, "foo", "old_bar");
+        put(&kv_store, "foo", "bar");
+        put(&kv_store, "foo", "new_bar");
 
         kv_store.update_compacted_revision(3);
 

--- a/crates/xline/src/server/watch_server.rs
+++ b/crates/xline/src/server/watch_server.rs
@@ -459,7 +459,6 @@ mod test {
                 &store.revision_gen().state(),
                 false,
             )
-            .await
             .unwrap();
     }
 
@@ -584,13 +583,13 @@ mod test {
     #[abort_on_panic]
     async fn test_watch_prev_kv() {
         let task_manager = Arc::new(TaskManager::new());
-        let (compact_tx, _compact_rx) = mpsc::channel(COMPACT_CHANNEL_SIZE);
+        let (compact_tx, _compact_rx) = flume::bounded(COMPACT_CHANNEL_SIZE);
         let index = Arc::new(Index::new());
         let db = DB::open(&EngineConfig::Memory).unwrap();
         let header_gen = Arc::new(HeaderGenerator::new(0, 0));
         let lease_collection = Arc::new(LeaseCollection::new(0));
         let next_id_gen = Arc::new(WatchIdGenerator::new(1));
-        let (kv_update_tx, kv_update_rx) = mpsc::channel(CHANNEL_SIZE);
+        let (kv_update_tx, kv_update_rx) = flume::bounded(CHANNEL_SIZE);
         let kv_store_inner = Arc::new(KvStoreInner::new(index, Arc::clone(&db)));
         let kv_store = Arc::new(KvStore::new(
             Arc::clone(&kv_store_inner),
@@ -770,13 +769,13 @@ mod test {
     #[tokio::test]
     async fn watch_compacted_revision_should_fail() {
         let task_manager = Arc::new(TaskManager::new());
-        let (compact_tx, _compact_rx) = mpsc::channel(COMPACT_CHANNEL_SIZE);
+        let (compact_tx, _compact_rx) = flume::bounded(COMPACT_CHANNEL_SIZE);
         let index = Arc::new(Index::new());
         let db = DB::open(&EngineConfig::Memory).unwrap();
         let header_gen = Arc::new(HeaderGenerator::new(0, 0));
         let lease_collection = Arc::new(LeaseCollection::new(0));
         let next_id_gen = Arc::new(WatchIdGenerator::new(1));
-        let (kv_update_tx, kv_update_rx) = mpsc::channel(CHANNEL_SIZE);
+        let (kv_update_tx, kv_update_rx) = flume::bounded(CHANNEL_SIZE);
         let kv_store_inner = Arc::new(KvStoreInner::new(index, Arc::clone(&db)));
         let kv_store = Arc::new(KvStore::new(
             Arc::clone(&kv_store_inner),

--- a/crates/xline/src/server/xline_server.rs
+++ b/crates/xline/src/server/xline_server.rs
@@ -17,7 +17,9 @@ use tokio::fs;
 #[cfg(not(madsim))]
 use tokio::io::{AsyncRead, AsyncWrite};
 #[cfg(not(madsim))]
-use tonic::transport::{server::Connected, Certificate, ClientTlsConfig, Identity, ServerTlsConfig};
+use tonic::transport::{
+    server::Connected, Certificate, ClientTlsConfig, Identity, ServerTlsConfig,
+};
 use tonic::transport::{server::Router, Server};
 use tracing::{info, warn};
 use utils::{

--- a/crates/xline/src/server/xline_server.rs
+++ b/crates/xline/src/server/xline_server.rs
@@ -13,13 +13,11 @@ use engine::{MemorySnapshotAllocator, RocksSnapshotAllocator, SnapshotAllocator}
 #[cfg(not(madsim))]
 use futures::Stream;
 use jsonwebtoken::{DecodingKey, EncodingKey};
+use tokio::fs;
 #[cfg(not(madsim))]
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::{fs, sync::mpsc::channel};
 #[cfg(not(madsim))]
-use tonic::transport::{
-    server::Connected, Certificate, ClientTlsConfig, Identity, ServerTlsConfig,
-};
+use tonic::transport::{server::Connected, Certificate, ClientTlsConfig, Identity, ServerTlsConfig};
 use tonic::transport::{server::Router, Server};
 use tracing::{info, warn};
 use utils::{
@@ -197,7 +195,8 @@ impl XlineServer {
         Arc::new(LeaseCollection::new(min_ttl_secs.numeric_cast()))
     }
 
-    /// Construct underlying storages, including `KvStore`, `LeaseStore`, `AuthStore`
+    /// Construct underlying storages, including `KvStore`, `LeaseStore`,
+    /// `AuthStore`
     #[allow(clippy::type_complexity)] // it is easy to read
     #[inline]
     async fn construct_underlying_storages(
@@ -213,9 +212,9 @@ impl XlineServer {
         Arc<AlarmStore>,
         Arc<KvWatcher>,
     )> {
-        let (compact_task_tx, compact_task_rx) = channel(COMPACT_CHANNEL_SIZE);
+        let (compact_task_tx, compact_task_rx) = flume::bounded(COMPACT_CHANNEL_SIZE);
         let index = Arc::new(Index::new());
-        let (kv_update_tx, kv_update_rx) = channel(CHANNEL_SIZE);
+        let (kv_update_tx, kv_update_rx) = flume::bounded(CHANNEL_SIZE);
         let kv_store_inner = Arc::new(KvStoreInner::new(Arc::clone(&index), Arc::clone(&db)));
         let kv_storage = Arc::new(KvStore::new(
             Arc::clone(&kv_store_inner),
@@ -426,8 +425,8 @@ impl XlineServer {
         self.start_inner(xline_incoming, curp_incoming).await
     }
 
-    /// Init `KvServer`, `LockServer`, `LeaseServer`, `WatchServer` and `CurpServer`
-    /// for the Xline Server.
+    /// Init `KvServer`, `LockServer`, `LeaseServer`, `WatchServer` and
+    /// `CurpServer` for the Xline Server.
     #[allow(
         clippy::type_complexity, // it is easy to read
         clippy::too_many_lines, // TODO: split this into multiple functions

--- a/crates/xline/src/storage/kv_store.rs
+++ b/crates/xline/src/storage/kv_store.rs
@@ -1308,9 +1308,7 @@ mod test {
         }
     }
 
-    async fn init_store(
-        db: Arc<DB>,
-    ) -> Result<(StoreWrapper, RevisionNumberGenerator), ExecuteError> {
+    fn init_store(db: Arc<DB>) -> Result<(StoreWrapper, RevisionNumberGenerator), ExecuteError> {
         let store = init_empty_store(db);
         let keys = vec!["a", "b", "c", "d", "e", "z", "z", "z"];
         let vals = vec!["a", "b", "c", "d", "e", "z1", "z2", "z3"];
@@ -1321,7 +1319,7 @@ mod test {
                 value: val.into(),
                 ..Default::default()
             });
-            exe_as_and_flush(&store, &req).await?;
+            exe_as_and_flush(&store, &req)?;
         }
         Ok((store, revision))
     }
@@ -1360,7 +1358,7 @@ mod test {
         StoreWrapper(Some(storage), task_manager)
     }
 
-    async fn exe_as_and_flush(
+    fn exe_as_and_flush(
         store: &Arc<KvStore>,
         request: &RequestWrapper,
     ) -> Result<(), ExecuteError> {
@@ -1389,7 +1387,7 @@ mod test {
     #[abort_on_panic]
     async fn test_keys_only() -> Result<(), ExecuteError> {
         let db = DB::open(&EngineConfig::Memory)?;
-        let (store, _rev) = init_store(db).await?;
+        let (store, _rev) = init_store(db)?;
         let request = RangeRequest {
             key: vec![0],
             range_end: vec![0],
@@ -1410,7 +1408,7 @@ mod test {
     #[abort_on_panic]
     async fn test_range_empty() -> Result<(), ExecuteError> {
         let db = DB::open(&EngineConfig::Memory)?;
-        let (store, _rev) = init_store(db).await?;
+        let (store, _rev) = init_store(db)?;
 
         let request = RangeRequest {
             key: "x".into(),
@@ -1430,7 +1428,7 @@ mod test {
     #[abort_on_panic]
     async fn test_range_filter() -> Result<(), ExecuteError> {
         let db = DB::open(&EngineConfig::Memory)?;
-        let (store, _rev) = init_store(db).await?;
+        let (store, _rev) = init_store(db)?;
 
         let request = RangeRequest {
             key: vec![0],
@@ -1455,7 +1453,7 @@ mod test {
     #[abort_on_panic]
     async fn test_range_sort() -> Result<(), ExecuteError> {
         let db = DB::open(&EngineConfig::Memory)?;
-        let (store, _rev) = init_store(db).await?;
+        let (store, _rev) = init_store(db)?;
         let keys = ["a", "b", "c", "d", "e", "z"];
         let reversed_keys = ["z", "e", "d", "c", "b", "a"];
         let version_keys = ["z", "a", "b", "c", "d", "e"];
@@ -1520,7 +1518,7 @@ mod test {
         let db = DB::open(&EngineConfig::Memory)?;
         let ops = vec![WriteOp::PutScheduledCompactRevision(8)];
         db.write_ops(ops)?;
-        let (store, _rev_gen) = init_store(Arc::clone(&db)).await?;
+        let (store, _rev_gen) = init_store(Arc::clone(&db))?;
         assert_eq!(store.inner.index.get_from_rev(b"z", b"", 5).len(), 3);
 
         let new_store = init_empty_store(db);
@@ -1590,8 +1588,8 @@ mod test {
             }],
         });
         let db = DB::open(&EngineConfig::Memory)?;
-        let (store, _rev) = init_store(db).await?;
-        exe_as_and_flush(&store, &txn_req).await?;
+        let (store, _rev) = init_store(db)?;
+        exe_as_and_flush(&store, &txn_req)?;
         let request = RangeRequest {
             key: "success".into(),
             range_end: vec![],
@@ -1612,7 +1610,7 @@ mod test {
     #[abort_on_panic]
     async fn test_kv_store_index_available() {
         let db = DB::open(&EngineConfig::Memory).unwrap();
-        let (store, _revision) = init_store(Arc::clone(&db)).await.unwrap();
+        let (store, _revision) = init_store(Arc::clone(&db)).unwrap();
         let handle = tokio::spawn({
             let store = Arc::clone(&store);
             async move {
@@ -1622,7 +1620,7 @@ mod test {
                         value: vec![i],
                         ..Default::default()
                     });
-                    exe_as_and_flush(&store, &req).await.unwrap();
+                    exe_as_and_flush(&store, &req).unwrap();
                 }
             }
         });
@@ -1667,7 +1665,7 @@ mod test {
         ];
 
         for req in requests {
-            exe_as_and_flush(&store, &req).await.unwrap();
+            exe_as_and_flush(&store, &req).unwrap();
         }
 
         let target_revisions = index_compact(&store, 3);

--- a/crates/xline/src/storage/kvwatcher.rs
+++ b/crates/xline/src/storage/kvwatcher.rs
@@ -654,7 +654,7 @@ mod test {
             let store = Arc::clone(&store);
             async move {
                 for i in 0..100_u8 {
-                    put(store.as_ref(), "foo", vec![i]).await;
+                    put(store.as_ref(), "foo", vec![i]);
                 }
             }
         });
@@ -716,7 +716,7 @@ mod test {
         });
 
         for i in 0..100_u8 {
-            put(store.as_ref(), "foo", vec![i]).await;
+            put(store.as_ref(), "foo", vec![i]);
         }
         handle.await.unwrap();
         drop(store);
@@ -747,7 +747,7 @@ mod test {
         task_manager.shutdown(true).await;
     }
 
-    async fn put(store: &KvStore, key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) {
+    fn put(store: &KvStore, key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) {
         let req = RequestWrapper::from(PutRequest {
             key: key.into(),
             value: value.into(),

--- a/crates/xline/src/storage/lease_store/mod.rs
+++ b/crates/xline/src/storage/lease_store/mod.rs
@@ -385,7 +385,7 @@ mod test {
         let rev_gen_state = rev_gen.state();
 
         let req1 = RequestWrapper::from(LeaseGrantRequest { ttl: 10, id: 1 });
-        let _ignore1 = exe_and_sync_req(&lease_store, &req1, &rev_gen_state).await?;
+        let _ignore1 = exe_and_sync_req(&lease_store, &req1, &rev_gen_state)?;
 
         let lo = lease_store.look_up(1).unwrap();
         assert_eq!(lo.id(), 1);
@@ -399,7 +399,7 @@ mod test {
         lease_store.lease_collection.detach(1, "key".as_bytes())?;
 
         let req2 = RequestWrapper::from(LeaseRevokeRequest { id: 1 });
-        let _ignore2 = exe_and_sync_req(&lease_store, &req2, &rev_gen_state).await?;
+        let _ignore2 = exe_and_sync_req(&lease_store, &req2, &rev_gen_state)?;
         assert!(lease_store.look_up(1).is_none());
         assert!(lease_store.leases().is_empty());
 
@@ -407,9 +407,9 @@ mod test {
         let req4 = RequestWrapper::from(LeaseGrantRequest { ttl: 10, id: 4 });
         let req5 = RequestWrapper::from(LeaseRevokeRequest { id: 3 });
         let req6 = RequestWrapper::from(LeaseLeasesRequest {});
-        let _ignore3 = exe_and_sync_req(&lease_store, &req3, &rev_gen_state).await?;
-        let _ignore4 = exe_and_sync_req(&lease_store, &req4, &rev_gen_state).await?;
-        let resp_1 = exe_and_sync_req(&lease_store, &req6, &rev_gen_state).await?;
+        let _ignore3 = exe_and_sync_req(&lease_store, &req3, &rev_gen_state)?;
+        let _ignore4 = exe_and_sync_req(&lease_store, &req4, &rev_gen_state)?;
+        let resp_1 = exe_and_sync_req(&lease_store, &req6, &rev_gen_state)?;
 
         let ResponseWrapper::LeaseLeasesResponse(leases_1) = resp_1 else {
             panic!("wrong response type: {resp_1:?}");
@@ -417,8 +417,8 @@ mod test {
         assert_eq!(leases_1.leases[0].id, 3);
         assert_eq!(leases_1.leases[1].id, 4);
 
-        let _ignore5 = exe_and_sync_req(&lease_store, &req5, &rev_gen_state).await?;
-        let resp_2 = exe_and_sync_req(&lease_store, &req6, &rev_gen_state).await?;
+        let _ignore5 = exe_and_sync_req(&lease_store, &req5, &rev_gen_state)?;
+        let resp_2 = exe_and_sync_req(&lease_store, &req6, &rev_gen_state)?;
         let ResponseWrapper::LeaseLeasesResponse(leases_2) = resp_2 else {
             panic!("wrong response type: {resp_2:?}");
         };
@@ -487,7 +487,7 @@ mod test {
         let rev_gen_state = rev_gen.state();
 
         let req1 = RequestWrapper::from(LeaseGrantRequest { ttl: 10, id: 1 });
-        let _ignore1 = exe_and_sync_req(&store, &req1, &rev_gen_state).await?;
+        let _ignore1 = exe_and_sync_req(&store, &req1, &rev_gen_state)?;
         store.lease_collection.attach(1, "key".into())?;
 
         let (new_store, _) = init_store(db);
@@ -516,7 +516,7 @@ mod test {
         )
     }
 
-    async fn exe_and_sync_req(
+    fn exe_and_sync_req(
         ls: &LeaseStore,
         req: &RequestWrapper,
         rev_gen: &RevisionNumberGeneratorState<'_>,

--- a/crates/xline/tests/it/kv_test.rs
+++ b/crates/xline/tests/it/kv_test.rs
@@ -12,6 +12,11 @@ use xline_test_utils::{
 #[tokio::test(flavor = "multi_thread")]
 #[abort_on_panic]
 async fn test_kv_put() -> Result<(), Box<dyn Error>> {
+    std::env::set_var("RUST_LOG", "curp=debug,xline=debug");
+    _ = tracing_subscriber::fmt()
+        .compact()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
     struct TestCase {
         key: &'static str,
         value: &'static str,

--- a/crates/xline/tests/it/kv_test.rs
+++ b/crates/xline/tests/it/kv_test.rs
@@ -12,11 +12,6 @@ use xline_test_utils::{
 #[tokio::test(flavor = "multi_thread")]
 #[abort_on_panic]
 async fn test_kv_put() -> Result<(), Box<dyn Error>> {
-    std::env::set_var("RUST_LOG", "curp=debug,xline=debug");
-    _ = tracing_subscriber::fmt()
-        .compact()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .try_init();
     struct TestCase {
         key: &'static str,
         value: &'static str,


### PR DESCRIPTION
This PR introduces the following major changes:
- Switch after sync to sync version (previously async)
- Rewrite error returning mechanism during after sync stage

During the after sync execution (in `crates/xline/src/server/command.rs`), we use batch persistent, and this will introduce two types of errors
- a execution error for a single command
- a batch persistent error

Thus, we cannot return immediately after encounter and error, but need to record the execution result for each command. A `ASResultStates` type is introduced to resolve this issue.

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
