### PR TITLE
fix: madsim tests

### DIFF
--- a/crates/curp/src/server/raw_curp/mod.rs
+++ b/crates/curp/src/server/raw_curp/mod.rs
@@ -1032,7 +1032,8 @@ impl<C: Command, RC: RoleChange> RawCurp<C, RC> {
         let prev_last_log_index = log_w.last_log_index();
         // TODO: Generate client id in the same way as client
         let propose_id = ProposeId(rand::random(), 0);
-        let _ignore = log_w.push(st_w.term, propose_id, EntryData::Empty);
+        let entry = log_w.push(st_w.term, propose_id, EntryData::Empty);
+        self.persistent_log_entries(&[&entry], &log_w);
         self.recover_from_spec_pools(&st_w, &mut log_w, spec_pools);
         self.recover_ucp_from_log(&log_w);
         let last_log_index = log_w.last_log_index();

--- a/crates/simulation/src/curp_group.rs
+++ b/crates/simulation/src/curp_group.rs
@@ -182,14 +182,19 @@ impl CurpGroup {
             .iter()
             .map(|(id, node)| (*id, vec![node.addr.clone()]))
             .collect();
-        SimClient {
-            inner: Arc::new(
+        let client = self
+            .client_node
+            .spawn(async move {
                 ClientBuilder::new(config, true)
                     .all_members(all_members)
                     .build()
                     .await
-                    .unwrap(),
-            ),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        SimClient {
+            inner: Arc::new(client),
             handle: self.client_node.clone(),
         }
     }


### PR DESCRIPTION
Depends-On: #938

Some assumptions of the madsim tests have changed. I rewrote some tests to meet the new refactor's assumptions.

Some of the new assumptions:
- follower does not need to execute the command
- the `ProposeRequest` will only be sent to the leader, the `RecordRequest` will be sent to the followers.

Other changes:
- We need to use the client id generated from the server to build a `ProposeId`, otherwise the server would reject the propose.

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
