### PR TITLE
refactor: record er and asr for recovered commands

### DIFF
--- a/crates/curp/src/server/cmd_board.rs
+++ b/crates/curp/src/server/cmd_board.rs
@@ -194,14 +194,12 @@ impl<C: Command> CommandBoard<C> {
     pub(super) async fn wait_for_er_asr(
         cb: &CmdBoardRef<C>,
         id: ProposeId,
-    ) -> (Result<C::ER, C::Error>, Option<Result<C::ASR, C::Error>>) {
+    ) -> (Result<C::ER, C::Error>, Result<C::ASR, C::Error>) {
         loop {
             {
                 let cb_r = cb.read();
-                match (cb_r.er_buffer.get(&id), cb_r.asr_buffer.get(&id)) {
-                    (Some(er), None) if er.is_err() => return (er.clone(), None),
-                    (Some(er), Some(asr)) => return (er.clone(), Some(asr.clone())),
-                    _ => {}
+                if let (Some(er), Some(asr)) = (cb_r.er_buffer.get(&id), cb_r.asr_buffer.get(&id)) {
+                    return (er.clone(), asr.clone());
                 }
             }
             let listener = cb.write().asr_listener(id);

--- a/crates/curp/src/server/cmd_worker/mod.rs
+++ b/crates/curp/src/server/cmd_worker/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     log_entry::{EntryData, LogEntry},
     response::ResponseSender,
     role_change::RoleChange,
-    rpc::{ConfChangeType, PoolEntry, ProposeResponse, SyncedResponse},
+    rpc::{ConfChangeType, PoolEntry, ProposeId, ProposeResponse, SyncedResponse},
     snapshot::{Snapshot, SnapshotMeta},
 };
 
@@ -42,10 +42,13 @@ pub(super) fn execute<C: Command, CE: CommandExecutor<C>, RC: RoleChange>(
     ce: &CE,
     curp: &RawCurp<C, RC>,
 ) -> Result<<C as Command>::ER, <C as Command>::Error> {
+    let cb = curp.cmd_board();
     let id = curp.id();
     match entry.entry_data {
         EntryData::Command(ref cmd) => {
             let er = ce.execute(cmd);
+            let mut cb_w = cb.write();
+            cb_w.insert_er(entry.propose_id, er.clone());
             debug!(
                 "{id} cmd({}) is speculatively executed, exe status: {}",
                 entry.propose_id,
@@ -95,9 +98,11 @@ fn after_sync_cmds<C: Command, CE: CommandExecutor<C>, RC: RoleChange>(
             )
         })
         .collect();
+    let propose_ids = cmd_entries.iter().map(|(e, _)| e.propose_id);
 
     let results = ce.after_sync(cmds, highest_index);
-    send_results(results.into_iter(), resp_txs);
+
+    send_results(curp, results.into_iter(), resp_txs, propose_ids);
 
     for (entry, _) in cmd_entries {
         curp.trigger(&entry.propose_id);
@@ -107,27 +112,35 @@ fn after_sync_cmds<C: Command, CE: CommandExecutor<C>, RC: RoleChange>(
 }
 
 /// Send cmd results to clients
-fn send_results<'a, C, R, S>(results: R, txs: S)
+fn send_results<'a, C, RC, R, S, P>(curp: &RawCurp<C, RC>, results: R, txs: S, propose_ids: P)
 where
     C: Command,
+    RC: RoleChange,
     R: Iterator<Item = Result<AfterSyncOk<C>, C::Error>>,
     S: Iterator<Item = Option<&'a ResponseSender>>,
+    P: Iterator<Item = ProposeId>,
 {
-    for (result, tx_opt) in results.zip(txs) {
+    let cb = curp.cmd_board();
+    let mut cb_w = cb.write();
+
+    for ((result, tx_opt), id) in results.zip(txs).zip(propose_ids) {
         match result {
             Ok(r) => {
                 let (asr, er_opt) = r.into_parts();
                 let _ignore_er = tx_opt.as_ref().zip(er_opt.as_ref()).map(|(tx, er)| {
                     tx.send_propose(ProposeResponse::new_result::<C>(&Ok(er.clone()), true));
                 });
+                let _ignore = er_opt.map(|er| cb_w.insert_er(id, Ok(er)));
                 let _ignore_asr = tx_opt
                     .as_ref()
                     .map(|tx| tx.send_synced(SyncedResponse::new_result::<C>(&Ok(asr.clone()))));
+                cb_w.insert_asr(id, Ok(asr));
             }
             Err(e) => {
                 let _ignore = tx_opt
                     .as_ref()
                     .map(|tx| tx.send_synced(SyncedResponse::new_result::<C>(&Err(e.clone()))));
+                cb_w.insert_asr(id, Err(e.clone()));
             }
         }
     }

--- a/crates/curp/src/server/mod.rs
+++ b/crates/curp/src/server/mod.rs
@@ -92,7 +92,8 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> crate::rpc::Protocol fo
         let (tx, rx) = flume::bounded(2);
         let resp_tx = Arc::new(ResponseSender::new(tx));
         self.inner
-            .propose_stream(&request.into_inner(), resp_tx, bypassed)?;
+            .propose_stream(&request.into_inner(), resp_tx, bypassed)
+            .await?;
 
         Ok(tonic::Response::new(rx.into_stream()))
     }

--- a/crates/curp/src/server/raw_curp/mod.rs
+++ b/crates/curp/src/server/raw_curp/mod.rs
@@ -1861,6 +1861,7 @@ impl<C: Command, RC: RoleChange> RawCurp<C, RC> {
     /// Apply new logs
     fn apply(&self, log: &mut Log<C>) {
         let mut entries = Vec::new();
+        let mut resp_txs_l = self.ctx.resp_txs.lock();
         for i in (log.last_as + 1)..=log.commit_index {
             let entry = log.get(i).unwrap_or_else(|| {
                 unreachable!(
@@ -1868,7 +1869,7 @@ impl<C: Command, RC: RoleChange> RawCurp<C, RC> {
                     log.last_log_index()
                 )
             });
-            let tx = self.ctx.resp_txs.lock().remove(&i);
+            let tx = resp_txs_l.remove(&i);
             entries.push((Arc::clone(entry), tx));
             log.last_as = i;
             if log.last_exe < log.last_as {


### PR DESCRIPTION
In normal propose path, the leader maintains a gRPC stream to the client. However, if the leader crashes and a new leader is elected, the client won't be able to retrive the previous result.

This PR makes the leader record the er and asr results to the cmd board and they will be returned to the client on next retry.

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
