### PR TITLE
fix: after sync result of read only commands

### DIFF
--- a/crates/curp-external-api/src/cmd.rs
+++ b/crates/curp-external-api/src/cmd.rs
@@ -105,6 +105,8 @@ where
     fn execute(&self, cmd: &C) -> Result<C::ER, C::Error>;
 
     /// Batch execute the after_sync callback
+    ///
+    /// This `highest_index` means the last log index of the `cmds`
     fn after_sync(
         &self,
         cmds: Vec<AfterSyncCmd<'_, C>>,

--- a/crates/curp-external-api/src/cmd.rs
+++ b/crates/curp-external-api/src/cmd.rs
@@ -108,7 +108,8 @@ where
     fn after_sync(
         &self,
         cmds: Vec<AfterSyncCmd<'_, C>>,
-        highest_index: LogIndex,
+        // might be `None` if it's a speculative execution
+        highest_index: Option<LogIndex>,
     ) -> Vec<Result<AfterSyncOk<C>, C::Error>>;
 
     /// Set the index of the last log entry that has been successfully applied

--- a/crates/curp-test-utils/src/test_cmd.rs
+++ b/crates/curp-test-utils/src/test_cmd.rs
@@ -298,6 +298,7 @@ impl CommandExecutor<TestCommand> for TestCE {
 
         if let Some(index) = highest_index {
             for (i, cmd) in cmds.iter().enumerate() {
+                // Calculate the log index of the current cmd
                 let index = index - (total - i - 1) as u64;
                 self.after_sync_sender
                     .send((cmd.cmd().clone(), index))

--- a/crates/curp/src/server/gc.rs
+++ b/crates/curp/src/server/gc.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use indexmap::IndexMap;
 use utils::task_manager::Listener;
 
 use crate::{cmd::Command, rpc::ProposeId, server::cmd_board::CmdBoardRef};

--- a/crates/utils/src/task_manager/tasks.rs
+++ b/crates/utils/src/task_manager/tasks.rs
@@ -65,8 +65,7 @@ impl TaskName {
             | TaskName::Election
             | TaskName::SyncFollower
             | TaskName::ConfChange
-            | TaskName::GcSpecPool
-            | TaskName::GcCmdBoard
+            | TaskName::GcClientLease
             | TaskName::RevokeExpiredLeases
             | TaskName::SyncVictims
             | TaskName::AutoCompactor => false,

--- a/crates/xline/src/server/command.rs
+++ b/crates/xline/src/server/command.rs
@@ -486,13 +486,6 @@ impl CurpCommandExecutor<Command> for CommandExecutor {
                     }
                 }
             };
-            if let RequestWrapper::CompactionRequest(ref compact_req) = *wrapper {
-                if compact_req.physical {
-                    if let Some(n) = self.compact_events.get(&cmd.compact_id()) {
-                        let _ignore = n.notify(usize::MAX);
-                    }
-                }
-            };
 
             self.lease_storage.mark_lease_synced(wrapper);
 

--- a/crates/xline/src/server/command.rs
+++ b/crates/xline/src/server/command.rs
@@ -427,7 +427,7 @@ impl CurpCommandExecutor<Command> for CommandExecutor {
     fn after_sync(
         &self,
         cmds: Vec<AfterSyncCmd<'_, Command>>,
-        highest_index: LogIndex,
+        highest_index: Option<LogIndex>,
     ) -> Vec<AfterSyncResult> {
         if cmds.is_empty() {
             return Vec::new();
@@ -452,8 +452,10 @@ impl CurpCommandExecutor<Command> for CommandExecutor {
         let auth_revision_state = auth_revision_gen.state();
 
         let txn_db = self.db.transaction();
-        if let Err(e) = txn_db.write_op(WriteOp::PutAppliedIndex(highest_index)) {
-            return states.into_errors(e);
+        if let Some(i) = highest_index {
+            if let Err(e) = txn_db.write_op(WriteOp::PutAppliedIndex(i)) {
+                return states.into_errors(e);
+            }
         }
 
         states.update_result(|c| {


### PR DESCRIPTION
Depends-On: #949 

This PR fixes read only commands execution. 

Currently read only commands won't go through the after sync phase. However, for etcd compatible API, the revision in after sync result must be returned to the client.

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
