### PR TITLE
chore: add version number to eliminate RA warnings

### DIFF
--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -25,7 +25,7 @@ derive_builder = "0.20.0"
 event-listener = "5.3.1"
 futures = "0.3.30"
 getset = "0.1"
-interval_map = { package = "rb-interval-map" }
+interval_map = { version = "0.1", package = "rb-interval-map" }
 opentelemetry = { version = "0.24.0", features = ["trace"] }
 opentelemetry_sdk = { version = "0.24.1", features = ["trace"] }
 parking_lot = { version = "0.12.3", optional = true }


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
 Refer to #960. Add a clear version number to eliminate RA warnings.
* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
