### PR TITLE
refactor: add auto reconnect to curp client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,9 +2490,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.14"
+version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
+checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
  "log",
  "once_cell",
@@ -2514,9 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"

--- a/crates/curp/src/client/mod.rs
+++ b/crates/curp/src/client/mod.rs
@@ -163,7 +163,7 @@ impl Drop for ProposeIdGuard<'_> {
 #[async_trait]
 trait RepeatableClientApi: ClientApi {
     /// Generate a unique propose id during the retry process.
-    fn gen_propose_id(&self) -> Result<ProposeIdGuard<'_>, Self::Error>;
+    async fn gen_propose_id(&self) -> Result<ProposeIdGuard<'_>, Self::Error>;
 
     /// Send propose to the whole cluster, `use_fast_path` set to `false` to fallback into ordered
     /// requests (event the requests are commutative).
@@ -422,51 +422,23 @@ impl ClientBuilder {
         })
     }
 
-    /// Wait for client id
-    async fn wait_for_client_id(&self, state: Arc<state::State>) -> Result<(), tonic::Status> {
-        /// Max retry count for waiting for a client ID
-        ///
-        /// TODO: This retry count is set relatively high to avoid test cluster startup timeouts.
-        /// We should consider setting this to a more reasonable value.
-        const RETRY_COUNT: usize = 30;
-        /// The interval for each retry
-        const RETRY_INTERVAL: Duration = Duration::from_secs(1);
-
-        for _ in 0..RETRY_COUNT {
-            if state.client_id() != 0 {
-                return Ok(());
-            }
-            debug!("waiting for client_id");
-            tokio::time::sleep(RETRY_INTERVAL).await;
-        }
-
-        Err(tonic::Status::deadline_exceeded(
-            "timeout waiting for client id",
-        ))
-    }
-
     /// Build the client
     ///
     /// # Errors
     ///
     /// Return `tonic::transport::Error` for connection failure.
     #[inline]
-    pub async fn build<C: Command>(
+    pub fn build<C: Command>(
         &self,
     ) -> Result<impl ClientApi<Error = tonic::Status, Cmd = C> + Send + Sync + 'static, tonic::Status>
     {
-        let state = Arc::new(
-            self.init_state_builder()
-                .build()
-                .await
-                .map_err(|e| tonic::Status::internal(e.to_string()))?,
-        );
+        let state = Arc::new(self.init_state_builder().build());
         let client = Retry::new(
             Unary::new(Arc::clone(&state), self.init_unary_config()),
             self.init_retry_config(),
             Some(self.spawn_bg_tasks(Arc::clone(&state))),
         );
-        self.wait_for_client_id(state).await?;
+
         Ok(client)
     }
 
@@ -477,21 +449,14 @@ impl ClientBuilder {
     ///
     /// Return `tonic::transport::Error` for connection failure.
     #[inline]
-    pub async fn build_with_client_id<C: Command>(
+    #[must_use]
+    pub fn build_with_client_id<C: Command>(
         &self,
-    ) -> Result<
-        (
-            impl ClientApi<Error = tonic::Status, Cmd = C> + Send + Sync + 'static,
-            Arc<AtomicU64>,
-        ),
-        tonic::Status,
-    > {
-        let state = Arc::new(
-            self.init_state_builder()
-                .build()
-                .await
-                .map_err(|e| tonic::Status::internal(e.to_string()))?,
-        );
+    ) -> (
+        impl ClientApi<Error = tonic::Status, Cmd = C> + Send + Sync + 'static,
+        Arc<AtomicU64>,
+    ) {
+        let state = Arc::new(self.init_state_builder().build());
 
         let client = Retry::new(
             Unary::new(Arc::clone(&state), self.init_unary_config()),
@@ -499,9 +464,8 @@ impl ClientBuilder {
             Some(self.spawn_bg_tasks(Arc::clone(&state))),
         );
         let client_id = state.clone_client_id();
-        self.wait_for_client_id(state).await?;
 
-        Ok((client, client_id))
+        (client, client_id)
     }
 }
 
@@ -512,22 +476,20 @@ impl<P: Protocol> ClientBuilderWithBypass<P> {
     ///
     /// Return `tonic::transport::Error` for connection failure.
     #[inline]
-    pub async fn build<C: Command>(
+    pub fn build<C: Command>(
         self,
     ) -> Result<impl ClientApi<Error = tonic::Status, Cmd = C>, tonic::Status> {
         let state = self
             .inner
             .init_state_builder()
-            .build_bypassed::<P>(self.local_server_id, self.local_server)
-            .await
-            .map_err(|e| tonic::Status::internal(e.to_string()))?;
+            .build_bypassed::<P>(self.local_server_id, self.local_server);
         let state = Arc::new(state);
         let client = Retry::new(
             Unary::new(Arc::clone(&state), self.inner.init_unary_config()),
             self.inner.init_retry_config(),
             Some(self.inner.spawn_bg_tasks(Arc::clone(&state))),
         );
-        self.inner.wait_for_client_id(state).await?;
+
         Ok(client)
     }
 }

--- a/crates/curp/src/client/retry.rs
+++ b/crates/curp/src/client/retry.rs
@@ -231,7 +231,7 @@ where
         use_fast_path: bool,
     ) -> Result<ProposeResponse<Self::Cmd>, tonic::Status> {
         self.retry::<_, _>(|client| async move {
-            let propose_id = self.inner.gen_propose_id()?;
+            let propose_id = self.inner.gen_propose_id().await?;
             RepeatableClientApi::propose(client, *propose_id, cmd, token, use_fast_path).await
         })
         .await
@@ -245,7 +245,7 @@ where
         self.retry::<_, _>(|client| {
             let changes_c = changes.clone();
             async move {
-                let propose_id = self.inner.gen_propose_id()?;
+                let propose_id = self.inner.gen_propose_id().await?;
                 RepeatableClientApi::propose_conf_change(client, *propose_id, changes_c).await
             }
         })
@@ -255,7 +255,7 @@ where
     /// Send propose to shutdown cluster
     async fn propose_shutdown(&self) -> Result<(), tonic::Status> {
         self.retry::<_, _>(|client| async move {
-            let propose_id = self.inner.gen_propose_id()?;
+            let propose_id = self.inner.gen_propose_id().await?;
             RepeatableClientApi::propose_shutdown(client, *propose_id).await
         })
         .await
@@ -272,7 +272,7 @@ where
             let name_c = node_name.clone();
             let node_client_urls_c = node_client_urls.clone();
             async move {
-                let propose_id = self.inner.gen_propose_id()?;
+                let propose_id = self.inner.gen_propose_id().await?;
                 RepeatableClientApi::propose_publish(
                     client,
                     *propose_id,

--- a/crates/curp/src/client/tests.rs
+++ b/crates/curp/src/client/tests.rs
@@ -751,7 +751,7 @@ async fn test_stream_client_keep_alive_works() {
         Box::pin(async move {
             client_id
                 .compare_exchange(
-                    0,
+                    1,
                     10,
                     std::sync::atomic::Ordering::Relaxed,
                     std::sync::atomic::Ordering::Relaxed,
@@ -775,7 +775,7 @@ async fn test_stream_client_keep_alive_on_redirect() {
         Box::pin(async move {
             client_id
                 .compare_exchange(
-                    0,
+                    1,
                     10,
                     std::sync::atomic::Ordering::Relaxed,
                     std::sync::atomic::Ordering::Relaxed,

--- a/crates/curp/src/client/unary/mod.rs
+++ b/crates/curp/src/client/unary/mod.rs
@@ -134,7 +134,7 @@ impl<C: Command> ClientApi for Unary<C> {
         token: Option<&String>,
         use_fast_path: bool,
     ) -> Result<ProposeResponse<C>, CurpError> {
-        let propose_id = self.gen_propose_id()?;
+        let propose_id = self.gen_propose_id().await?;
         RepeatableClientApi::propose(self, *propose_id, cmd, token, use_fast_path).await
     }
 
@@ -143,13 +143,13 @@ impl<C: Command> ClientApi for Unary<C> {
         &self,
         changes: Vec<ConfChange>,
     ) -> Result<Vec<Member>, CurpError> {
-        let propose_id = self.gen_propose_id()?;
+        let propose_id = self.gen_propose_id().await?;
         RepeatableClientApi::propose_conf_change(self, *propose_id, changes).await
     }
 
     /// Send propose to shutdown cluster
     async fn propose_shutdown(&self) -> Result<(), CurpError> {
-        let propose_id = self.gen_propose_id()?;
+        let propose_id = self.gen_propose_id().await?;
         RepeatableClientApi::propose_shutdown(self, *propose_id).await
     }
 
@@ -160,7 +160,7 @@ impl<C: Command> ClientApi for Unary<C> {
         node_name: String,
         node_client_urls: Vec<String>,
     ) -> Result<(), Self::Error> {
-        let propose_id = self.gen_propose_id()?;
+        let propose_id = self.gen_propose_id().await?;
         RepeatableClientApi::propose_publish(
             self,
             *propose_id,
@@ -306,8 +306,11 @@ impl<C: Command> ClientApi for Unary<C> {
 #[async_trait]
 impl<C: Command> RepeatableClientApi for Unary<C> {
     /// Generate a unique propose id during the retry process.
-    fn gen_propose_id(&self) -> Result<ProposeIdGuard<'_>, Self::Error> {
-        let client_id = self.state.client_id();
+    async fn gen_propose_id(&self) -> Result<ProposeIdGuard<'_>, Self::Error> {
+        let mut client_id = self.state.client_id();
+        if client_id == 0 {
+            client_id = self.state.wait_for_client_id().await?;
+        };
         let seq_num = self.new_seq_num();
         Ok(ProposeIdGuard::new(
             &self.tracker,

--- a/crates/curp/src/members.rs
+++ b/crates/curp/src/members.rs
@@ -439,8 +439,6 @@ pub async fn get_cluster_info_from_remote(
     let peers = init_cluster_info.peers_addrs();
     let self_client_urls = init_cluster_info.self_client_urls();
     let connects = rpc::connects(peers, tls_config)
-        .await
-        .ok()?
         .map(|pair| pair.1)
         .collect_vec();
     let mut futs = connects

--- a/crates/curp/src/rpc/mod.rs
+++ b/crates/curp/src/rpc/mod.rs
@@ -67,6 +67,9 @@ mod metrics;
 pub(crate) mod connect;
 pub(crate) use connect::{connect, connects, inner_connects};
 
+/// Auto reconnect connection
+mod reconnect;
+
 // Skip for generated code
 #[allow(
     clippy::all,

--- a/crates/curp/src/rpc/reconnect.rs
+++ b/crates/curp/src/rpc/reconnect.rs
@@ -1,0 +1,198 @@
+use std::{
+    sync::{atomic::AtomicU64, Arc},
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use event_listener::Event;
+use futures::Stream;
+
+use crate::{
+    members::ServerId,
+    rpc::{
+        connect::ConnectApi, CurpError, FetchClusterRequest, FetchClusterResponse,
+        FetchReadStateRequest, FetchReadStateResponse, MoveLeaderRequest, MoveLeaderResponse,
+        OpResponse, ProposeConfChangeRequest, ProposeConfChangeResponse, ProposeRequest,
+        PublishRequest, PublishResponse, ReadIndexResponse, RecordRequest, RecordResponse,
+        ShutdownRequest, ShutdownResponse,
+    },
+};
+
+/// Auto reconnect of a connection
+pub(super) struct Reconnect<C> {
+    /// Connect id
+    id: ServerId,
+    /// The connection
+    connect: tokio::sync::RwLock<Option<C>>,
+    /// The connect builder
+    builder: Box<dyn Fn() -> C + Send + Sync + 'static>,
+    /// Signal to abort heartbeat
+    event: Event,
+}
+
+impl<C: ConnectApi> Reconnect<C> {
+    /// Creates a new `Reconnect`
+    pub(crate) fn new(builder: Box<dyn Fn() -> C + Send + Sync + 'static>) -> Self {
+        let init_connect = builder();
+        Self {
+            id: init_connect.id(),
+            connect: tokio::sync::RwLock::new(Some(init_connect)),
+            builder,
+            event: Event::new(),
+        }
+    }
+
+    /// Creating a new connection to replace the current
+    async fn reconnect(&self) {
+        let new_connect = (self.builder)();
+        // Cancel the leader keep alive loop task because it hold a read lock
+        let _cancel = self.event.notify(1);
+        let _ignore = self.connect.write().await.replace(new_connect);
+        // After connection is updated, notify to start the keep alive loop
+        let _continue = self.event.notify(1);
+    }
+
+    /// Try to reconnect if the result is `Err`
+    async fn try_reconnect<R>(&self, result: Result<R, CurpError>) -> Result<R, CurpError> {
+        // TODO: use `tonic::Status` instead of `CurpError`, we can't tell
+        // if a reconnect is required from `CurpError`.
+        if matches!(
+            result,
+            Err(CurpError::RpcTransport(()) | CurpError::Internal(_))
+        ) {
+            tracing::info!("client reconnecting");
+            self.reconnect().await;
+        }
+        result
+    }
+}
+
+/// Execute with reconnect
+macro_rules! execute_with_reconnect {
+    ($self:expr, $trait_method:path, $($arg:expr),*) => {{
+        let result = {
+            let connect = $self.connect.read().await;
+            let connect_ref = connect.as_ref().unwrap();
+            ($trait_method)(connect_ref, $($arg),*).await
+        };
+        $self.try_reconnect(result).await
+    }};
+}
+
+#[allow(clippy::unwrap_used, clippy::unwrap_in_result)]
+#[async_trait]
+impl<C: ConnectApi> ConnectApi for Reconnect<C> {
+    /// Get server id
+    fn id(&self) -> ServerId {
+        self.id
+    }
+
+    /// Update server addresses, the new addresses will override the old ones
+    async fn update_addrs(&self, addrs: Vec<String>) -> Result<(), tonic::transport::Error> {
+        let connect = self.connect.read().await;
+        connect.as_ref().unwrap().update_addrs(addrs).await
+    }
+
+    /// Send `ProposeRequest`
+    async fn propose_stream(
+        &self,
+        request: ProposeRequest,
+        token: Option<String>,
+        timeout: Duration,
+    ) -> Result<
+        tonic::Response<Box<dyn Stream<Item = Result<OpResponse, tonic::Status>> + Send>>,
+        CurpError,
+    > {
+        execute_with_reconnect!(self, ConnectApi::propose_stream, request, token, timeout)
+    }
+
+    /// Send `RecordRequest`
+    async fn record(
+        &self,
+        request: RecordRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<RecordResponse>, CurpError> {
+        execute_with_reconnect!(self, ConnectApi::record, request, timeout)
+    }
+
+    /// Send `ReadIndexRequest`
+    async fn read_index(
+        &self,
+        timeout: Duration,
+    ) -> Result<tonic::Response<ReadIndexResponse>, CurpError> {
+        execute_with_reconnect!(self, ConnectApi::read_index, timeout)
+    }
+
+    /// Send `ProposeRequest`
+    async fn propose_conf_change(
+        &self,
+        request: ProposeConfChangeRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<ProposeConfChangeResponse>, CurpError> {
+        execute_with_reconnect!(self, ConnectApi::propose_conf_change, request, timeout)
+    }
+
+    /// Send `PublishRequest`
+    async fn publish(
+        &self,
+        request: PublishRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<PublishResponse>, CurpError> {
+        execute_with_reconnect!(self, ConnectApi::publish, request, timeout)
+    }
+
+    /// Send `ShutdownRequest`
+    async fn shutdown(
+        &self,
+        request: ShutdownRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<ShutdownResponse>, CurpError> {
+        execute_with_reconnect!(self, ConnectApi::shutdown, request, timeout)
+    }
+
+    /// Send `FetchClusterRequest`
+    async fn fetch_cluster(
+        &self,
+        request: FetchClusterRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<FetchClusterResponse>, CurpError> {
+        execute_with_reconnect!(self, ConnectApi::fetch_cluster, request, timeout)
+    }
+
+    /// Send `FetchReadStateRequest`
+    async fn fetch_read_state(
+        &self,
+        request: FetchReadStateRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<FetchReadStateResponse>, CurpError> {
+        execute_with_reconnect!(self, ConnectApi::fetch_read_state, request, timeout)
+    }
+
+    /// Send `MoveLeaderRequest`
+    async fn move_leader(
+        &self,
+        request: MoveLeaderRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<MoveLeaderResponse>, CurpError> {
+        execute_with_reconnect!(self, ConnectApi::move_leader, request, timeout)
+    }
+
+    /// Keep send lease keep alive to server and mutate the client id
+    async fn lease_keep_alive(&self, client_id: Arc<AtomicU64>, interval: Duration) -> CurpError {
+        loop {
+            let connect = self.connect.read().await;
+            let connect_ref = connect.as_ref().unwrap();
+            tokio::select! {
+                err = connect_ref.lease_keep_alive(Arc::clone(&client_id), interval) => {
+                    return err;
+                }
+                _empty = self.event.listen() => {},
+            }
+            // Creates the listener before dropping the read lock.
+            // This prevents us from losting the event.
+            let listener = self.event.listen();
+            drop(connect);
+            let _connection_updated = listener.await;
+        }
+    }
+}

--- a/crates/curp/src/server/mod.rs
+++ b/crates/curp/src/server/mod.rs
@@ -263,7 +263,7 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> Rpc<C, CE, RC> {
     /// Panic if storage creation failed
     #[inline]
     #[allow(clippy::too_many_arguments)] // TODO: refactor this use builder pattern
-    pub async fn new(
+    pub fn new(
         cluster_info: Arc<ClusterInfo>,
         is_leader: bool,
         executor: Arc<CE>,
@@ -289,9 +289,7 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> Rpc<C, CE, RC> {
             client_tls_config,
             sps,
             ucps,
-        )
-        .await
-        {
+        ) {
             Ok(n) => n,
             Err(err) => {
                 panic!("failed to create curp service, {err:?}");
@@ -345,8 +343,7 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> Rpc<C, CE, RC> {
             client_tls_config,
             sps,
             ucps,
-        )
-        .await;
+        );
 
         tonic::transport::Server::builder()
             .add_service(ProtocolServer::new(server.clone()))

--- a/crates/curp/tests/it/common/curp_group.rs
+++ b/crates/curp/tests/it/common/curp_group.rs
@@ -136,22 +136,19 @@ impl CurpGroup {
             let role_change_cb = TestRoleChange::default();
             let role_change_arc = role_change_cb.get_inner_arc();
             let curp_storage = Arc::new(DB::open(&config.engine_cfg).unwrap());
-            let server = Arc::new(
-                Rpc::new(
-                    cluster_info,
-                    name == leader_name,
-                    ce,
-                    snapshot_allocator,
-                    role_change_cb,
-                    config,
-                    curp_storage,
-                    Arc::clone(&task_manager),
-                    client_tls_config.clone(),
-                    vec![Box::<TestSpecPool>::default()],
-                    vec![Box::<TestUncomPool>::default()],
-                )
-                .await,
-            );
+            let server = Arc::new(Rpc::new(
+                cluster_info,
+                name == leader_name,
+                ce,
+                snapshot_allocator,
+                role_change_cb,
+                config,
+                curp_storage,
+                Arc::clone(&task_manager),
+                client_tls_config.clone(),
+                vec![Box::<TestSpecPool>::default()],
+                vec![Box::<TestUncomPool>::default()],
+            ));
             task_manager.spawn(TaskName::TonicServer, |n| async move {
                 let ig = Self::run(server, listener, n).await;
             });
@@ -268,22 +265,19 @@ impl CurpGroup {
         let role_change_cb = TestRoleChange::default();
         let role_change_arc = role_change_cb.get_inner_arc();
         let curp_storage = Arc::new(DB::open(&config.engine_cfg).unwrap());
-        let server = Arc::new(
-            Rpc::new(
-                cluster_info,
-                false,
-                ce,
-                snapshot_allocator,
-                role_change_cb,
-                config,
-                curp_storage,
-                Arc::clone(&task_manager),
-                self.client_tls_config.clone(),
-                vec![],
-                vec![],
-            )
-            .await,
-        );
+        let server = Arc::new(Rpc::new(
+            cluster_info,
+            false,
+            ce,
+            snapshot_allocator,
+            role_change_cb,
+            config,
+            curp_storage,
+            Arc::clone(&task_manager),
+            self.client_tls_config.clone(),
+            vec![],
+            vec![],
+        ));
         task_manager.spawn(TaskName::TonicServer, |n| async move {
             let _ig = Self::run(server, listener, n).await;
         });
@@ -329,7 +323,6 @@ impl CurpGroup {
             .await
             .unwrap()
             .build()
-            .await
             .unwrap()
     }
 

--- a/crates/curp/tests/it/server.rs
+++ b/crates/curp/tests/it/server.rs
@@ -455,7 +455,6 @@ async fn shutdown_rpc_should_shutdown_the_cluster_when_client_has_wrong_leader()
         .leader_state(follower_id, 0)
         .all_members(group.all_addrs_map())
         .build::<TestCommand>()
-        .await
         .unwrap();
     client.propose_shutdown().await.unwrap();
 
@@ -477,7 +476,6 @@ async fn propose_conf_change_to_follower() {
         .leader_state(follower_id, 0)
         .all_members(group.all_addrs_map())
         .build::<TestCommand>()
-        .await
         .unwrap();
 
     let node_id = group.nodes.keys().next().copied().unwrap();

--- a/crates/simulation/src/curp_group.rs
+++ b/crates/simulation/src/curp_group.rs
@@ -195,10 +195,8 @@ impl CurpGroup {
                 ClientBuilder::new(config, true)
                     .all_members(all_members)
                     .build_with_client_id()
-                    .await
             })
             .await
-            .unwrap()
             .unwrap();
         SimClient {
             inner: Arc::new(client),

--- a/crates/xline-client/src/lib.rs
+++ b/crates/xline-client/src/lib.rs
@@ -244,8 +244,7 @@ impl Client {
                 .tls_config(options.tls_config)
                 .discover_from(addrs)
                 .await?
-                .build::<Command>()
-                .await?,
+                .build::<Command>()?,
         ) as Arc<CurpClient>;
         let id_gen = Arc::new(lease_gen::LeaseIdGenerator::new());
 

--- a/crates/xline/src/server/xline_server.rs
+++ b/crates/xline/src/server/xline_server.rs
@@ -518,8 +518,7 @@ impl XlineServer {
             self.client_tls_config.clone(),
             XlineSpeculativePools::new(Arc::clone(&lease_collection)).into_inner(),
             XlineUncommittedPools::new(lease_collection).into_inner(),
-        )
-        .await;
+        );
 
         let client = Arc::new(
             CurpClientBuilder::new(*self.cluster_config.client_config(), false)
@@ -527,8 +526,7 @@ impl XlineServer {
                 .cluster_version(self.cluster_info.cluster_version())
                 .all_members(self.cluster_info.all_members_peer_urls())
                 .bypass(self.cluster_info.self_id(), curp_server.clone())
-                .build::<Command>()
-                .await?,
+                .build::<Command>()?,
         ) as Arc<CurpClient>;
 
         if let Some(compactor) = auto_compactor_c {


### PR DESCRIPTION
This PR includes two major changes:

* Implements an auto reconnect layer.
* Lazily build connections for client.

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
