### PR TITLE
feat: replace hardcoded temp directory paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -916,6 +916,7 @@ dependencies = [
  "parking_lot",
  "rocksdb",
  "serde",
+ "tempfile",
  "test-macros",
  "thiserror",
  "tokio-util",
@@ -1502,7 +1503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2019,7 +2020,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2812,14 +2813,15 @@ checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3488,7 +3490,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3506,7 +3508,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3526,18 +3537,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -3548,9 +3559,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3560,9 +3571,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3572,15 +3583,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3590,9 +3601,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3602,9 +3613,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3614,9 +3625,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3626,9 +3637,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -35,3 +35,4 @@ workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [dev-dependencies]
 test-macros = { path = "../test-macros" }
+tempfile = "3"

--- a/crates/engine/src/proxy.rs
+++ b/crates/engine/src/proxy.rs
@@ -332,6 +332,8 @@ impl SnapshotApi for Snapshot {
 mod test {
     use std::iter::{repeat, zip};
 
+    use tempfile::TempDir;
+
     use clippy_utilities::NumericCast;
     use test_macros::abort_on_panic;
 
@@ -342,8 +344,8 @@ mod test {
 
     #[test]
     fn write_batch_into_a_non_existing_table_should_fail() {
-        let dir = PathBuf::from("/tmp/write_batch_into_a_non_existing_table_should_fail");
-        let rocks_engine_path = dir.join("rocks_engine");
+        let dir = TempDir::with_prefix("write_batch_into_a_non_existing_table_should_fail-").unwrap();
+        let rocks_engine_path = dir.path().join("rocks_engine");
         let engines = vec![
             Engine::new(EngineType::Memory, &TESTTABLES).unwrap(),
             Engine::new(EngineType::Rocks(rocks_engine_path), &TESTTABLES).unwrap(),
@@ -363,13 +365,13 @@ mod test {
             let delete_range = WriteOperation::new_delete_range("hello", b"hello", b"world");
             assert!(engine.write_multi(vec![delete_range], false).is_err());
         }
-        std::fs::remove_dir_all(dir).unwrap();
+        dir.close().unwrap();
     }
 
     #[test]
     fn write_batch_should_success() {
-        let dir = PathBuf::from("/tmp/write_batch_should_success");
-        let rocks_engine_path = dir.join("rocks_engine");
+        let dir = TempDir::with_prefix("write_batch_should_success-").unwrap();
+        let rocks_engine_path = dir.path().join("rocks_engine");
         let engines = vec![
             Engine::new(EngineType::Memory, &TESTTABLES).unwrap(),
             Engine::new(EngineType::Rocks(rocks_engine_path), &TESTTABLES).unwrap(),
@@ -409,13 +411,13 @@ mod test {
             assert!(engine.get("kv", &get_key_1).unwrap().is_some());
             assert!(engine.get("kv", &get_key_2).unwrap().is_none());
         }
-        std::fs::remove_dir_all(dir).unwrap();
+        dir.close().unwrap();
     }
 
     #[test]
     fn get_operation_should_success() {
-        let dir = PathBuf::from("/tmp/get_operation_should_success");
-        let rocks_engine_path = dir.join("rocks_engine");
+        let dir = TempDir::with_prefix("get_operation_should_success-").unwrap();
+        let rocks_engine_path = dir.path().join("rocks_engine");
         let engines = vec![
             Engine::new(EngineType::Memory, &TESTTABLES).unwrap(),
             Engine::new(EngineType::Rocks(rocks_engine_path), &TESTTABLES).unwrap(),
@@ -447,17 +449,17 @@ mod test {
                 .collect::<Vec<(Vec<u8>, Vec<u8>)>>();
             assert_eq!(res_3.sort(), expected_all_values.sort());
         }
-        std::fs::remove_dir_all(dir).unwrap();
+        dir.close().unwrap();
     }
 
     #[tokio::test]
     #[abort_on_panic]
     async fn snapshot_should_work() {
-        let dir = PathBuf::from("/tmp/snapshot_should_work");
-        let origin_data_dir = dir.join("origin");
-        let recover_data_dir = dir.join("recover");
-        let snapshot_dir = dir.join("snapshot");
-        let snapshot_bak_dir = dir.join("snapshot_bak");
+        let dir = TempDir::with_prefix("snapshot_should_work-").unwrap();
+        let origin_data_dir = dir.path().join("origin");
+        let recover_data_dir = dir.path().join("recover");
+        let snapshot_dir = dir.path().join("snapshot");
+        let snapshot_bak_dir = dir.path().join("snapshot_bak");
         let engines = vec![
             Engine::new(EngineType::Memory, &TESTTABLES).unwrap(),
             Engine::new(EngineType::Rocks(origin_data_dir), &TESTTABLES).unwrap(),
@@ -508,14 +510,14 @@ mod test {
             assert!(value2.is_none());
         }
 
-        std::fs::remove_dir_all(&dir).unwrap();
+        dir.close().unwrap();
     }
 
     #[tokio::test]
     #[abort_on_panic]
     async fn txn_write_multi_should_success() {
-        let dir = PathBuf::from("/tmp/txn_write_multi_should_success");
-        let rocks_engine_path = dir.join("rocks_engine");
+        let dir = TempDir::with_prefix("txn_write_multi_should_success-").unwrap();
+        let rocks_engine_path = dir.path().join("rocks_engine");
         let engines = vec![
             Engine::new(EngineType::Memory, &TESTTABLES).unwrap(),
             Engine::new(EngineType::Rocks(rocks_engine_path), &TESTTABLES).unwrap(),
@@ -558,14 +560,14 @@ mod test {
 
             txn.commit().unwrap();
         }
-        std::fs::remove_dir_all(dir).unwrap();
+        dir.close().unwrap();
     }
 
     #[tokio::test]
     #[abort_on_panic]
     async fn txn_get_operation_should_success() {
-        let dir = PathBuf::from("/tmp/txn_get_operation_should_success");
-        let rocks_engine_path = dir.join("rocks_engine");
+        let dir = TempDir::with_prefix("txn_get_operation_should_success-").unwrap();
+        let rocks_engine_path = dir.path().join("rocks_engine");
         let engines = vec![
             Engine::new(EngineType::Memory, &TESTTABLES).unwrap(),
             Engine::new(EngineType::Rocks(rocks_engine_path), &TESTTABLES).unwrap(),
@@ -592,14 +594,14 @@ mod test {
             assert_eq!(res_2, expected_multi_values);
             txn.commit().unwrap();
         }
-        std::fs::remove_dir_all(dir).unwrap();
+        dir.close().unwrap();
     }
 
     #[tokio::test]
     #[abort_on_panic]
     async fn txn_operation_is_atomic() {
-        let dir = PathBuf::from("/tmp/txn_operation_should_be_atomic");
-        let rocks_engine_path = dir.join("rocks_engine");
+        let dir = TempDir::with_prefix("txn_operation_should_be_atomic-").unwrap();
+        let rocks_engine_path = dir.path().join("rocks_engine");
         let engines = vec![
             Engine::new(EngineType::Memory, &TESTTABLES).unwrap(),
             Engine::new(EngineType::Rocks(rocks_engine_path), &TESTTABLES).unwrap(),
@@ -625,14 +627,14 @@ mod test {
                 assert_eq!(engine.get("kv", key).unwrap().unwrap(), val);
             }
         }
-        std::fs::remove_dir_all(dir).unwrap();
+        dir.close().unwrap();
     }
 
     #[tokio::test]
     #[abort_on_panic]
     async fn txn_revert_should_success() {
-        let dir = PathBuf::from("/tmp/txn_revert_should_success");
-        let rocks_engine_path = dir.join("rocks_engine");
+        let dir = TempDir::with_prefix("txn_revert_should_success-").unwrap();
+        let rocks_engine_path = dir.path().join("rocks_engine");
         let engines = vec![
             Engine::new(EngineType::Memory, &TESTTABLES).unwrap(),
             Engine::new(EngineType::Rocks(rocks_engine_path), &TESTTABLES).unwrap(),
@@ -659,6 +661,6 @@ mod test {
                 assert!(engine.get("kv", key).unwrap().is_none());
             }
         }
-        std::fs::remove_dir_all(dir).unwrap();
+        dir.close().unwrap();
     }
 }

--- a/crates/engine/src/rocksdb_engine/mod.rs
+++ b/crates/engine/src/rocksdb_engine/mod.rs
@@ -726,6 +726,7 @@ impl SnapshotApi for RocksSnapshot {
 #[cfg(test)]
 mod test {
     use std::env::temp_dir;
+    use tempfile::TempDir;
 
     use test_macros::abort_on_panic;
 
@@ -735,9 +736,9 @@ mod test {
     #[tokio::test]
     #[abort_on_panic]
     async fn test_rocks_errors() {
-        let dir = PathBuf::from("/tmp/test_rocks_errors");
-        let engine_path = dir.join("engine");
-        let snapshot_path = dir.join("snapshot");
+        let dir = TempDir::with_prefix("test_rocks_errors-").unwrap();
+        let engine_path = dir.path().join("engine");
+        let snapshot_path = dir.path().join("snapshot");
         let engine = RocksEngine::new(engine_path, &TEST_TABLES).unwrap();
         let res = engine.get("not_exist", "key");
         assert!(res.is_err());
@@ -756,7 +757,7 @@ mod test {
         };
         let res = engine.apply_snapshot(fake_snapshot, &["not_exist"]).await;
         assert!(res.is_err());
-        fs::remove_dir_all(dir).unwrap();
+        dir.close().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Fixes #933 
* what changes does this pull request make?
This PR replaces the hardcoded tmp path with calls to [tempfile](https://docs.rs/tempfile/latest/tempfile/index.html) crate
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
