### PR TITLE
refactor: curp client propose

### DIFF
--- a/crates/curp/src/client/mod.rs
+++ b/crates/curp/src/client/mod.rs
@@ -54,7 +54,7 @@ use crate::{
 /// The response of propose command, deserialized from [`crate::rpc::ProposeResponse`] or
 /// [`crate::rpc::WaitSyncedResponse`].
 #[allow(type_alias_bounds)] // that's not bad
-type ProposeResponse<C: Command> = Result<(C::ER, Option<C::ASR>), C::Error>;
+pub(crate) type ProposeResponse<C: Command> = Result<(C::ER, Option<C::ASR>), C::Error>;
 
 /// `ClientApi`, a higher wrapper for `ConnectApi`, providing some methods for communicating to
 /// the whole curp cluster. Automatically discovery curp server to update it's quorum.

--- a/crates/curp/src/client/mod.rs
+++ b/crates/curp/src/client/mod.rs
@@ -304,7 +304,7 @@ impl ClientBuilder {
             match self.try_discover_from(&addrs).await {
                 Ok(()) => return Ok(self),
                 Err(e) if matches!(e.code(), tonic::Code::Unavailable) => {
-                    warn!("cluster is starting, sleep for {DISCOVER_SLEEP_DURATION} secs");
+                    warn!("cluster is unavailable, sleep for {DISCOVER_SLEEP_DURATION} secs");
                     tokio::time::sleep(Duration::from_secs(DISCOVER_SLEEP_DURATION)).await;
                 }
                 Err(e) => return Err(e),

--- a/crates/curp/src/client/tests.rs
+++ b/crates/curp/src/client/tests.rs
@@ -293,6 +293,7 @@ async fn test_unary_propose_fast_path_works() {
                 assert_eq!(id, 0, "followers should not receive propose");
                 let resp = async_stream::stream! {
                     yield Ok(build_propose_response(false));
+                    tokio::time::sleep(Duration::from_millis(100)).await;
                     yield Ok(build_synced_response());
                 };
                 Ok(tonic::Response::new(Box::new(resp)))
@@ -540,6 +541,7 @@ async fn test_read_index_success() {
                 assert_eq!(id, 0, "followers should not receive propose");
                 let resp = async_stream::stream! {
                     yield Ok(build_propose_response(false));
+                    tokio::time::sleep(Duration::from_millis(100)).await;
                     yield Ok(build_synced_response());
                 };
                 Ok(tonic::Response::new(Box::new(resp)))

--- a/crates/curp/src/client/unary/propose_impl.rs
+++ b/crates/curp/src/client/unary/propose_impl.rs
@@ -1,0 +1,323 @@
+use std::pin::Pin;
+
+use curp_external_api::cmd::Command;
+use futures::{future, stream, FutureExt, Stream, StreamExt};
+
+use crate::{
+    client::ProposeResponse,
+    members::ServerId,
+    quorum,
+    rpc::{CurpError, OpResponse, ProposeId, ProposeRequest, RecordRequest, ResponseOp},
+    super_quorum,
+};
+
+use super::Unary;
+
+/// A stream of propose events
+type EventStream<'a, C> = Box<dyn Stream<Item = Result<ProposeEvent<C>, CurpError>> + Send + 'a>;
+
+/// An event returned by the cluster during propose
+enum ProposeEvent<C: Command> {
+    /// Speculative execution result
+    SpecExec {
+        /// conflict returned by the leader
+        conflict_l: bool,
+        /// Speculative execution result
+        er: Result<C::ER, C::Error>,
+    },
+    /// After sync result
+    AfterSync {
+        /// After sync result
+        asr: Result<C::ASR, C::Error>,
+    },
+    /// Record result
+    Record {
+        /// conflict returned by the follower
+        conflict: bool,
+    },
+}
+
+impl<C: Command> Unary<C> {
+    /// Propose for mutative commands
+    pub(super) async fn propose_mutative(
+        &self,
+        cmd: &C,
+        propose_id: ProposeId,
+        token: Option<&String>,
+        use_fast_path: bool,
+    ) -> Result<ProposeResponse<C>, CurpError> {
+        let stream = self
+            .send_propose_mutative(cmd, propose_id, use_fast_path, token)
+            .await?;
+        let mut stream = Box::into_pin(stream);
+        let first_two_events = (
+            Self::next_event(&mut stream).await?,
+            Self::next_event(&mut stream).await?,
+        );
+        match first_two_events {
+            (ProposeEvent::SpecExec { er, .. }, ProposeEvent::AfterSync { asr })
+            | (ProposeEvent::AfterSync { asr }, ProposeEvent::SpecExec { er, .. }) => {
+                Ok(Self::combine_er_asr(er, asr))
+            }
+            (ProposeEvent::SpecExec { conflict_l, er }, ProposeEvent::Record { conflict })
+            | (ProposeEvent::Record { conflict }, ProposeEvent::SpecExec { conflict_l, er }) => {
+                let require_asr = !use_fast_path || conflict | conflict_l;
+                Self::with_spec_exec(stream, er, require_asr).await
+            }
+            (ProposeEvent::AfterSync { asr }, ProposeEvent::Record { .. })
+            | (ProposeEvent::Record { .. }, ProposeEvent::AfterSync { asr }) => {
+                Self::with_after_sync(stream, asr).await
+            }
+            _ => unreachable!("no other possible events"),
+        }
+    }
+
+    /// Propose for read only commands
+    ///
+    /// For read-only commands, we only need to send propose to leader
+    ///
+    /// TODO: Provide an implementation that delegates the read index to the leader for batched
+    /// processing.
+    pub(super) async fn propose_read_only(
+        &self,
+        cmd: &C,
+        propose_id: ProposeId,
+        token: Option<&String>,
+        use_fast_path: bool,
+    ) -> Result<ProposeResponse<C>, CurpError> {
+        let leader_id = self.leader_id().await?;
+        let stream = self
+            .send_leader_propose(cmd, leader_id, propose_id, use_fast_path, token)
+            .await?;
+        let mut stream_pinned = Box::into_pin(stream);
+        if !self.send_read_index(leader_id).await {
+            return Err(CurpError::WrongClusterVersion(()));
+        }
+        if use_fast_path {
+            let event = Self::next_event(&mut stream_pinned).await?;
+            match event {
+                ProposeEvent::SpecExec { conflict_l, er } => {
+                    Self::with_spec_exec(stream_pinned, er, conflict_l).await
+                }
+                ProposeEvent::AfterSync { asr } => Self::with_after_sync(stream_pinned, asr).await,
+                ProposeEvent::Record { .. } => unreachable!("leader does not returns record event"),
+            }
+        } else {
+            let leader_events = (
+                Self::next_event(&mut stream_pinned).await?,
+                Self::next_event(&mut stream_pinned).await?,
+            );
+            match leader_events {
+                (ProposeEvent::SpecExec { er, .. }, ProposeEvent::AfterSync { asr })
+                | (ProposeEvent::AfterSync { asr }, ProposeEvent::SpecExec { er, .. }) => {
+                    Ok(Self::combine_er_asr(er, asr))
+                }
+                _ => unreachable!("no other possible events"),
+            }
+        }
+    }
+
+    /// Send propose to the cluster
+    ///
+    /// Returns a stream that combines the propose stream and record request
+    async fn send_propose_mutative(
+        &self,
+        cmd: &C,
+        propose_id: ProposeId,
+        use_fast_path: bool,
+        token: Option<&String>,
+    ) -> Result<EventStream<'_, C>, CurpError> {
+        let leader_id = self.leader_id().await?;
+        let leader_stream = self
+            .send_leader_propose(cmd, leader_id, propose_id, use_fast_path, token)
+            .await?;
+        let follower_stream = self.send_record(cmd, leader_id, propose_id).await;
+        let select = stream::select(Box::into_pin(leader_stream), Box::into_pin(follower_stream));
+
+        Ok(Box::new(select))
+    }
+
+    /// Send propose request to the leader
+    async fn send_leader_propose(
+        &self,
+        cmd: &C,
+        leader_id: ServerId,
+        propose_id: ProposeId,
+        use_fast_path: bool,
+        token: Option<&String>,
+    ) -> Result<EventStream<'_, C>, CurpError> {
+        let term = self.state.term().await;
+        let propose_req = ProposeRequest::new::<C>(
+            propose_id,
+            cmd,
+            self.state.cluster_version().await,
+            term,
+            !use_fast_path,
+            self.tracker.read().first_incomplete(),
+        );
+        let timeout = self.config.propose_timeout;
+        let token = token.cloned();
+        let stream = self
+            .state
+            .map_server(leader_id, move |conn| async move {
+                conn.propose_stream(propose_req, token, timeout).await
+            })
+            .map(Self::flatten_propose_stream_result)
+            .map(Box::into_pin)
+            .flatten_stream();
+
+        Ok(Box::new(stream))
+    }
+
+    /// Send read index requests to the cluster
+    ///
+    /// Returns `true` if the read index is successful
+    async fn send_read_index(&self, leader_id: ServerId) -> bool {
+        let term = self.state.term().await;
+        let connects_len = self.state.connects_len().await;
+        let quorum = quorum(connects_len);
+        let expect = quorum.wrapping_sub(1);
+        let timeout = self.config.propose_timeout;
+
+        self.state
+            .for_each_follower(
+                leader_id,
+                |conn| async move { conn.read_index(timeout).await },
+            )
+            .await
+            .filter_map(|res| future::ready(res.ok()))
+            .filter(|resp| future::ready(resp.get_ref().term == term))
+            .take(expect)
+            .count()
+            .map(|c| c >= expect)
+            .await
+    }
+
+    /// Send record requests to the cluster
+    ///
+    /// Returns a stream that yield a single event
+    async fn send_record(
+        &self,
+        cmd: &C,
+        leader_id: ServerId,
+        propose_id: ProposeId,
+    ) -> EventStream<'_, C> {
+        let connects_len = self.state.connects_len().await;
+        let superquorum = super_quorum(connects_len);
+        let timeout = self.config.propose_timeout;
+        let record_req = RecordRequest::new::<C>(propose_id, cmd);
+        let expect = superquorum.wrapping_sub(1);
+        let stream = self
+            .state
+            .for_each_follower(leader_id, |conn| {
+                let record_req_c = record_req.clone();
+                async move { conn.record(record_req_c, timeout).await }
+            })
+            .await
+            .filter_map(|res| future::ready(res.ok()))
+            .filter(|resp| future::ready(!resp.get_ref().conflict))
+            .take(expect)
+            .count()
+            .map(move |c| ProposeEvent::Record {
+                conflict: c < expect,
+            })
+            .map(Ok)
+            .into_stream();
+
+        Box::new(stream)
+    }
+
+    /// Flattens the result of `ConnectApi::propose_stream`
+    ///
+    /// It is considered a propose failure when the stream returns a `CurpError`
+    #[allow(clippy::type_complexity)] // copied from the return value of `ConnectApi::propose_stream`
+    fn flatten_propose_stream_result(
+        result: Result<
+            tonic::Response<Box<dyn Stream<Item = Result<OpResponse, tonic::Status>> + Send>>,
+            CurpError,
+        >,
+    ) -> EventStream<'static, C> {
+        match result {
+            Ok(stream) => {
+                let pinned_stream = Box::into_pin(stream.into_inner());
+                Box::new(
+                    pinned_stream.map(|r| r.map_err(CurpError::from).map(ProposeEvent::<C>::from)),
+                )
+            }
+            Err(e) => Box::new(future::ready(Err(e)).into_stream()),
+        }
+    }
+
+    /// Combines the results of speculative execution and after-sync replication.
+    fn combine_er_asr(
+        er: Result<C::ER, C::Error>,
+        asr: Result<C::ASR, C::Error>,
+    ) -> ProposeResponse<C> {
+        er.and_then(|e| asr.map(|a| (e, Some(a))))
+    }
+
+    /// Handles speculative execution and record processing.
+    async fn with_spec_exec(
+        mut stream: Pin<EventStream<'_, C>>,
+        er: Result<C::ER, C::Error>,
+        require_asr: bool,
+    ) -> Result<ProposeResponse<C>, CurpError> {
+        if require_asr {
+            let event = Self::next_event(&mut stream).await?;
+            let ProposeEvent::AfterSync { asr } = event else {
+                unreachable!("event should only be asr");
+            };
+            Ok(Self::combine_er_asr(er, asr))
+        } else {
+            Ok(er.map(|e| (e, None)))
+        }
+    }
+
+    /// Handles after-sync and record processing.
+    async fn with_after_sync(
+        mut stream: Pin<EventStream<'_, C>>,
+        asr: Result<C::ASR, C::Error>,
+    ) -> Result<ProposeResponse<C>, CurpError> {
+        let event = Self::next_event(&mut stream).await?;
+        let ProposeEvent::SpecExec { er, .. } = event else {
+            unreachable!("event should only be er");
+        };
+        Ok(Self::combine_er_asr(er, asr))
+    }
+
+    /// Retrieves the next event from the stream.
+    async fn next_event(
+        stream: &mut Pin<EventStream<'_, C>>,
+    ) -> Result<ProposeEvent<C>, CurpError> {
+        stream
+            .next()
+            .await
+            .transpose()?
+            .ok_or(CurpError::internal("propose stream closed"))
+    }
+}
+
+// Converts the propose stream response to event
+// TODO: The deserialization structure need to be simplified
+#[allow(clippy::expect_used)] // too verbose to write unreachables
+impl<C: Command> From<OpResponse> for ProposeEvent<C> {
+    fn from(resp: OpResponse) -> Self {
+        match resp.op.expect("op should always exist") {
+            ResponseOp::Propose(resp) => Self::SpecExec {
+                conflict_l: resp.conflict,
+                er: resp
+                    .map_result::<C, _, _>(Result::transpose)
+                    .ok()
+                    .flatten()
+                    .expect("er deserialization should never fail"),
+            },
+            ResponseOp::Synced(resp) => Self::AfterSync {
+                asr: resp
+                    .map_result::<C, _, _>(|res| res)
+                    .ok()
+                    .flatten()
+                    .expect("asr deserialization should never fail"),
+            },
+        }
+    }
+}

--- a/crates/curp/src/response.rs
+++ b/crates/curp/src/response.rs
@@ -1,14 +1,8 @@
-use std::{
-    pin::Pin,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use std::sync::atomic::{AtomicBool, Ordering};
 
-use curp_external_api::cmd::Command;
-use futures::Stream;
-use tokio_stream::StreamExt;
 use tonic::Status;
 
-use crate::rpc::{CurpError, OpResponse, ProposeResponse, ResponseOp, SyncedResponse};
+use crate::rpc::{OpResponse, ProposeResponse, ResponseOp, SyncedResponse};
 
 /// The response sender
 #[derive(Debug)]
@@ -56,79 +50,5 @@ impl ResponseSender {
         };
         // Ignore the result because the client might close the receiving stream
         let _ignore = self.tx.try_send(Ok(resp));
-    }
-}
-
-/// Receiver for obtaining execution or after sync results
-pub(crate) struct ResponseReceiver {
-    /// The response stream
-    resp_stream: Pin<Box<dyn Stream<Item = Result<OpResponse, Status>> + Send>>,
-}
-
-impl ResponseReceiver {
-    /// Creates a new [`ResponseReceiver`].
-    pub(crate) fn new(
-        resp_stream: Box<dyn Stream<Item = Result<OpResponse, Status>> + Send>,
-    ) -> Self {
-        Self {
-            resp_stream: Box::into_pin(resp_stream),
-        }
-    }
-
-    /// Receives the results
-    pub(crate) async fn recv<C: Command>(
-        &mut self,
-        both: bool,
-    ) -> Result<Result<(C::ER, Option<C::ASR>), C::Error>, CurpError> {
-        let fst = self.recv_resp().await?;
-
-        match fst {
-            ResponseOp::Propose(propose_resp) => {
-                let conflict = propose_resp.conflict;
-                let er_result = propose_resp.map_result::<C, _, _>(|res| {
-                    res.map(|er| er.unwrap_or_else(|| unreachable!()))
-                })?;
-                if let Err(e) = er_result {
-                    return Ok(Err(e));
-                }
-                if conflict || both {
-                    let snd = self.recv_resp().await?;
-                    let ResponseOp::Synced(synced_resp) = snd else {
-                        unreachable!()
-                    };
-                    let asr_result = synced_resp
-                        .map_result::<C, _, _>(|res| res.unwrap_or_else(|| unreachable!()))?;
-                    return Ok(er_result.and_then(|er| asr_result.map(|asr| (er, Some(asr)))));
-                }
-                Ok(er_result.map(|er| (er, None)))
-            }
-            ResponseOp::Synced(synced_resp) => {
-                let asr_result = synced_resp
-                    .map_result::<C, _, _>(|res| res.unwrap_or_else(|| unreachable!()))?;
-                if let Err(e) = asr_result {
-                    return Ok(Err(e));
-                }
-                let snd = self.recv_resp().await?;
-                let ResponseOp::Propose(propose_resp) = snd else {
-                    unreachable!("op: {snd:?}")
-                };
-                let er_result = propose_resp.map_result::<C, _, _>(|res| {
-                    res.map(|er| er.unwrap_or_else(|| unreachable!()))
-                })?;
-                Ok(er_result.and_then(|er| asr_result.map(|asr| (er, Some(asr)))))
-            }
-        }
-    }
-
-    /// Receives a single response from stream
-    async fn recv_resp(&mut self) -> Result<ResponseOp, CurpError> {
-        let resp = self
-            .resp_stream
-            .next()
-            .await
-            .ok_or(CurpError::internal("stream reaches on an end".to_owned()))??;
-        Ok(resp
-            .op
-            .unwrap_or_else(|| unreachable!("op should always exist")))
     }
 }

--- a/crates/curp/src/server/cmd_worker/mod.rs
+++ b/crates/curp/src/server/cmd_worker/mod.rs
@@ -137,10 +137,8 @@ where
                 cb_w.insert_asr(id, Ok(asr));
             }
             Err(e) => {
-                let _ignore = tx_opt
-                    .as_ref()
-                    .map(|tx| tx.send_synced(SyncedResponse::new_result::<C>(&Err(e.clone()))));
-                cb_w.insert_asr(id, Err(e.clone()));
+                let _ignore = tx_opt.as_ref().map(|tx| tx.send_err::<C>(e.clone()));
+                cb_w.insert_asr(id, Err(e));
             }
         }
     }

--- a/crates/curp/src/server/curp_node.rs
+++ b/crates/curp/src/server/curp_node.rs
@@ -323,7 +323,7 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> CurpNode<C, CE, RC> {
                 Ok((er, None)) => {
                     resp_tx.send_propose(ProposeResponse::new_result::<C>(&Ok(er), false));
                 }
-                Err(e) => resp_tx.send_synced(SyncedResponse::new_result::<C>(&Err(e))),
+                Err(e) => resp_tx.send_err::<C>(e),
             }
         }
     }


### PR DESCRIPTION
This PR includes several changes:

* Moves client propose code to a seperate module `propose_impl`
* Improve propose latency for mutative commands
  This is done by simultaneously waitting for the `record` request to the cluster and the message from the leader gRPC stream.


Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
