### PR TITLE
chore: remove one repeated line in raw_curp/mod.rs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,7 @@ on:
     - cron: "00 00 * * 1"
 
 env:
-  CI_RUST_TOOLCHAIN: 1.74.0
+  CI_RUST_TOOLCHAIN: 1.81.0
 
 jobs:
   benchmark:

--- a/.github/workflows/build_xline.yml
+++ b/.github/workflows/build_xline.yml
@@ -1,6 +1,6 @@
 name: Build Xline
 env:
-  CI_RUST_TOOLCHAIN: 1.74.0
+  CI_RUST_TOOLCHAIN: 1.81.0
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -7,7 +7,7 @@ on:
       - master
 
 env:
-  CI_RUST_TOOLCHAIN: 1.74.0
+  CI_RUST_TOOLCHAIN: 1.81.0
   IMAGE_ID: ghcr.io/xline-kv/xline
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 env:
-  CI_RUST_TOOLCHAIN: 1.74.0
+  CI_RUST_TOOLCHAIN: 1.81.0
   IMAGE_ID: ghcr.io/xline-kv/xline
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ Check the code format.
 cargo fmt --all -- --check
 ```
 
-**Note**: The current version of the Rust toolchain used for CI is **1.74.0** .
+**Note**: The current version of the Rust toolchain used for CI is **1.81.0** .
 Please use this version to run the above command, otherwise you may get
 different results with CI.
 

--- a/ci/rust-toolchain.toml
+++ b/ci/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.81.0"
 components = ["rustfmt", "clippy", "rust-src"]

--- a/crates/curp/src/server/raw_curp/mod.rs
+++ b/crates/curp/src/server/raw_curp/mod.rs
@@ -1655,7 +1655,6 @@ impl<C: Command, RC: RoleChange> RawCurp<C, RC> {
         );
 
         st.role = Role::PreCandidate;
-        cst.votes_received = HashMap::from([(self.id(), true)]);
         st.leader_id = None;
         let _ig = self.ctx.leader_tx.send(None).ok();
         self.reset_election_tick();


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
close https://github.com/xline-kv/Xline/issues/1044. I believe the repeated initialization is unnecessary

* what changes does this pull request make?
remove one repeated line in /crates/curp/src/server/raw_curp/mod.rs

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
I suppose no
