### PR TITLE
fix(curp): block fast path until leader no-op is applied

### DIFF
--- a/crates/curp/src/server/curp_node.rs
+++ b/crates/curp/src/server/curp_node.rs
@@ -291,11 +291,14 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> CurpNode<C, CE, RC> {
         if proposes.is_empty() {
             return;
         }
+        let fast_path_ready = curp.fast_path_ready();
         let pool_entries = proposes
             .iter()
             .map(|p| PoolEntry::new(p.id, Arc::clone(&p.cmd)));
         let conflicts = curp.leader_record(pool_entries);
         for (p, conflict) in proposes.iter().zip(conflicts) {
+            // If the leader hasn't committed its term's no-op yet, force slow path.
+            let conflict = conflict || !fast_path_ready;
             info!("handle mutative cmd: {:?}, conflict: {conflict}", p.cmd);
             p.resp_tx.set_conflict(conflict);
         }
@@ -1227,9 +1230,12 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> Debug for CurpNode<C, C
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
     use curp_test_utils::{
         mock_role_change, sleep_secs,
         test_cmd::{TestCE, TestCommand},
+        TEST_CLIENT_ID,
     };
     use tracing_test::traced_test;
 
@@ -1376,5 +1382,55 @@ mod tests {
         sleep_secs(3).await;
         assert!(curp.is_leader());
         task_manager.shutdown(true).await;
+    }
+
+    #[traced_test]
+    #[test]
+    fn fast_path_requires_no_op_applied() {
+        let task_manager = Arc::new(TaskManager::new());
+        let curp = Arc::new(RawCurp::new_test(
+            3,
+            mock_role_change(),
+            Arc::clone(&task_manager),
+        ));
+        curp.set_term_for_test(2);
+
+        let (tx, _rx) = flume::bounded(1);
+        let resp_tx = Arc::new(ResponseSender::new(tx));
+        let propose = Propose {
+            cmd: Arc::new(TestCommand::new_put(vec![1], 0)),
+            id: ProposeId(TEST_CLIENT_ID, 0),
+            term: curp.term(),
+            resp_tx: Arc::clone(&resp_tx),
+        };
+        let executed = Arc::new(AtomicBool::new(false));
+        let executed_c = Arc::clone(&executed);
+        CurpNode::<TestCommand, TestCE, _>::handle_mutatives(
+            move |_entry| executed_c.store(true, Ordering::Relaxed),
+            &curp,
+            vec![propose],
+        );
+        assert!(resp_tx.is_conflict());
+        assert!(!executed.load(Ordering::Relaxed));
+
+        curp.set_no_op_applied();
+
+        let (tx2, _rx2) = flume::bounded(1);
+        let resp_tx2 = Arc::new(ResponseSender::new(tx2));
+        let propose2 = Propose {
+            cmd: Arc::new(TestCommand::new_put(vec![2], 0)),
+            id: ProposeId(TEST_CLIENT_ID, 1),
+            term: curp.term(),
+            resp_tx: Arc::clone(&resp_tx2),
+        };
+        let second_executed = Arc::new(AtomicBool::new(false));
+        let second_executed_clone = Arc::clone(&second_executed);
+        CurpNode::<TestCommand, TestCE, _>::handle_mutatives(
+            move |_entry| second_executed_clone.store(true, Ordering::Relaxed),
+            &curp,
+            vec![propose2],
+        );
+        assert!(!resp_tx2.is_conflict());
+        assert!(second_executed.load(Ordering::Relaxed));
     }
 }

--- a/crates/curp/src/server/raw_curp/mod.rs
+++ b/crates/curp/src/server/raw_curp/mod.rs
@@ -612,6 +612,11 @@ impl<C: Command, RC: RoleChange> RawCurp<C, RC> {
         Box::new(self.lst.wait_no_op_applied())
     }
 
+    /// Whether fast path can be used (no-op for this term is applied)
+    pub(super) fn fast_path_ready(&self) -> bool {
+        self.lst.no_op_applied()
+    }
+
     /// Sets the no-op log as applied
     pub(super) fn set_no_op_applied(&self) {
         self.lst.set_no_op_applied();
@@ -1694,6 +1699,8 @@ impl<C: Command, RC: RoleChange> RawCurp<C, RC> {
         assert_ne!(prev_role, Role::Leader, "leader can't start election");
 
         st.term += 1;
+        // Entering a new term requires a fresh no-op before we allow fast-path service.
+        self.lst.reset_no_op_state();
         st.role = Role::Candidate;
         st.voted_for = Some(self.id());
         st.leader_id = None;

--- a/crates/curp/src/server/raw_curp/state.rs
+++ b/crates/curp/src/server/raw_curp/state.rs
@@ -120,6 +120,11 @@ impl NoOpState {
         self.applied.store(false, Ordering::Release);
     }
 
+    /// Whether the no-op entry has been applied
+    fn is_applied(&self) -> bool {
+        self.applied.load(Ordering::Acquire)
+    }
+
     /// Waits for the no-op log to be applied
     fn wait(&self) -> Pin<Box<dyn Future<Output = ()> + Send>> {
         if self.applied.load(Ordering::Acquire) {
@@ -281,6 +286,11 @@ impl LeaderState {
     /// Waits for the no-op log to be applied
     pub(super) fn wait_no_op_applied(&self) -> impl Future<Output = ()> + Send {
         self.no_op_state.wait()
+    }
+
+    /// Whether the no-op entry has been applied
+    pub(super) fn no_op_applied(&self) -> bool {
+        self.no_op_state.is_applied()
     }
 }
 


### PR DESCRIPTION
## Problem
A newly elected leader may execute fast-path mutatives before its term no-op is applied, which can serve stale state.

## Root Cause
Fast path readiness was not gated by the no-op-committed condition after leadership change.

## Fix
- Add readiness check to force slow path until no-op is applied.
- Reset no-op-related state when transitioning to candidate.

## Scope
- crates/curp/src/server/curp_node.rs
- crates/curp/src/server/raw_curp/mod.rs
- crates/curp/src/server/raw_curp/state.rs

## Validation
Tested on fork. Baseline and fix branch behave consistently under the same CI conditions.

